### PR TITLE
Model builder changes

### DIFF
--- a/examples/conf.yaml
+++ b/examples/conf.yaml
@@ -11,7 +11,7 @@ paths:
     shot_list_dir: '/shot_lists/'
     tensorboard_save_path: '/Graph/'
     data: 'jet_data'
-    specific_signals: [] #if left empty will use all valid signals defined on a machine. Only use if need a custom set
+    specific_signals: [] #['q95','li','ip','betan','energy','lm','pradcore','pradedge','pradtot','pin','torquein','tmamp1','tmamp2','tmfreq1','tmfreq2','pechin','energydt','ipdirect','etemp_profile','edens_profile'] #if left empty will use all valid signals defined on a machine. Only use if need a custom set
 
 data:
     cut_shot_ends: True
@@ -69,7 +69,7 @@ model:
     dense_regularization: 0.01
     #1e-4 is too high, 5e-7 is too low. 5e-5 seems best at 256 batch size, full dataset and ~10 epochs, and lr decay of 0.90. 1e-4 also works well if we decay a lot (i.e ~0.7 or more)
     lr: 0.00001 #0.0005 #for adam plots 0.0000001 #0.00005 #0.00005 #0.00005
-    lr_decay: 1.0 #0.98 #0.9
+    lr_decay: 0.9 #0.98 #0.9
     stateful: True
     return_sequences: True
     dropout_prob: 0.3
@@ -87,7 +87,7 @@ training:
     max_patch_length: 100000
     #How many shots are we loading at once?
     num_shots_at_once: 200
-    num_epochs: 4
+    num_epochs: 400
     use_mock_data: False
     data_parallel: False
     hyperparam_tuning: False
@@ -99,5 +99,5 @@ callbacks:
     metrics: ['val_loss','val_roc','train_loss']
     mode: 'max'
     monitor: 'val_roc'
-    patience: 4
+    patience: 3
     write_grads: False

--- a/plasma/models/builder.py
+++ b/plasma/models/builder.py
@@ -9,7 +9,6 @@ from keras.utils.data_utils import get_file
 from keras.layers.wrappers import TimeDistributed
 from keras.layers.merge import Concatenate
 from keras.callbacks import Callback
-from keras.optimizers import *
 from keras.regularizers import l1,l2,l1_l2
 
 
@@ -73,27 +72,9 @@ class ModelBuilder(object):
         model_conf = conf['model']
         rnn_size = model_conf['rnn_size']
         rnn_type = model_conf['rnn_type']
-        optimizer = model_conf['optimizer']
-        lr = model_conf['lr']
-        clipnorm = model_conf['clipnorm']
         regularization = model_conf['regularization']
         dense_regularization = model_conf['dense_regularization']
 
-        if optimizer == 'sgd':
-            optimizer_class = SGD
-        elif optimizer == 'adam':
-            optimizer_class = Adam
-        elif optimizer == 'rmsprop':
-            optimizer_class = RMSprop 
-        elif optimizer == 'nadam':
-            optimizer_class = Nadam
-        else:
-            optimizer = optimizer
-
-        if lr is not None or clipnorm is not None:
-            optimizer = optimizer_class(lr = lr,clipnorm=clipnorm)
-
-        loss_fn = conf['data']['target'].loss#model_conf['loss']
         dropout_prob = model_conf['dropout_prob']
         length = model_conf['length']
         pred_length = model_conf['pred_length']
@@ -108,7 +89,6 @@ class ModelBuilder(object):
         size_conv_filters = model_conf['size_conv_filters']
         pool_size = model_conf['pool_size']
         dense_size = model_conf['dense_size']
-        # num_signals = conf['data']['num_signals']
 
 
         batch_size = self.conf['training']['batch_size']
@@ -203,7 +183,6 @@ class ModelBuilder(object):
         else:
             x_out = Dense(1,activation=output_activation) (x_in)
         model = Model(inputs=x_input,outputs=x_out)
-        model.compile(loss=loss_fn, optimizer=optimizer)
         #bug with tensorflow/Keras
         if conf['model']['backend'] == 'tf' or conf['model']['backend'] == 'tensorflow':
                 first_time = "tensorflow" not in sys.modules
@@ -212,7 +191,6 @@ class ModelBuilder(object):
                     K.get_session().run(tf.global_variables_initializer())
 
         model.reset_states()
-        #model.compile(loss='mean_squared_error', optimizer='sgd') #for numerical output
         return model
 
     def build_train_test_models(self):
@@ -293,26 +271,8 @@ class ModelBuilder(object):
         model_conf = conf['model']
         rnn_size = model_conf['rnn_size']
         rnn_type = model_conf['rnn_type']
-        optimizer = model_conf['optimizer']
-        lr = model_conf['lr']
-        clipnorm = model_conf['clipnorm']
         regularization = model_conf['regularization']
 
-        if optimizer == 'sgd':
-            optimizer_class = SGD
-        elif optimizer == 'adam':
-            optimizer_class = Adam
-        elif optimizer == 'rmsprop':
-            optimizer_class = RMSprop
-        elif optimizer == 'nadam':
-            optimizer_class = Nadam
-        else:
-            optimizer = optimizer
-
-        if lr is not None or clipnorm is not None:
-            optimizer = optimizer_class(lr = lr,clipnorm=clipnorm)
-
-        loss_fn = conf['data']['target'].loss#model_conf['loss']
         dropout_prob = model_conf['dropout_prob']
         length = model_conf['length']
         pred_length = model_conf['pred_length']
@@ -355,9 +315,6 @@ class ModelBuilder(object):
             model.add(TimeDistributed(Dense(1,activation=output_activation)))
         else:
             model.add(Dense(1,activation=output_activation))
-        model.compile(loss=loss_fn, optimizer=optimizer)
         model.reset_states()
-        #model.compile(loss='mean_squared_error', optimizer='sgd') #for numerical output
 
         return model
-

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -45,7 +45,7 @@ MY_GPU = task_index % NUM_GPUS
 backend = conf['model']['backend']
 
 if backend == 'tf' or backend == 'tensorflow':
-    os.environ['CUDA_VISIBLE_DEVICES'] = '{}'.format(MY_GPU)#,mode=NanGuardMode'
+    if NUM_GPUS > 1: os.environ['CUDA_VISIBLE_DEVICES'] = '{}'.format(MY_GPU)#,mode=NanGuardMode'
     os.environ['KERAS_BACKEND'] = 'tensorflow'
     import tensorflow as tf
     from keras.backend.tensorflow_backend import set_session

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -182,7 +182,6 @@ class MPIModel():
     self.model = model
     self.optimizer = optimizer
     self.max_lr = 0.1
-    self.lr = lr if (lr < self.max_lr) else self.max_lr
     self.DUMMY_LR = 0.001
     self.comm = comm
     self.batch_size = batch_size
@@ -197,6 +196,7 @@ class MPIModel():
         self.num_replicas = self.num_workers
     else:
         self.num_replicas = num_replicas
+    self.lr = lr/(1.0+self.num_replicas/100.0) if (lr < self.max_lr) else self.max_lr/(1.0+self.num_replicas/100.0)
 
 
   def set_batch_iterator_func(self):

--- a/plasma/models/runner.py
+++ b/plasma/models/runner.py
@@ -49,11 +49,15 @@ def train(conf,shot_list_train,shot_list_validate,loader):
 
     from keras.utils.generic_utils import Progbar 
     from keras import backend as K
+    from keras.optimizers import *
     from plasma.models import builder
 
     print('Build model...',end='')
     specific_builder = builder.ModelBuilder(conf)
     train_model = specific_builder.build_model(False) 
+    print('Compile model',end='')
+    optimizer_class = optimizer_class(conf['model']['optimizer'])
+    train_model.compile(optimizer=optimizer_class(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm']),loss=conf['data']['target'].loss)
     print('...done')
 
     #load the latest epoch we did. Returns -1 if none exist yet
@@ -65,7 +69,6 @@ def train(conf,shot_list_train,shot_list_validate,loader):
     num_epochs = conf['training']['num_epochs']
     num_at_once = conf['training']['num_shots_at_once']
     lr_decay = conf['model']['lr_decay']
-    lr = conf['model']['lr']
     print('{} epochs left to go'.format(num_epochs - 1 - e))
     num_so_far_accum = 0
     num_so_far = 0
@@ -160,6 +163,22 @@ def train(conf,shot_list_train,shot_list_validate,loader):
     batch_iterator.__exit__()
     print('...done')
 
+
+def optimizer_class(optimizer):
+    if optimizer == 'sgd':
+        optimizer_class = SGD
+    elif optimizer == 'adam':
+        optimizer_class = Adam
+    elif optimizer == 'rmsprop':
+        optimizer_class = RMSprop
+    elif optimizer == 'nadam':
+        optimizer_class = Nadam
+    else:
+        print("Optimizer not implemented yet")
+        exit(1)
+    return optimizer_class
+
+
 class HyperRunner(object):
     def __init__(self,conf,loader,shot_list):
         self.loader = loader
@@ -172,7 +191,9 @@ class HyperRunner(object):
 
         specific_builder = builder.ModelBuilder(self.conf)
 
-        train_model, test_model = specific_builder.hyper_build_model(space,False), specific_builder.hyper_build_model(space,True)
+        train_model = specific_builder.hyper_build_model(space,False)
+        optimizer_class = optimizer_class(conf['model']['optimizer'])
+        train_model.compile(optimizer=optimizer_class(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm']),loss=conf['data']['target'].loss)
 
         np.random.seed(1)
         validation_losses = []
@@ -186,7 +207,6 @@ class HyperRunner(object):
         num_epochs = self.conf['training']['num_epochs']
         num_at_once = self.conf['training']['num_shots_at_once']
         lr_decay = self.conf['model']['lr_decay']
-        lr = self.conf['model']['lr']
 
         resulting_dict = {'loss':None,'status':STATUS_OK,'model':None}
 
@@ -295,6 +315,9 @@ def make_predictions(conf,shot_list,loader):
     disruptive = []
 
     model = specific_builder.build_model(True)
+    optimizer_class = optimizer_class(conf['model']['optimizer'])
+    model.compile(optimizer=optimizer_class(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm']),loss=conf['data']['target'].loss)
+
     specific_builder.load_model_weights(model)
     model_save_path = specific_builder.get_latest_save_path()
 
@@ -317,6 +340,9 @@ def make_predictions(conf,shot_list,loader):
 
 def make_single_prediction(shot,specific_builder,loader,model_save_path):
     model = specific_builder.build_model(True)
+    optimizer_class = optimizer_class(conf['model']['optimizer'])
+    model.compile(optimizer=optimizer_class(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm']),loss=conf['data']['target'].loss)
+
     model.load_weights(model_save_path)
     model.reset_states()
     X,y = loader.load_as_X_y(shot,prediction_mode=True)
@@ -357,6 +383,9 @@ def make_predictions_gpu(conf,shot_list,loader):
     disruptive = []
 
     model = specific_builder.build_model(True)
+    optimizer_class = optimizer_class(conf['model']['optimizer'])
+    model.compile(optimizer=optimizer_class(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm']),loss=conf['data']['target'].loss)
+
     specific_builder.load_model_weights(model)
     model.reset_states()
 
@@ -426,6 +455,9 @@ def make_evaluations_gpu(conf,shot_list,loader):
     for (i,shot_sublist) in enumerate(shot_sublists):
         batch_size = len(shot_sublist)
         model = specific_builder.build_model(True,custom_batch_size=batch_size)
+        optimizer_class = optimizer_class(conf['model']['optimizer'])
+        model.compile(optimizer=optimizer_class(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm']),loss=conf['data']['target'].loss)
+
         specific_builder.load_model_weights(model)
         model.reset_states()
         X,y,shot_lengths,disr = loader.load_as_X_y_pred(shot_sublist,custom_batch_size=batch_size)

--- a/plasma/models/runner.py
+++ b/plasma/models/runner.py
@@ -49,15 +49,13 @@ def train(conf,shot_list_train,shot_list_validate,loader):
 
     from keras.utils.generic_utils import Progbar 
     from keras import backend as K
-    from keras.optimizers import SGD,Adam,RMSprop,Nadam,TFOptimizer
     from plasma.models import builder
 
     print('Build model...',end='')
     specific_builder = builder.ModelBuilder(conf)
     train_model = specific_builder.build_model(False) 
     print('Compile model',end='')
-    optimizer_class = optimizer_class(conf['model']['optimizer'])
-    train_model.compile(optimizer=optimizer_class,loss=conf['data']['target'].loss)
+    train_model.compile(optimizer=optimizer_class(),loss=conf['data']['target'].loss)
     print('...done')
 
     #load the latest epoch we did. Returns -1 if none exist yet
@@ -163,26 +161,26 @@ def train(conf,shot_list_train,shot_list_validate,loader):
     batch_iterator.__exit__()
     print('...done')
 
-def optimizer_class(conf,optimizer):
-    if optimizer == 'sgd':
-        optimizer_class = SGD(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm'])
-    elif optimizer == 'momentum_sgd':
-        optimizer_class = SGD(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm'], decay=1e-6, momentum=0.9)
-    elif optimizer == 'tf_momentum_sgd':
-        optimizer_class = TFOptimizer(tf.train.MomentumOptimizer(learning_rate=conf['model']['lr'],momentum=0.9))
-    elif optimizer == 'adam':
-        optimizer_class = Adam(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm'])
-    elif optimizer == 'tf_adam':
-        optimizer_class = TFOptimizer(tf.train.AdamOptimizer(learning_rate=conf['model']['lr']))
-    elif optimizer == 'rmsprop':
-        optimizer_class = RMSprop(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm'])
-    elif optimizer == 'nadam':
-        optimizer_class = Nadam(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm'])
+def optimizer_class():
+    from keras.optimizers import SGD,Adam,RMSprop,Nadam,TFOptimizer
+
+    if conf['model']['optimizer'] == 'sgd':
+        return SGD(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm'])
+    elif conf['model']['optimizer'] == 'momentum_sgd':
+        return SGD(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm'], decay=1e-6, momentum=0.9)
+    elif conf['model']['optimizer'] == 'tf_momentum_sgd':
+        return TFOptimizer(tf.train.MomentumOptimizer(learning_rate=conf['model']['lr'],momentum=0.9))
+    elif conf['model']['optimizer'] == 'adam':
+        return Adam(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm'])
+    elif conf['model']['optimizer'] == 'tf_adam':
+        return TFOptimizer(tf.train.AdamOptimizer(learning_rate=conf['model']['lr']))
+    elif conf['model']['optimizer'] == 'rmsprop':
+        return RMSprop(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm'])
+    elif conf['model']['optimizer'] == 'nadam':
+        return Nadam(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm'])
     else:
         print("Optimizer not implemented yet")
         exit(1)
-
-    return optimizer_class
 
 
 class HyperRunner(object):
@@ -198,8 +196,7 @@ class HyperRunner(object):
         specific_builder = builder.ModelBuilder(self.conf)
 
         train_model = specific_builder.hyper_build_model(space,False)
-        optimizer_class = optimizer_class(conf['model']['optimizer'])
-        train_model.compile(optimizer=optimizer_class,loss=conf['data']['target'].loss)
+        train_model.compile(optimizer=optimizer_class(),loss=conf['data']['target'].loss)
 
         np.random.seed(1)
         validation_losses = []
@@ -321,8 +318,7 @@ def make_predictions(conf,shot_list,loader):
     disruptive = []
 
     model = specific_builder.build_model(True)
-    optimizer_class = optimizer_class(conf['model']['optimizer'])
-    model.compile(optimizer=optimizer_class,loss=conf['data']['target'].loss)
+    model.compile(optimizer=optimizer_class(),loss=conf['data']['target'].loss)
 
     specific_builder.load_model_weights(model)
     model_save_path = specific_builder.get_latest_save_path()
@@ -346,8 +342,7 @@ def make_predictions(conf,shot_list,loader):
 
 def make_single_prediction(shot,specific_builder,loader,model_save_path):
     model = specific_builder.build_model(True)
-    optimizer_class = optimizer_class(conf['model']['optimizer'])
-    model.compile(optimizer=optimizer_class,loss=conf['data']['target'].loss)
+    model.compile(optimizer=optimizer_class(),loss=conf['data']['target'].loss)
 
     model.load_weights(model_save_path)
     model.reset_states()
@@ -389,8 +384,7 @@ def make_predictions_gpu(conf,shot_list,loader):
     disruptive = []
 
     model = specific_builder.build_model(True)
-    optimizer_class = optimizer_class(conf['model']['optimizer'])
-    model.compile(optimizer=optimizer_class,loss=conf['data']['target'].loss)
+    model.compile(optimizer=optimizer_class(),loss=conf['data']['target'].loss)
 
     specific_builder.load_model_weights(model)
     model.reset_states()
@@ -461,8 +455,7 @@ def make_evaluations_gpu(conf,shot_list,loader):
     for (i,shot_sublist) in enumerate(shot_sublists):
         batch_size = len(shot_sublist)
         model = specific_builder.build_model(True,custom_batch_size=batch_size)
-        optimizer_class = optimizer_class(conf['model']['optimizer'])
-        model.compile(optimizer=optimizer_class,loss=conf['data']['target'].loss)
+        model.compile(optimizer=optimizer_class(),loss=conf['data']['target'].loss)
 
         specific_builder.load_model_weights(model)
         model.reset_states()

--- a/plasma/models/runner.py
+++ b/plasma/models/runner.py
@@ -49,7 +49,7 @@ def train(conf,shot_list_train,shot_list_validate,loader):
 
     from keras.utils.generic_utils import Progbar 
     from keras import backend as K
-    from keras.optimizers import *
+    from keras.optimizers import SGD,Adam,RMSprop,Nadam,TFOptimizer
     from plasma.models import builder
 
     print('Build model...',end='')
@@ -57,7 +57,7 @@ def train(conf,shot_list_train,shot_list_validate,loader):
     train_model = specific_builder.build_model(False) 
     print('Compile model',end='')
     optimizer_class = optimizer_class(conf['model']['optimizer'])
-    train_model.compile(optimizer=optimizer_class(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm']),loss=conf['data']['target'].loss)
+    train_model.compile(optimizer=optimizer_class,loss=conf['data']['target'].loss)
     print('...done')
 
     #load the latest epoch we did. Returns -1 if none exist yet
@@ -163,19 +163,25 @@ def train(conf,shot_list_train,shot_list_validate,loader):
     batch_iterator.__exit__()
     print('...done')
 
-
-def optimizer_class(optimizer):
+def optimizer_class(conf,optimizer):
     if optimizer == 'sgd':
-        optimizer_class = SGD
+        optimizer_class = SGD(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm'])
+    elif optimizer == 'momentum_sgd':
+        optimizer_class = SGD(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm'], decay=1e-6, momentum=0.9)
+    elif optimizer == 'tf_momentum_sgd':
+        optimizer_class = TFOptimizer(tf.train.MomentumOptimizer(learning_rate=conf['model']['lr'],momentum=0.9))
     elif optimizer == 'adam':
-        optimizer_class = Adam
+        optimizer_class = Adam(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm'])
+    elif optimizer == 'tf_adam':
+        optimizer_class = TFOptimizer(tf.train.AdamOptimizer(learning_rate=conf['model']['lr']))
     elif optimizer == 'rmsprop':
-        optimizer_class = RMSprop
+        optimizer_class = RMSprop(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm'])
     elif optimizer == 'nadam':
-        optimizer_class = Nadam
+        optimizer_class = Nadam(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm'])
     else:
         print("Optimizer not implemented yet")
         exit(1)
+
     return optimizer_class
 
 
@@ -193,7 +199,7 @@ class HyperRunner(object):
 
         train_model = specific_builder.hyper_build_model(space,False)
         optimizer_class = optimizer_class(conf['model']['optimizer'])
-        train_model.compile(optimizer=optimizer_class(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm']),loss=conf['data']['target'].loss)
+        train_model.compile(optimizer=optimizer_class,loss=conf['data']['target'].loss)
 
         np.random.seed(1)
         validation_losses = []
@@ -316,7 +322,7 @@ def make_predictions(conf,shot_list,loader):
 
     model = specific_builder.build_model(True)
     optimizer_class = optimizer_class(conf['model']['optimizer'])
-    model.compile(optimizer=optimizer_class(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm']),loss=conf['data']['target'].loss)
+    model.compile(optimizer=optimizer_class,loss=conf['data']['target'].loss)
 
     specific_builder.load_model_weights(model)
     model_save_path = specific_builder.get_latest_save_path()
@@ -341,7 +347,7 @@ def make_predictions(conf,shot_list,loader):
 def make_single_prediction(shot,specific_builder,loader,model_save_path):
     model = specific_builder.build_model(True)
     optimizer_class = optimizer_class(conf['model']['optimizer'])
-    model.compile(optimizer=optimizer_class(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm']),loss=conf['data']['target'].loss)
+    model.compile(optimizer=optimizer_class,loss=conf['data']['target'].loss)
 
     model.load_weights(model_save_path)
     model.reset_states()
@@ -384,7 +390,7 @@ def make_predictions_gpu(conf,shot_list,loader):
 
     model = specific_builder.build_model(True)
     optimizer_class = optimizer_class(conf['model']['optimizer'])
-    model.compile(optimizer=optimizer_class(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm']),loss=conf['data']['target'].loss)
+    model.compile(optimizer=optimizer_class,loss=conf['data']['target'].loss)
 
     specific_builder.load_model_weights(model)
     model.reset_states()
@@ -456,7 +462,7 @@ def make_evaluations_gpu(conf,shot_list,loader):
         batch_size = len(shot_sublist)
         model = specific_builder.build_model(True,custom_batch_size=batch_size)
         optimizer_class = optimizer_class(conf['model']['optimizer'])
-        model.compile(optimizer=optimizer_class(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm']),loss=conf['data']['target'].loss)
+        model.compile(optimizer=optimizer_class,loss=conf['data']['target'].loss)
 
         specific_builder.load_model_weights(model)
         model.reset_states()


### PR DESCRIPTION
The PR implements a set of changes to standardize `runner` and `mpi_runner` modules, affects the model `builder` module.
 1. Compile models in `runner` and `mpi_runner`. Do not recompile the model in `mpi_runner`
 1. Only build NN architecture (layers, activations) in the model builder, add optimizer/loss later (in runners)
 1. Provide more optimizer options, including `TFOptimizer`
 
Minor changes:
 1. Do not mask all GPUs via `CUDA_VISIBLE_DEVICES` for architectures with only 1 GPU per node (OLCF Titan)
 1. Minor changes in the conf: enable learning rate decay, but reduce patience. 
 1. Reduce base learning rate as a function of number of workers to restore model convergence