### PR TITLE
Batch iterator/stability of tests on Titan at very large number of GPUs

### DIFF
--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -362,7 +362,7 @@ class MPIModel():
     num_batches_minimum = 100
     num_batches_current = 0
 
-    while num_so_far < num_total and num_batches_current < num_batches_minimum:
+    while (num_so_far-self.epoch*num_total) < num_total and num_batches_current < num_batches_minimum:
 
       try:
           batch_xs,batch_ys,reset_states_now,num_so_far,num_total = batch_iterator_func.next()

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -155,6 +155,7 @@ class MPIModel():
     self.max_lr = 0.1
     self.comm = comm
     self.batch_size = batch_size
+    self.batch_iterator_func = batch_iterator()
     self.batch_iterator = batch_iterator
     self.warmup_steps=warmup_steps
     self.num_workers = comm.Get_size()
@@ -349,7 +350,7 @@ class MPIModel():
     loss_averager = Averager()
     t_start = time.time()
 
-    batch_iterator_func = self.batch_iterator()
+    batch_iterator_func = self.batch_iterator_func
     num_so_far = 0
     num_total = 1
     ave_loss = -1

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -362,10 +362,6 @@ class MPIModel():
     num_batches_minimum = 50
     num_batches_current = 0
 
-    #run the model once to force compilation. Don't actually use these values.
-    t0_comp = time.time()
-    _,_ = self.get_deltas(batch_xs,batch_ys,verbose)
-    print_unique('compilation finished in {:.2f}s'.format(time.time()-t0_comp))
 
     while (num_so_far-self.epoch*num_total) < num_total or num_batches_current < num_batches_minimum:
 
@@ -384,6 +380,12 @@ class MPIModel():
       num_replicas = 1 if warmup_phase else self.num_replicas
 
       num_so_far = self.mpi_sum_scalars(num_so_far,num_replicas)
+
+      #run the model once to force compilation. Don't actually use these values.
+      if step == 0 and self.epoch == 0
+        t0_comp = time.time()
+    	_,_ = self.get_deltas(batch_xs,batch_ys,verbose)
+    	print_unique('compilation finished in {:.2f}s'.format(time.time()-t0_comp))
       
       t0 = time.time()
       deltas,loss = self.get_deltas(batch_xs,batch_ys,verbose)

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -382,7 +382,7 @@ class MPIModel():
       num_so_far = self.mpi_sum_scalars(num_so_far,num_replicas)
 
       #run the model once to force compilation. Don't actually use these values.
-      if step == 0 and self.epoch == 0
+      if step == 0 and self.epoch == 0:
         t0_comp = time.time()
     	_,_ = self.get_deltas(batch_xs,batch_ys,verbose)
     	print_unique('compilation finished in {:.2f}s'.format(time.time()-t0_comp))


### PR DESCRIPTION
This PR summarizes some work performed during Julian's visit.
 1. A set of modifications to the MPIModel class regarding the batch iterator. Our batch iterator is infinite - it has a **while True** statement. Epoch are typically stopped when global step variable (num_so_far) reaches the sample size. Modifications are targeted to not reset the batch iterator at the end of epoch, in short, the batch iterator is moved outside the epoch loop, but we keep a copy of the batch iterator object as a data member of the MPIModel class (in addition to batch generator function)
```python
class MPIModel():
  def __init__(self,model,optimizer,comm,batch_iterator,batch_size,num_replicas=None,warmup_steps=1000,lr=0.01):
    ...
    self.batch_iterator_func = batch_iterator()
    self.batch_iterator = batch_iterator
```

As a result num_so_far needs to be epoch aware:
```python
num_so_far ---> num_so_far-self.epoch*num_total
```
 
 2. A set of modifications in the mpi_runner to improve stability of of tests on Titan with very large number of GPUs - in the regime of data starvation (resulting in a very few mini-batches per epoch):
```python
    while (num_so_far-self.epoch*num_total) < num_total or num_batches_current < num_batches_minimum:
       #trainin the epoch
```