### PR TITLE
Alternative batch generator, Callbacks

### DIFF
--- a/examples/conf.yaml
+++ b/examples/conf.yaml
@@ -90,3 +90,7 @@ training:
     num_epochs: 3
     use_mock_data: False
     data_parallel: False
+callbacks:
+    mode: 'max'
+    monitor: 'var_loss'
+    patience: 2

--- a/examples/conf.yaml
+++ b/examples/conf.yaml
@@ -92,6 +92,7 @@ training:
     data_parallel: False
 callbacks:
     list: ['earlystop']
+    metrics: ['val_loss','val_roc','train_loss']
     mode: 'max'
     monitor: 'var_loss'
     patience: 2

--- a/examples/conf.yaml
+++ b/examples/conf.yaml
@@ -94,5 +94,5 @@ callbacks:
     list: ['earlystop']
     metrics: ['val_loss','val_roc','train_loss']
     mode: 'max'
-    monitor: 'var_loss'
+    monitor: 'val_loss'
     patience: 2

--- a/examples/conf.yaml
+++ b/examples/conf.yaml
@@ -91,6 +91,7 @@ training:
     use_mock_data: False
     data_parallel: False
 callbacks:
+    list: ['earlystop']
     mode: 'max'
     monitor: 'var_loss'
     patience: 2

--- a/examples/conf.yaml
+++ b/examples/conf.yaml
@@ -4,8 +4,8 @@ fs_path: '/tigress'
 target: 'hinge'
 
 paths:
-    shot_files: ['short_list.txt'] #['CWall_clear.txt','CFC_unint.txt']
-    shot_files_test: ['short_list.txt'] #['BeWall_clear.txt','ILW_unint.txt']
+    shot_files: ['CWall_clear.txt','CFC_unint.txt']
+    shot_files_test: ['BeWall_clear.txt','ILW_unint.txt']
     signals_dirs: [['jpf/da/c2-ipla'], # Plasma Current [A]
                 ['jpf/da/c2-loca'], # Mode Lock Amplitude [A]
                 ['jpf/db/b5r-ptot>out'], #Radiated Power [W]
@@ -22,6 +22,9 @@ paths:
                  'jpf/df/g1r-lid:006',
                  'jpf/df/g1r-lid:007',
                  'jpf/df/g1r-lid:008']]
+    signal_prepath: '/signal_data/jet/'
+    shot_list_dir: '/shot_lists/'
+
 data:
     T_min_warn: 30
     recompute: False

--- a/examples/mpi_learn.py
+++ b/examples/mpi_learn.py
@@ -75,17 +75,17 @@ print("...done")
 
 shot_list_train,shot_list_validate,shot_list_test = loader.load_shotlists(conf)
 
-#FIXME prepare callbacks to pass here
-#other possible Callbacks
-#callbacks += [cbks.ProgbarLogger() ModelCheckpoint RemoteMonitor LearningRateScheduler
+#prepare callbacks to pass here
+#other possible Callbacks to add: RemoteMonitor, LearningRateScheduler
 #https://github.com/fchollet/keras/blob/fbc9a18f0abc5784607cd4a2a3886558efa3f794/keras/callbacks.py
 
+#potentially move to conf.yaml
 mode = 'max'
 monitor = 'val_loss'
 patience = 1
 callbacks = [cbks.EarlyStopping(patience=patience, monitor=monitor, mode=mode)]
 callbacks += [cbks.BaseLogger()]
-callbacks += [cbks.CSVLogger("{}{}.log".format(conf['paths']['callback_save_path'],datetime.datetime.now())) 
+callbacks += [cbks.CSVLogger("{}callbacks-{}.log".format(conf['paths']['callback_save_path'],datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S"))) 
 
 mpi_train(conf,shot_list_train,shot_list_validate,loader,callbacks)
 

--- a/examples/mpi_learn.py
+++ b/examples/mpi_learn.py
@@ -34,6 +34,9 @@ from plasma.conf import conf
 from plasma.models.loader import Loader
 from plasma.preprocessor.normalize import Normalizer
 
+#FIXME do we lose by adding it here?
+import keras.callbacks as cbks
+
 if conf['data']['normalizer'] == 'minmax':
     from plasma.preprocessor.normalize import MinMaxNormalizer as Normalizer
 elif conf['data']['normalizer'] == 'meanvar':
@@ -72,7 +75,19 @@ print("...done")
 
 shot_list_train,shot_list_validate,shot_list_test = loader.load_shotlists(conf)
 
-mpi_train(conf,shot_list_train,shot_list_validate,loader)
+#FIXME prepare callbacks to pass here
+#other possible Callbacks
+#callbacks += [cbks.ProgbarLogger() ModelCheckpoint RemoteMonitor LearningRateScheduler
+#https://github.com/fchollet/keras/blob/fbc9a18f0abc5784607cd4a2a3886558efa3f794/keras/callbacks.py
+
+mode = 'max'
+monitor = 'val_loss'
+patience = 1
+callbacks = [cbks.EarlyStopping(patience=patience, monitor=monitor, mode=mode)]
+callbacks += [cbks.BaseLogger()]
+callbacks += [cbks.CSVLogger('/tigress/alexeys/training.log')]
+
+mpi_train(conf,shot_list_train,shot_list_validate,loader,callbacks)
 
 #load last model for testing
 print('saving results')

--- a/examples/mpi_learn.py
+++ b/examples/mpi_learn.py
@@ -85,7 +85,7 @@ monitor = 'val_loss'
 patience = 1
 callbacks = [cbks.EarlyStopping(patience=patience, monitor=monitor, mode=mode)]
 callbacks += [cbks.BaseLogger()]
-callbacks += [cbks.CSVLogger("{}callbacks-{}.log".format(conf['paths']['callback_save_path'],datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S"))) 
+callbacks += [cbks.CSVLogger("{}callbacks-{}.log".format(conf['paths']['callback_save_path'],datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")))] 
 
 mpi_train(conf,shot_list_train,shot_list_validate,loader,callbacks)
 

--- a/examples/mpi_learn.py
+++ b/examples/mpi_learn.py
@@ -85,7 +85,7 @@ monitor = 'val_loss'
 patience = 1
 callbacks = [cbks.EarlyStopping(patience=patience, monitor=monitor, mode=mode)]
 callbacks += [cbks.BaseLogger()]
-callbacks += [cbks.CSVLogger('/tigress/alexeys/training.log')]
+callbacks += [cbks.CSVLogger("{}{}.log".format(conf['paths']['callback_save_path'],datetime.datetime.now())) 
 
 mpi_train(conf,shot_list_train,shot_list_validate,loader,callbacks)
 

--- a/examples/mpi_learn.py
+++ b/examples/mpi_learn.py
@@ -34,9 +34,6 @@ from plasma.conf import conf
 from plasma.models.loader import Loader
 from plasma.preprocessor.normalize import Normalizer
 
-#FIXME do we lose by adding it here?
-import keras.callbacks as cbks
-
 if conf['data']['normalizer'] == 'minmax':
     from plasma.preprocessor.normalize import MinMaxNormalizer as Normalizer
 elif conf['data']['normalizer'] == 'meanvar':
@@ -75,19 +72,7 @@ print("...done")
 
 shot_list_train,shot_list_validate,shot_list_test = loader.load_shotlists(conf)
 
-#prepare callbacks to pass here
-#other possible Callbacks to add: RemoteMonitor, LearningRateScheduler
-#https://github.com/fchollet/keras/blob/fbc9a18f0abc5784607cd4a2a3886558efa3f794/keras/callbacks.py
-
-#potentially move to conf.yaml
-mode = 'max'
-monitor = 'val_loss'
-patience = 1
-callbacks = [cbks.EarlyStopping(patience=patience, monitor=monitor, mode=mode)]
-callbacks += [cbks.BaseLogger()]
-callbacks += [cbks.CSVLogger("{}callbacks-{}.log".format(conf['paths']['callback_save_path'],datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")))] 
-
-mpi_train(conf,shot_list_train,shot_list_validate,loader,callbacks)
+mpi_train(conf,shot_list_train,shot_list_validate,loader)
 
 #load last model for testing
 print('saving results')

--- a/plasma/conf_parser.py
+++ b/plasma/conf_parser.py
@@ -26,10 +26,10 @@ def parameters(input_file):
         base_path = output_path
 
         params['paths']['base_path'] = base_path
-        params['paths']['signal_prepath'] = base_path + '/signal_data/jet/'
+        params['paths']['signal_prepath'] = base_path + params['paths']['signal_prepath']
         params['paths']['signals_masks'] = signals_masks
         params['paths']['positivity_mask'] = positivity_mask
-        params['paths']['shot_list_dir'] = base_path + '/shot_lists/'
+        params['paths']['shot_list_dir'] = base_path + params['paths']['shot_list_dir']
         params['paths']['output_path'] = output_path
         params['paths']['processed_prepath'] = output_path +'/processed_shots/'
         params['paths']['normalizer_path'] = output_path + '/normalization/normalization.npz'

--- a/plasma/conf_parser.py
+++ b/plasma/conf_parser.py
@@ -35,6 +35,7 @@ def parameters(input_file):
         params['paths']['normalizer_path'] = output_path + '/normalization/normalization.npz'
         params['paths']['results_prepath'] = output_path + '/results/'
         params['paths']['model_save_path'] = output_path + '/model_checkpoints/'
+        params['paths']['callback_save_path'] = output_path + '/callback_logs/'
 
         params['data']['num_signals'] = sum([sum([1 for predicate in subl if predicate]) for subl in signals_masks])
         if params['target'] == 'hinge':

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -26,6 +26,8 @@ import socket
 sys.setrecursionlimit(10000)
 import getpass
 
+import pdb
+
 #import keras sequentially because it otherwise reads from ~/.keras/keras.json with too many threads.
 #from mpi_launch_tensorflow import get_mpi_task_index 
 from mpi4py import MPI
@@ -250,10 +252,11 @@ class MPIModel():
       monitor = conf['callbacks']['monitor']
       patience = conf['callbacks']['patience']
       callback_save_path = conf['paths']['callback_save_path']
+      callbacks_list = conf['callbacks']['list']
 
       callbacks = [cbks.BaseLogger()]
+      callbacks += [self.history]
       callbacks += [cbks.CSVLogger("{}callbacks-{}.log".format(callback_save_path,datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")))]
-      callbacks = callbacks + [self.history]
 
       if "earlystop" in callbacks_list: 
           callbacks += [cbks.EarlyStopping(patience=patience, monitor=monitor, mode=mode)]
@@ -473,6 +476,7 @@ def mpi_train(conf,shot_list_train,shot_list_validate,loader, callbacks_list=Non
 
     batch_generator = partial(loader.training_batch_generator,shot_list=shot_list_train)
 
+    pdb.set_trace()
     mpi_model = MPIModel(train_model,optimizer,comm,batch_generator,batch_size,lr=lr,warmup_steps = warmup_steps)
     mpi_model.compile(loss=conf['data']['target'].loss)
 

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -455,7 +455,7 @@ def mpi_make_predictions_and_evaluate(conf,shot_list,loader):
     return roc_area,loss
 
 
-def mpi_train(conf,shot_list_train,shot_list_validate,loaderi, callbacks_list=None):   
+def mpi_train(conf,shot_list_train,shot_list_validate,loader, callbacks_list=None):   
 
     specific_builder = builder.ModelBuilder(conf)
     train_model,test_model = specific_builder.build_train_test_models()

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -240,27 +240,27 @@ class MPIModel():
     new_weights = self.comm.bcast(new_weights,root=0)
     self.model.set_weights(new_weights)
 
-    def build_callbacks(self,conf,callbacks_list):
-        #prepare callbacks to pass here
-        #other possible Callbacks to add: RemoteMonitor, LearningRateScheduler
-        #https://github.com/fchollet/keras/blob/fbc9a18f0abc5784607cd4a2a3886558efa3f794/keras/callbacks.py
+  def build_callbacks(self,conf,callbacks_list):
+      #prepare callbacks to pass here
+      #other possible Callbacks to add: RemoteMonitor, LearningRateScheduler
+      #https://github.com/fchollet/keras/blob/fbc9a18f0abc5784607cd4a2a3886558efa3f794/keras/callbacks.py
 
-        #potentially move to conf.yaml
-        mode = conf['callbacks']['mode']
-        monitor = conf['callbacks']['monitor']
-        patience = conf['callbacks']['patience']
-        callback_save_path = conf['paths']['callback_save_path']
+      #potentially move to conf.yaml
+      mode = conf['callbacks']['mode']
+      monitor = conf['callbacks']['monitor']
+      patience = conf['callbacks']['patience']
+      callback_save_path = conf['paths']['callback_save_path']
 
-        callbacks = [cbks.BaseLogger()]
-        callbacks += [cbks.CSVLogger("{}callbacks-{}.log".format(callback_save_path,datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")))]
-        callbacks = callbacks + [self.history]
+      callbacks = [cbks.BaseLogger()]
+      callbacks += [cbks.CSVLogger("{}callbacks-{}.log".format(callback_save_path,datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")))]
+      callbacks = callbacks + [self.history]
 
-        if "earlystop" in callbacks_list: 
-            callbacks += [cbks.EarlyStopping(patience=patience, monitor=monitor, mode=mode)]
-        if "lr_scheduler" in callbacks_list: 
-            pass
-        
-        return cbks.CallbackList(callbacks)
+      if "earlystop" in callbacks_list: 
+          callbacks += [cbks.EarlyStopping(patience=patience, monitor=monitor, mode=mode)]
+      if "lr_scheduler" in callbacks_list: 
+          pass
+      
+      return cbks.CallbackList(callbacks)
 
 
   def train_epoch(self):

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -26,8 +26,6 @@ import socket
 sys.setrecursionlimit(10000)
 import getpass
 
-import pdb
-
 #import keras sequentially because it otherwise reads from ~/.keras/keras.json with too many threads.
 #from mpi_launch_tensorflow import get_mpi_task_index 
 from mpi4py import MPI
@@ -476,7 +474,6 @@ def mpi_train(conf,shot_list_train,shot_list_validate,loader, callbacks_list=Non
 
     batch_generator = partial(loader.training_batch_generator,shot_list=shot_list_train)
 
-    pdb.set_trace()
     mpi_model = MPIModel(train_model,optimizer,comm,batch_generator,batch_size,lr=lr,warmup_steps = warmup_steps)
     mpi_model.compile(loss=conf['data']['target'].loss)
 

--- a/plasma/primitives/shots.py
+++ b/plasma/primitives/shots.py
@@ -188,6 +188,8 @@ class Shot(object):
         return self.is_disruptive
 
     def save(self,prepath):
+        if not os.path.exists(prepath):
+            os.makedirs(prepath)
         save_path = self.get_save_path(prepath)
         np.savez(save_path,number=self.number,valid=self.valid,is_disruptive=self.is_disruptive,
             signals=self.signals,ttd=self.ttd)


### PR DESCRIPTION
* The FRNN uses mini-batch gradient descent implemented around the Keras **train_on_batch()** method. Each epoch is terminated as the ensemble of workers sees _at least_ a certain number of events **num_total**, before individual batch generators on worker GPUs are exhausted.

The pull request implements changes in the **MPIMolde.train_epoch** method preventing reseting the generators on worker GPUs before they are exhausted.

* Another feature implemented in this PR is Keras Callbacks. Keras Callbacks provide a more standardized approach to monitoring training/validation history and statistical summaries for variables. In addition it provides solutions for EarlyStopping (potentially, learning rate adjustment, model checkpointing and CSV summaries too)