### PR TITLE
Tensorboard callback

### DIFF
--- a/examples/conf.yaml
+++ b/examples/conf.yaml
@@ -17,7 +17,7 @@ paths:
                  'jpf/df/g1r-lid:008']]
     positivity_mask: [['jpf/da/c2-ipla'], 
                      ['jpf/gs/bl-fdwdt<s']]
-    tensorboard_save_path: 'Graph'
+    tensorboard_save_path: '/Graph/'
 
 data:
     T_min_warn: 30
@@ -86,7 +86,7 @@ training:
     use_mock_data: False
     data_parallel: False
 callbacks:
-    list: ['earlystop']
+    list: ['earlystop','tensorboard']
     metrics: ['val_loss','val_roc','train_loss']
     mode: 'max'
     monitor: 'val_loss'

--- a/examples/conf.yaml
+++ b/examples/conf.yaml
@@ -82,7 +82,7 @@ training:
     max_patch_length: 100000
     #How many shots are we loading at once?
     num_shots_at_once: 200
-    num_epochs: 3
+    num_epochs: 10
     use_mock_data: False
     data_parallel: False
 callbacks:
@@ -91,6 +91,7 @@ callbacks:
     mode: 'max'
     monitor: 'val_loss'
     patience: 2
+    write_grads: False
 
 plots:
     #LaTeX strings for performance analysis, sorted in lists by signal_group

--- a/examples/conf.yaml
+++ b/examples/conf.yaml
@@ -6,22 +6,7 @@ target: 'hinge'
 paths:
     shot_files: ['CWall_clear.txt','CFC_unint.txt']
     shot_files_test: ['BeWall_clear.txt','ILW_unint.txt']
-    signals_dirs: [['jpf/da/c2-ipla'], # Plasma Current [A]
-                ['jpf/da/c2-loca'], # Mode Lock Amplitude [A]
-                ['jpf/db/b5r-ptot>out'], #Radiated Power [W]
-                ['jpf/gs/bl-li<s'], #Plasma Internal Inductance
-                ['jpf/gs/bl-fdwdt<s'], #Stored Diamagnetic Energy (time derivative) [W] Might cause a lot of false positives!
-                ['jpf/gs/bl-ptot<s'], #total input power [W]
-                ['jpf/gs/bl-wmhd<s'], #total stored diamagnetic energy
-                #density signals [m^-2]
-                #4 vertical channels and 4 horizontal channels
-                ['jpf/df/g1r-lid:002',
-                 'jpf/df/g1r-lid:003',
-                 'jpf/df/g1r-lid:004',
-                 'jpf/df/g1r-lid:005',
-                 'jpf/df/g1r-lid:006',
-                 'jpf/df/g1r-lid:007',
-                 'jpf/df/g1r-lid:008']]
+    signals_dirs: [['jpf/da/c2-ipla']]
     signal_prepath: '/signal_data/jet/'
     shot_list_dir: '/shot_lists/'
     signals_masks: [['jpf/df/g1r-lid:003',
@@ -32,6 +17,7 @@ paths:
                  'jpf/df/g1r-lid:008']]
     positivity_mask: [['jpf/da/c2-ipla'], 
                      ['jpf/gs/bl-fdwdt<s']]
+    tensorboard_save_path: 'Graph'
 
 data:
     T_min_warn: 30
@@ -84,7 +70,7 @@ model:
     dropout_prob: 0.3
     #only relevant if we want to do mpi training. The number of steps with a single replica
     warmup_steps: 0
-    backend: 'theano'
+    backend: 'tensorflow'
 
 training:
     as_array_of_shots: True
@@ -105,7 +91,6 @@ callbacks:
     mode: 'max'
     monitor: 'val_loss'
     patience: 2
-    tensorboard_save_path: 'Graph'
 
 plots:
     #LaTeX strings for performance analysis, sorted in lists by signal_group

--- a/examples/conf.yaml
+++ b/examples/conf.yaml
@@ -105,6 +105,7 @@ callbacks:
     mode: 'max'
     monitor: 'val_loss'
     patience: 2
+    tensorboard_save_path: 'Graph'
 
 plots:
     #LaTeX strings for performance analysis, sorted in lists by signal_group

--- a/plasma/conf_parser.py
+++ b/plasma/conf_parser.py
@@ -39,7 +39,8 @@ def parameters(input_file):
         params['paths']['normalizer_path'] = output_path + '/normalization/normalization.npz'
         params['paths']['results_prepath'] = output_path + '/results/'
         params['paths']['model_save_path'] = output_path + '/model_checkpoints/'
-        params['paths']['callback_save_path'] = output_path + '/callback_logs/'
+        params['paths']['csvlog_save_path'] = output_path + '/csv_logs/'
+        params['paths']['tensorboard_save_path'] = output_path + params['paths']['tensorboard_save_path']
 
         params['data']['num_signals'] = sum([sum([1 for predicate in subl if predicate]) for subl in signals_masks])
         if params['target'] == 'hinge':

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -320,7 +320,7 @@ class MPIModel():
 
       if "earlystop" in callbacks_list: 
           callbacks += [cbks.EarlyStopping(patience=patience, monitor=monitor, mode=mode)]
-      if "tensorboard" in callbacks_list and not backend == "theano":
+      if "tensorboard" in callbacks_list and backend != "theano":
           callbacks += [cbks.TensorBoard(log_dir=tensorboard_save_path, histogram_freq=1, write_graph=True)]
       if "lr_scheduler" in callbacks_list: 
           pass
@@ -579,6 +579,9 @@ def mpi_train(conf,shot_list_train,shot_list_validate,loader, callbacks_list=Non
     batch_generator = partial(loader.training_batch_generator,shot_list=shot_list_train)
 
     mpi_model = MPIModel(train_model,optimizer,comm,batch_generator,batch_size,lr=lr,warmup_steps = warmup_steps)
+    if backend != "theano":
+        mpi_model.model.summary()
+
     mpi_model.compile(loss=conf['data']['target'].loss)
 
     callbacks = mpi_model.build_callbacks(conf,callbacks_list)

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -313,6 +313,7 @@ class MPIModel():
 
       tensorboard_save_path = conf['paths']['tensorboard_save_path']
       callbacks_list = conf['callbacks']['list']
+      write_grads = conf['callbacks']['write_grads']
 
       callbacks = [cbks.BaseLogger()]
       callbacks += [self.history]
@@ -321,8 +322,7 @@ class MPIModel():
       if "earlystop" in callbacks_list: 
           callbacks += [cbks.EarlyStopping(patience=patience, monitor=monitor, mode=mode)]
       if "tensorboard" in callbacks_list and backend != "theano" and task_index == 0:
-          callbacks += [cbks.TensorBoard(log_dir=tensorboard_save_path, histogram_freq=1, write_graph=True, write_grads=True)]
-          #keras.callbacks.TensorBoard(log_dir='./logs', histogram_freq=0, write_graph=True, write_grads=False, write_images=False, embeddings_freq=0, embeddings_layer_names=None, embeddings_metadata=None)
+          callbacks += [cbks.TensorBoard(log_dir=tensorboard_save_path, histogram_freq=1, write_graph=True, write_grads=write_grads, embeddings_freq=1)]
       if "lr_scheduler" in callbacks_list: 
           pass
       

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -320,8 +320,9 @@ class MPIModel():
 
       if "earlystop" in callbacks_list: 
           callbacks += [cbks.EarlyStopping(patience=patience, monitor=monitor, mode=mode)]
-      if "tensorboard" in callbacks_list and backend != "theano":
-          callbacks += [cbks.TensorBoard(log_dir=tensorboard_save_path, histogram_freq=1, write_graph=True)]
+      if "tensorboard" in callbacks_list and backend != "theano" and task_index == 0:
+          callbacks += [cbks.TensorBoard(log_dir=tensorboard_save_path, histogram_freq=1, write_graph=True, write_grads=True)]
+          #keras.callbacks.TensorBoard(log_dir='./logs', histogram_freq=0, write_graph=True, write_grads=False, write_images=False, embeddings_freq=0, embeddings_layer_names=None, embeddings_metadata=None)
       if "lr_scheduler" in callbacks_list: 
           pass
       
@@ -579,7 +580,7 @@ def mpi_train(conf,shot_list_train,shot_list_validate,loader, callbacks_list=Non
     batch_generator = partial(loader.training_batch_generator,shot_list=shot_list_train)
 
     mpi_model = MPIModel(train_model,optimizer,comm,batch_generator,batch_size,lr=lr,warmup_steps = warmup_steps)
-    if backend != "theano":
+    if backend != "theano" and task_index == 0:
         mpi_model.model.summary()
 
     mpi_model.compile(loss=conf['data']['target'].loss)

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -306,15 +306,18 @@ class MPIModel():
       mode = conf['callbacks']['mode']
       monitor = conf['callbacks']['monitor']
       patience = conf['callbacks']['patience']
-      callback_save_path = conf['paths']['callback_save_path']
+      csvlog_save_path = conf['paths']['csvlog_save_path']
+      tensorboard_save_path = conf['paths']['tensorboard_save_path']
       callbacks_list = conf['callbacks']['list']
 
       callbacks = [cbks.BaseLogger()]
       callbacks += [self.history]
-      callbacks += [cbks.CSVLogger("{}callbacks-{}.log".format(callback_save_path,datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")))]
+      callbacks += [cbks.CSVLogger("{}callbacks-{}.log".format(csvlog_save_path,datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")))]
 
       if "earlystop" in callbacks_list: 
           callbacks += [cbks.EarlyStopping(patience=patience, monitor=monitor, mode=mode)]
+      if "tensorboard" in callbacks_list and not backend == "theano":
+          callbacks += [cbks.TensorBoard(log_dir=tensorboard_save_path, histogram_freq=1, write_graph=True)]
       if "lr_scheduler" in callbacks_list: 
           pass
       

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -26,6 +26,8 @@ import socket
 sys.setrecursionlimit(10000)
 import getpass
 
+import pdb
+
 #import keras sequentially because it otherwise reads from ~/.keras/keras.json with too many threads.
 #from mpi_launch_tensorflow import get_mpi_task_index 
 from mpi4py import MPI
@@ -311,9 +313,7 @@ class MPIModel():
       if not os.path.exists(csvlog_save_path):
           os.makedirs(csvlog_save_path)
 
-      tensorboard_save_path = conf['paths']['tensorboard_save_path']
       callbacks_list = conf['callbacks']['list']
-      write_grads = conf['callbacks']['write_grads']
 
       callbacks = [cbks.BaseLogger()]
       callbacks += [self.history]
@@ -321,13 +321,10 @@ class MPIModel():
 
       if "earlystop" in callbacks_list: 
           callbacks += [cbks.EarlyStopping(patience=patience, monitor=monitor, mode=mode)]
-      if "tensorboard" in callbacks_list and backend != "theano" and task_index == 0:
-          callbacks += [cbks.TensorBoard(log_dir=tensorboard_save_path, histogram_freq=1, write_graph=True, write_grads=write_grads, embeddings_freq=1)]
       if "lr_scheduler" in callbacks_list: 
           pass
       
       return cbks.CallbackList(callbacks)
-
 
   def train_epoch(self):
     '''
@@ -512,7 +509,6 @@ def mpi_make_predictions(conf,shot_list,loader):
     if task_index != 0:
         loader.verbose = False
 
-
     for (i,shot_sublist) in enumerate(shot_sublists):
 
         if i % num_workers == task_index:
@@ -580,7 +576,13 @@ def mpi_train(conf,shot_list_train,shot_list_validate,loader, callbacks_list=Non
     batch_generator = partial(loader.training_batch_generator,shot_list=shot_list_train)
 
     mpi_model = MPIModel(train_model,optimizer,comm,batch_generator,batch_size,lr=lr,warmup_steps = warmup_steps)
+
+    tensorboard = None
     if backend != "theano" and task_index == 0:
+        tensorboard_save_path = conf['paths']['tensorboard_save_path']
+        write_grads = conf['callbacks']['write_grads']
+        tensorboard = TensorBoard(log_dir=tensorboard_save_path,histogram_freq=1,write_graph=True,write_grads=write_grads)
+        tensorboard.set_model(mpi_model.model)
         mpi_model.model.summary()
 
     mpi_model.compile(loss=conf['data']['target'].loss)
@@ -593,6 +595,7 @@ def mpi_train(conf,shot_list_train,shot_list_validate,loader, callbacks_list=Non
     callbacks.set_params({
         'epochs': num_epochs,
         'metrics': callback_metrics,
+        'batch_size': batch_size,
     })
     callbacks.on_train_begin()
 
@@ -611,10 +614,6 @@ def mpi_train(conf,shot_list_train,shot_list_validate,loader, callbacks_list=Non
         epoch_logs = {}
         roc_area,loss = mpi_make_predictions_and_evaluate(conf,shot_list_validate,loader)
 
-        #validation_losses.append(loss)
-        #validation_roc.append(roc_area)
-        #training_losses.append(ave_loss)
-
         epoch_logs['val_roc'] = roc_area 
         epoch_logs['val_loss'] = loss
         epoch_logs['train_loss'] = ave_loss
@@ -627,4 +626,92 @@ def mpi_train(conf,shot_list_train,shot_list_validate,loader, callbacks_list=Non
 
             callbacks.on_epoch_end(int(round(e)), epoch_logs)
 
+            #tensorboard
+            val_generator = partial(loader.validation_batch_generator,shot_list=shot_list_validate)()
+            val_steps = 20
+            tensorboard.on_epoch_end(val_generator,val_steps,int(round(e)),epoch_logs)
+
     callbacks.on_train_end()
+    if task_index == 0:
+        tensorboard.on_train_end()
+
+
+class TensorBoard(object):
+    def __init__(self, log_dir='./logs',
+                 histogram_freq=0,
+                 validation_steps=0,
+                 write_graph=True,
+                 write_grads=False):
+        if K.backend() != 'tensorflow':
+            raise RuntimeError('TensorBoard callback only works '
+                               'with the TensorFlow backend.')
+        self.log_dir = log_dir
+        self.histogram_freq = histogram_freq
+        self.merged = None
+        self.writer = None
+        self.write_graph = write_graph
+        self.write_grads = write_grads
+        self.validation_steps = validation_steps
+        self.sess = None
+        self.model = None
+
+    def set_model(self, model):
+        self.model = model
+        self.sess = K.get_session()
+
+        if self.histogram_freq and self.merged is None:
+            for layer in self.model.layers:
+
+                for weight in layer.weights:
+                    tf.summary.histogram(weight.name, weight)
+                    if self.write_grads:
+                        grads = model.optimizer.get_gradients(model.total_loss,
+                                                            weight)
+                        tf.summary.histogram('{}_grad'.format(weight.name), grads)
+
+                if hasattr(layer, 'output'):
+                    tf.summary.histogram('{}_out'.format(layer.name),
+                                       layer.output)
+        self.merged = tf.summary.merge_all()
+
+        if self.write_graph:
+            self.writer = tf.summary.FileWriter(self.log_dir,
+                                              self.sess.graph)
+        else:
+            self.writer = tf.summary.FileWriter(self.log_dir)
+
+
+    def on_epoch_end(self, val_generator, val_steps, epoch, logs=None):
+        logs = logs or {}
+
+        for name, value in logs.items():
+            tf.summary.scalar(name,value)
+
+        tensors = (self.model.inputs +
+                   self.model.targets +
+                   self.model.sample_weights)
+
+        if self.model.uses_learning_phase:
+            tensors += [K.learning_phase()]
+
+        self.sess = K.get_session()
+
+        for val_data in val_generator:
+            batch_val = []
+            sh = val_data[0].shape[0]
+            batch_val.append(val_data[0])
+            batch_val.append(val_data[1])
+            batch_val.append(np.ones(sh))
+            if self.model.uses_learning_phase:
+                batch_val.append(1)
+
+            feed_dict = dict(zip(tensors, batch_val))
+            result = self.sess.run([self.merged], feed_dict=feed_dict)
+            summary_str = result[0]
+            self.writer.add_summary(summary_str, int(round(epoch)))
+            val_steps -= 1
+            if val_steps <= 0: break
+
+
+    def on_train_end(self, _):
+        self.writer.close()

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -307,6 +307,10 @@ class MPIModel():
       monitor = conf['callbacks']['monitor']
       patience = conf['callbacks']['patience']
       csvlog_save_path = conf['paths']['csvlog_save_path']
+      #CSV callback is on by default
+      if not os.path.exists(csvlog_save_path):
+          os.makedirs(csvlog_save_path)
+
       tensorboard_save_path = conf['paths']['tensorboard_save_path']
       callbacks_list = conf['callbacks']['list']
 


### PR DESCRIPTION
This PR implements Tensorboard callback allowing to visualize graphs of the training and test metrics, as well as activation histograms for the different layers in the model.

PR introduces a `Tensorboard` class with custom `set_model`, `on_epoch_end` and `on_train_end` methods.

Currently monitoring: 
1. Scalar variable summaries for training and validation loss, validation ROC, per epoch
1. Weights, biases and activations histograms and distributions, per each layers, per epoch
1. Graph visualization

Note: completely independent on Keras, but consider inheriting from Callback in future. Reason: current Keras implementation does not allow passing validation data as a generator, while loading the whole list causes OOM.

Note: free parameter is the number of validation steps, which is passed along with the validation data generator. Consider changing the value as appropriate