### PR TITLE
Tensorflow backend

### DIFF
--- a/examples/conf.yaml
+++ b/examples/conf.yaml
@@ -84,6 +84,7 @@ model:
     dropout_prob: 0.3
     #only relevant if we want to do mpi training. The number of steps with a single replica
     warmup_steps: 0
+    backend: 'theano'
 
 training:
     as_array_of_shots: True

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -34,16 +34,18 @@ task_index = comm.Get_rank()
 num_workers = comm.Get_size()
 NUM_GPUS = 4
 MY_GPU = task_index % NUM_GPUS
-backend = 'theano'
 
 from pprint import pprint
 from plasma.conf import conf
+
+backend = conf['model']['backend']
 
 if backend == 'tf' or backend == 'tensorflow':
     os.environ['CUDA_VISIBLE_DEVICES'] = '{}'.format(MY_GPU)#,mode=NanGuardMode'
     os.environ['KERAS_BACKEND'] = 'tensorflow'
     import tensorflow
 else:
+    os.environ['KERAS_BACKEND'] = 'theano'
     base_compile_dir = '{}/tmp/{}-{}'.format(conf['paths']['output_path'],socket.gethostname(),task_index)
     os.environ['THEANO_FLAGS'] = 'device=gpu{},floatX=float32,base_compiledir={}'.format(MY_GPU,base_compile_dir)#,mode=NanGuardMode'
     import theano

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -43,7 +43,7 @@ backend = conf['model']['backend']
 if backend == 'tf' or backend == 'tensorflow':
     os.environ['CUDA_VISIBLE_DEVICES'] = '{}'.format(MY_GPU)#,mode=NanGuardMode'
     os.environ['KERAS_BACKEND'] = 'tensorflow'
-    import tensorflow
+    import tensorflow as tf
     from keras.backend.tensorflow_backend import set_session
     gpu_options = tf.GPUOptions(per_process_gpu_memory_fraction=0.95, allow_growth=True)
     config = tf.ConfigProto(gpu_options=gpu_options)

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -44,6 +44,10 @@ if backend == 'tf' or backend == 'tensorflow':
     os.environ['CUDA_VISIBLE_DEVICES'] = '{}'.format(MY_GPU)#,mode=NanGuardMode'
     os.environ['KERAS_BACKEND'] = 'tensorflow'
     import tensorflow
+    from keras.backend.tensorflow_backend import set_session
+    gpu_options = tf.GPUOptions(per_process_gpu_memory_fraction=0.95, allow_growth=True)
+    config = tf.ConfigProto(gpu_options=gpu_options)
+    set_session(tf.Session(config=config))
 else:
     os.environ['KERAS_BACKEND'] = 'theano'
     base_compile_dir = '{}/tmp/{}-{}'.format(conf['paths']['output_path'],socket.gethostname(),task_index)


### PR DESCRIPTION
The purpose of this PR is to enable TensorFlow backend support in FRNN. The version has been tested on a single GPU on Tigressdata, full multi-GPU support will follow in subsequent pull requests after migration to Keras-2.0 is finished.

Key changes:
Control backend with a single parameter in the FRNN conf.yaml
```yaml
model:
    backend: 'tensorflow'
```
This will modify the Keras backend at runtime:

```python
if backend == 'tf' or backend == 'tensorflow':
    os.environ['KERAS_BACKEND'] = 'tensorflow'
```

Use TensorFlow `ConfigProto`: 
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/protobuf/config.proto
https://www.tensorflow.org/api_docs/python/tf/ConfigProto

```python
    import tensorflow
    from keras.backend.tensorflow_backend import set_session
    gpu_options = tf.GPUOptions(per_process_gpu_memory_fraction=0.95, allow_growth=True)
    config = tf.ConfigProto(gpu_options=gpu_options)
    set_session(tf.Session(config=config))
```
Currently, GPU devices is controlled via `CUDA_VISIBLE_DEVICES` env variable. Consider a possibility of using `visible_device_list`
