### PR TITLE
Do not broadcast weights after all-reduce

### DIFF
--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -338,11 +338,7 @@ class MPIModel():
     self.optimizer.set_lr(effective_lr)
     global_deltas = self.optimizer.get_deltas(global_deltas)
 
-    if self.comm.rank == 0:
-      new_weights = self.get_new_weights(global_deltas)
-    else:
-      new_weights = None
-    new_weights = self.comm.bcast(new_weights,root=0)
+    new_weights = self.get_new_weights(global_deltas)
     self.model.set_weights(new_weights)
 
   def build_callbacks(self,conf,callbacks_list):

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -226,7 +226,16 @@ class MPIModel():
     else:
         print("Optimizer not implemented yet")
         exit(1)
-    self.model.compile(optimizer=optimizer_class,loss=loss)        
+    self.model.compile(optimizer=optimizer_class,loss=loss)
+    self.ensure_equal_weights()
+    
+  def ensure_equal_weights(self):
+    if task_index == 0:
+        new_weights = self.model.get_weights()
+    else:
+        new_weights = None
+    nw = comm.bcast(new_weights,root=0)
+    self.model.set_weights(nw)
 
 
 


### PR DESCRIPTION
The data parallel training algorithm implemented here uses ``all_reduce`` to get global weight updates (by summing and averaging them), as such the global weight updates become available to all the ranks, not only the root rank (which would be the case with ``reduce``). There is no need to broadcast the global weights after each update iteration, but we need to broadcast the initial weights to all workers to ensure identical starting point for training. 