### PR TITLE
Loss scaling

### DIFF
--- a/examples/conf.yaml
+++ b/examples/conf.yaml
@@ -54,6 +54,7 @@ data:
     floatx: 'float32'
 
 model:
+    loss_scale_factor: 1.0
     use_bidirectional: false
     use_batch_norm: false
     shallow: False

--- a/examples/slurm.cmd
+++ b/examples/slurm.cmd
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH -t 01:30:00
+#SBATCH -t 01:00:00
 #SBATCH -N 3
 #SBATCH --ntasks-per-node=4
 #SBATCH --ntasks-per-socket=2
@@ -7,21 +7,19 @@
 #SBATCH -c 4
 #SBATCH --mem-per-cpu=0
 
-export PYTHONHASHSEED=0
-module load anaconda
-source activate pppl
+module load anaconda/4.4.0
+source activate PPPL
 module load cudatoolkit/8.0
 module load cudnn/cuda-8.0/6.0
 module load openmpi/cuda-8.0/intel-17.0/2.1.0/64
-module load intel/17.0/64/17.0.4.196 intel-mkl/2017.3/4/64
+module load intel/17.0/64/17.0.4.196
 
 #remove checkpoints for a benchmark run
-rm /tigress/$USER/model_checkpoints/*
-rm /tigress/$USER/results/*
-rm /tigress/$USER/csv_logs/*
-rm /tigress/$USER/Graph/*
-rm /tigress/$USER/normalization/*
+rm /scratch/gpfs/$USER/model_checkpoints/*
+rm /scratch/gpfs/$USER/results/*
+rm /scratch/gpfs/$USER/csv_logs/*
+rm /scratch/gpfs/$USER/Graph/*
+rm /scratch/gpfs/$USER/normalization/*
 
 export OMPI_MCA_btl="tcp,self,sm"
-
 srun python mpi_learn.py

--- a/plasma/models/targets.py
+++ b/plasma/models/targets.py
@@ -5,6 +5,8 @@ from keras.losses import hinge, squared_hinge, mean_absolute_percentage_error
 from plasma.utils.evaluation import mae_np,mse_np,binary_crossentropy_np,hinge_np,squared_hinge_np
 import keras.backend as K
 
+import plasma.conf
+
 #Requirement: larger value must mean disruption more likely.
 class Target(object):
     activation = 'linear'
@@ -12,7 +14,7 @@ class Target(object):
 
     @abc.abstractmethod
     def loss_np(y_true,y_pred):
-        return mse_np(y_true,y_pred)
+        return conf['model']['loss_scale_factor']*mse_np(y_true,y_pred)
 
     @abc.abstractmethod
     def remapper(ttd,T_warning):
@@ -29,7 +31,7 @@ class BinaryTarget(Target):
 
     @staticmethod
     def loss_np(y_true,y_pred):
-        return binary_crossentropy_np(y_true,y_pred)
+        return conf['model']['loss_scale_factor']*binary_crossentropy_np(y_true,y_pred)
 
     @staticmethod
     def remapper(ttd,T_warning,as_array_of_shots=True):
@@ -51,7 +53,7 @@ class TTDTarget(Target):
 
     @staticmethod
     def loss_np(y_true,y_pred):
-        return mse_np(y_true,y_pred)
+        return conf['model']['loss_scale_factor']*mse_np(y_true,y_pred)
 
     @staticmethod
     def remapper(ttd,T_warning):
@@ -85,7 +87,6 @@ class TTDInvTarget(Target):
     def threshold_range(T_warning):
         return np.logspace(-6,np.log10(T_warning),100)
 
-    
 
 class TTDLinearTarget(Target):
     activation = 'linear'
@@ -93,7 +94,7 @@ class TTDLinearTarget(Target):
 
     @staticmethod
     def loss_np(y_true,y_pred):
-        return mse_np(y_true,y_pred)
+        return conf['model']['loss_scale_factor']*mse_np(y_true,y_pred)
     
 
     @staticmethod
@@ -128,7 +129,7 @@ class MaxHingeTarget(Target):
         weight_mask = K.cast(K.greater(weight_mask,0.0),K.floatx()) #positive label!
         weight_mask = fac*weight_mask + (1 - weight_mask)
         #return weight_mask*squared_hinge(y_true,y_pred1)
-        return overall_fac*weight_mask*hinge(y_true,y_pred1)
+        return conf['model']['loss_scale_factor']*overall_fac*weight_mask*hinge(y_true,y_pred1)
 
     @staticmethod
     def loss_np(y_true, y_pred):
@@ -144,7 +145,7 @@ class MaxHingeTarget(Target):
         weight_mask = np.greater(y_true,0.0).astype(np.float32) #positive label!
         weight_mask = fac*weight_mask + (1 - weight_mask)
         #return np.mean(weight_mask*np.square(np.maximum(1. - y_true * y_pred, 0.)))#, axis=-1) only during training, here we want to completely sum up over all instances
-        return np.mean(overall_fac*weight_mask*np.maximum(1. - y_true * y_pred, 0.))#, axis=-1) only during training, here we want to completely sum up over all instances
+        return conf['model']['loss_scale_factor']*np.mean(overall_fac*weight_mask*np.maximum(1. - y_true * y_pred, 0.))#, axis=-1) only during training, here we want to completely sum up over all instances
 
 
     # def _loss_tensor_old(y_true, y_pred):
@@ -174,7 +175,7 @@ class HingeTarget(Target):
     
     @staticmethod
     def loss_np(y_true, y_pred):
-        return hinge_np(y_true,y_pred)
+        return conf['model']['loss_scale_factor']*hinge_np(y_true,y_pred)
         #return squared_hinge_np(y_true,y_pred)
         
     @staticmethod
@@ -188,4 +189,3 @@ class HingeTarget(Target):
     @staticmethod
     def threshold_range(T_warning):
         return np.concatenate((np.linspace(-2,-1.06,100),np.linspace(-1.06,-0.96,100),np.linspace(-0.96,2,50)))
-


### PR DESCRIPTION
The pull request enables loss scaling and augments the global weight update to facilitate low precision calculation.

Loss scaling is controlled from the config:
```yaml
model:
    loss_scale_factor: 1.0
```

which is propagated to `plasma.models.targets`, e.g. like:
```python
class BinaryTarget(Target):
    activation = 'sigmoid'
    loss = 'binary_crossentropy'

    @staticmethod
    def loss_np(y_true,y_pred):
        return conf['model']['loss_scale_factor']*binary_crossentropy_np(y_true,y_pred)
```

Rearrange steps in the `plasma.models.train_on_batch_and_get_deltas`:
```python
    #unscale before subtracting -- used to be subtract then unscale
    weights_before_update = multiply_params(weights_before_update,1.0/self.DUMMY_LR)
    weights_after_update = multiply_params(weights_after_update,1.0/self.DUMMY_LR)

    deltas = subtract_params(weights_after_update,weights_before_update)

    #unscale loss
    if conf['model']['loss_scale_factor'] != 1.0:
        deltas = multiply_params(deltas,1.0/conf['model']['loss_scale_factor'])
```