### PR TITLE
Add Python style checker (flake8) and fix existing violations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
     - stage: python linter
       env:
       install: pip install flake8
-      script: python -m flake8
+      script: python -m flake8 && echo "Finished linting Python files with flake8"
 
 addons:
   apt:
@@ -55,6 +55,7 @@ notifications:
     on_success: change
     on_failure: always
   slack:
-    secure: NBjGYpIF2VO/GvhbC7XVPIfi0WLGFEuVhi51UbZjfHg4IOv1UuCF0fImi8GN2UZZBFRnZcbtPVffZnyMUyJI0Krw0M1ropkjA4YDaJx1JUGnYuQLxNmX+jbQmN61Usjg5MQOgcRnAn1bdMN1ttWInqkKejpV5buCjZbt8SZbDePfXz4U3No68P/pRsDTVXSy0xLTtRacuEITJjwxfjp6phbmR3qs127MZMRbVYDC2HA6KsoJW6YSKF1vFyHqnFMl7GSavxYw/XQpqFLJkGKXfnNgPZV6qAbVk5+bzyytAbbwLGvgbuFpnJsGPvAyebV8wVYaIPg7OeK+Sm1A3q0jt774NnqFp2AZ+pSKrxbxIkygDM0zoWLm4i3pt6ToJ6dKcqSbCKbELnSY5NphcyYuiJ8uhLVpAR0Y+vp+fOvhb8td/nH2AWkxFpp6xwOHPXvtodBsyPMkiaeKoVElYBfbfOhDSYH2KafADECTX75S63A9KleeNZh0DSImfFdQPaN3GFLEL8Z9UFABzTkM9eYKP9pyEP82Wh/JGDaqbARazEgNzy8rwghomsEguV247XHdOx32PSd0att541gsRFZ5uyMuVFKzI0jiLijekibY2I1c5b6dDeuK4O8uBiq4FTS+bM55Rj4Job01kdxSCKw3RwOh0amzITRTQvEWKpTAekg=
+    rooms:
+    - secure: "NBjGYpIF2VO/GvhbC7XVPIfi0WLGFEuVhi51UbZjfHg4IOv1UuCF0fImi8GN2UZZBFRnZcbtPVffZnyMUyJI0Krw0M1ropkjA4YDaJx1JUGnYuQLxNmX+jbQmN61Usjg5MQOgcRnAn1bdMN1ttWInqkKejpV5buCjZbt8SZbDePfXz4U3No68P/pRsDTVXSy0xLTtRacuEITJjwxfjp6phbmR3qs127MZMRbVYDC2HA6KsoJW6YSKF1vFyHqnFMl7GSavxYw/XQpqFLJkGKXfnNgPZV6qAbVk5+bzyytAbbwLGvgbuFpnJsGPvAyebV8wVYaIPg7OeK+Sm1A3q0jt774NnqFp2AZ+pSKrxbxIkygDM0zoWLm4i3pt6ToJ6dKcqSbCKbELnSY5NphcyYuiJ8uhLVpAR0Y+vp+fOvhb8td/nH2AWkxFpp6xwOHPXvtodBsyPMkiaeKoVElYBfbfOhDSYH2KafADECTX75S63A9KleeNZh0DSImfFdQPaN3GFLEL8Z9UFABzTkM9eYKP9pyEP82Wh/JGDaqbARazEgNzy8rwghomsEguV247XHdOx32PSd0att541gsRFZ5uyMuVFKzI0jiLijekibY2I1c5b6dDeuK4O8uBiq4FTS+bM55Rj4Job01kdxSCKw3RwOh0amzITRTQvEWKpTAekg="
     on_success: always
     on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 
-sudo: required
-
 os:
   - linux
+
+dist: xenial
 
 #python:
 #  - 2.7
@@ -15,12 +15,20 @@ matrix:
       python: 2.7
     - env: MPI_LIBRARY=openmpi MPI_LIBRARY_VERSION=2.0.0
       python: 3.6
+    - stage: python linter
+      install: pip install flake8
+      script: python -m flake8
 
 addons:
   apt:
     packages:
       - python-numpy
       - python-setuptools
+
+env:
+  - TEST_DIR=.;  TEST_SCRIPT="python setup.py test"
+
+# before_install:
 
 install:
   - sh install-mpi.sh
@@ -30,11 +38,22 @@ install:
   - pip install --upgrade pip
   - pip install -r requirements-travis.txt
 
-env:
-  - TEST_DIR=.;  TEST_SCRIPT="python setup.py test"
+# before_script:
 
-script: cd $TEST_DIR  &&  $TEST_SCRIPT && cd ..
+script:
+  - cd $TEST_DIR  &&  $TEST_SCRIPT && cd ..
+
+# Specify order of stages; build matrix of installation and regression tests
+# will only run if linter stage passes
+stages:
+  - python linter
+  - test
 
 notifications:
+  email:
+    on_success: change
+    on_failure: always
   slack:
     secure: NBjGYpIF2VO/GvhbC7XVPIfi0WLGFEuVhi51UbZjfHg4IOv1UuCF0fImi8GN2UZZBFRnZcbtPVffZnyMUyJI0Krw0M1ropkjA4YDaJx1JUGnYuQLxNmX+jbQmN61Usjg5MQOgcRnAn1bdMN1ttWInqkKejpV5buCjZbt8SZbDePfXz4U3No68P/pRsDTVXSy0xLTtRacuEITJjwxfjp6phbmR3qs127MZMRbVYDC2HA6KsoJW6YSKF1vFyHqnFMl7GSavxYw/XQpqFLJkGKXfnNgPZV6qAbVk5+bzyytAbbwLGvgbuFpnJsGPvAyebV8wVYaIPg7OeK+Sm1A3q0jt774NnqFp2AZ+pSKrxbxIkygDM0zoWLm4i3pt6ToJ6dKcqSbCKbELnSY5NphcyYuiJ8uhLVpAR0Y+vp+fOvhb8td/nH2AWkxFpp6xwOHPXvtodBsyPMkiaeKoVElYBfbfOhDSYH2KafADECTX75S63A9KleeNZh0DSImfFdQPaN3GFLEL8Z9UFABzTkM9eYKP9pyEP82Wh/JGDaqbARazEgNzy8rwghomsEguV247XHdOx32PSd0att541gsRFZ5uyMuVFKzI0jiLijekibY2I1c5b6dDeuK4O8uBiq4FTS+bM55Rj4Job01kdxSCKw3RwOh0amzITRTQvEWKpTAekg=
+    on_success: always
+    on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
     - env: MPI_LIBRARY=openmpi MPI_LIBRARY_VERSION=2.0.0
       python: 3.6
     - stage: python linter
+      env:
       install: pip install flake8
       script: python -m flake8
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FRNN 
 
-[![Build Status](https://travis-ci.org/PPPLDeepLearning/plasma-python.svg?branch=master)](https://travis-ci.org/PPPLDeepLearning/plasma-python) 
+[![Build Status](https://travis-ci.com/PPPLDeepLearning/plasma-python.svg?branch=master)](https://travis-ci.com/PPPLDeepLearning/plasma-python)
 [![Build Status](https://jenkins.princeton.edu/buildStatus/icon?job=FRNM/PPPL)](https://jenkins.princeton.edu/job/FRNM/job/PPPL/)
 
 ## Package description

--- a/data/d3d_signals.py
+++ b/data/d3d_signals.py
@@ -1,59 +1,59 @@
-#JET signal hierarchy
-#------------------------------------------------------------------------#
-#User only needs to look at 1st and last sections
+# D3D signal hierarchy
+# ------------------------------------------------------------------------
+# User only needs to look at 1st and last sections
 #    - conf.py only needs to import signals_dirs and signals_masks
 #    - get_mdsplus_data.py only needs signals_dirs and download_masks
 #    - performance_analysis_utils.py needs :
 #         - signals_dirs, plot_masks, ppf_labels, jpf_labels
-#------------------------------------------------------------------------#
+# ------------------------------------------------------------------------
 ################
 # Signal names #
 ################
-#This section contains all the exact JET signal strings and their
-#groupings by type and dimensionality.
-#User should not touch this. Use for reference
+# This section contains all the exact D3D signal strings and their
+# groupings by type and dimensionality.
+# User should not touch this. Use for reference
 
 
-### 0D signals ###
+# 0D signals #
 signal_paths = [
-'efsli', #Internal Inductance
-'ipsip', #Plasma Current
-'efsbetan', #Normalized Beta
-'efswmhd', #Stored Energy
-'nssampn1l', #Tearing Mode Amplitude (rotating 2/1)
-'nssfrqn1l', #Tearing Mode Frequency (rotating 2/1)
-'nssampn2l', #Tearing Mode Amplitude (rotating 3/2)
-'nssfrqn2l', #Tearing Mode Frequency (rotating 3/2)
-'dusbradial', #LM Amplitude
-'dssdenest', #Plasma Density
-r'\bol_l15_p', #Radiated Power core
-r'\bol_l03_p', #Radiated Power Edge
-'bmspinj', #Total Beam Power
-'bmstinj',] #Total Beam Torque
-#'pcechpwrf'] #Total ECH Power Not always on!
+    'efsli',  # Internal Inductance
+    'ipsip',  # Plasma Current
+    'efsbetan',  # Normalized Beta
+    'efswmhd',  # Stored Energy
+    'nssampn1l',  # Tearing Mode Amplitude (rotating 2/1)
+    'nssfrqn1l',  # Tearing Mode Frequency (rotating 2/1)
+    'nssampn2l',  # Tearing Mode Amplitude (rotating 3/2)
+    'nssfrqn2l',  # Tearing Mode Frequency (rotating 3/2)
+    'dusbradial',  # LM Amplitude
+    'dssdenest',  # Plasma Density
+    r'\bol_l15_p',  # Radiated Power core
+    r'\bol_l03_p',  # Radiated Power Edge
+    'bmspinj',  # Total Beam Power
+    'bmstinj', ]  # Total Beam Torque
+# 'pcechpwrf'] #Total ECH Power Not always on!
 
 signal_paths = ['d3d/' + path for path in signal_paths]
 
-### 0D EFIT signals ###
+# 0D EFIT signals
 signal_paths += ['EFIT01/RESULTS.AEQDSK.Q95']
-  
-### 1D EFIT signals ###
-#signal_paths += [
-#'AOT/EQU.t_e', #electron temperature profile vs rho (uniform mapping over time)
-#'AOT/EQU.dens_e'] #electron density profile vs rho (uniform mapping over time)
 
-#these signals seem to give more reliable data
+# 1D EFIT signals
+# signal_paths += [
+# 'AOT/EQU.t_e', # electron temperature profile vs rho
+# 'AOT/EQU.dens_e'] # electron density profile vs rho
+
+# these signals seem to give more reliable data
 signal_paths += [
-'ZIPFIT01/PROFILES.ETEMPFIT', #electron temperature profile vs rho (uniform mapping over time)
-'ZIPFIT01/PROFILES.EDENSFIT'] #electron density profile vs rho (uniform mapping over time)
+    'ZIPFIT01/PROFILES.ETEMPFIT',  # electron temperature profile vs rho
+    'ZIPFIT01/PROFILES.EDENSFIT']  # electron density profile vs rho
 
-#make into list of lists format to be consistent with jet_signals.py
+# make into list of lists format to be consistent with jet_signals.py
 signal_paths = [[path] for path in signal_paths]
 
-#format : 'tree/signal_path' for each path
+# format : 'tree/signal_path' for each path
 signals_dirs = signal_paths
 
- 
+
 ##################################################
 #             USER SELECTIONS                    #
 ##################################################
@@ -63,37 +63,39 @@ signals_dirs = signal_paths
 # Select signals for downloading #
 ##################################
 
-#Default pass to get_mdsplus_data.py: download all above signals
+# Default pass to get_mdsplus_data.py: download all above signals
 download_masks = [[True]*len(sig_list) for sig_list in signals_dirs]
-# download_masks[-1] = [False] # enable/disable temperature profile 
-# download_masks[-2] = [False] # enable/disable density profile 
+# download_masks[-1] = [False] # enable/disable temperature profile
+# download_masks[-2] = [False] # enable/disable density profile
 
 #######################################
 # Select signals for training/testing #
 #######################################
 
-#Default pass to conf.py: train with all above signals
+# Default pass to conf.py: train with all above signals
 signals_masks = [[True]*len(sig_list) for sig_list in signals_dirs]
-signals_masks[-1] = [False] # enable/disable temperature profile 
-signals_masks[-2] = [False] # enable/disable density profile 
+signals_masks[-1] = [False]  # enable/disable temperature profile
+signals_masks[-2] = [False]  # enable/disable density profile
 
-#num_signals = sum([group.count(True) for i,group in enumerate(jet_signals.signals_masks)]
+# num_signals = sum([group.count(True) for i, group in
+# enumerate(jet_signals.signals_masks)]
+
 ###########################################
 # Select signals for performance analysis #
 ###########################################
 
-#User selects these by signal name
+# User selects these by signal name
 plot_masks = [[True]*len(sig_list) for sig_list in signals_dirs]
 
-#LaTeX strings for performance analysis, sorted in lists by signal_group
+# LaTeX strings for performance analysis, sorted in lists by signal_group
 group_labels = [[r' $I_{plasma}$ [A]'],
-              [r' Mode L. A. [A]'],
-              [r' $P_{radiated}$ [W]'], #0d radiation, db/
-              [r' $P_{radiated}$ [W]'],#1d radiation, db/
-              [r' $\rho_{plasma}$ [m^-2]'],
-              [r' $L_{plasma,internal}$'],
-              [r'$\frac{d}{dt} E_{D}$ [W]'],
-              [r' $P_{input}$ [W]'],
-              [r'$E_{D}$'],
-#ppf signal labels
+                [r' Mode L. A. [A]'],
+                [r' $P_{radiated}$ [W]'],  # 0d radiation, db/
+                [r' $P_{radiated}$ [W]'],  # 1d radiation, db/
+                [r' $\rho_{plasma}$ [m^-2]'],
+                [r' $L_{plasma,internal}$'],
+                [r'$\frac{d}{dt} E_{D}$ [W]'],
+                [r' $P_{input}$ [W]'],
+                [r'$E_{D}$'],
+                # ppf signal labels
                 [r'ECE unit?']]

--- a/data/gadata.py
+++ b/data/gadata.py
@@ -1,94 +1,108 @@
-import MDSplus 
+import MDSplus
 import numpy
-import time
-import sys
+# import time
+
 
 class gadata:
-	"""GA Data Obj"""
-	def __init__(self,signal,shot,tree=None,connection=None,nomds=False):
+    """GA Data Obj"""
 
-		# Save object values
-		self.signal = signal
-		self.shot = shot
-		self.zdata = -1
-		self.xdata = -1
-		self.ydata = -1
-		self.zunits = ''
-		self.xunits = ''
-		self.yunits = ''
-		self.rank = -1
-		self.connection = connection
-		
+    def __init__(self, signal, shot, tree=None, connection=None, nomds=False):
 
-		## Retrieve Data 
-		t0 =  time.time()
-		self.found = False
+        # Save object values
+        self.signal = signal
+        self.shot = shot
+        self.zdata = -1
+        self.xdata = -1
+        self.ydata = -1
+        self.zunits = ''
+        self.xunits = ''
+        self.yunits = ''
+        self.rank = -1
+        self.connection = connection
 
-		# Create the MDSplus connection (thin) if not passed in  
-		if self.connection is None:
-			self.connection = MDSplus.Connection('atlas.gat.com')
+        # Retrieve Data
+        # t0 = time.time()
+        self.found = False
 
-		# Retrieve data from MDSplus (thin)
-		if nomds == False:
-			#first try, retrieve directly from tree and tag
-			try:     
-				#print 'trying direct using tree and tag'
-				if tree != None:
-					tag = self.signal
-					fstree 	= tree
-				else:					
-					tag = self.connection.get('findsig("'+self.signal+'",_fstree)').value
-					fstree = self.connection.get('_fstree').value 
+        # Create the MDSplus connection (thin) if not passed in
+        if self.connection is None:
+            self.connection = MDSplus.Connection('atlas.gat.com')
 
-				self.connection.openTree(fstree,shot)
-				self.zdata  = self.connection.get('_s = '+tag).data()
-				self.zunits = self.connection.get('units_of(_s)').data()  
-				self.rank = numpy.ndim(self.zdata)	
-				if self.rank > 1:
-					self.xdata = self.connection.get('dim_of(_s,1)').data()
-					self.xunits = self.connection.get('units_of(dim_of(_s,1))').data()
-					if self.xunits == '' or self.xunits == ' ': 
-						self.xunits = self.connection.get('units(dim_of(_s,1))').data()
+        # Retrieve data from MDSplus (thin)
+        if not nomds:
+            # first try, retrieve directly from tree and tag
+            try:
+                # print('trying direct using tree and tag')
+                if tree is not None:
+                    tag = self.signal
+                    fstree = tree
+                else:
+                    tag = self.connection.get(
+                        'findsig("' + self.signal + '",_fstree)').value
+                    fstree = self.connection.get('_fstree').value
 
-					self.ydata 	= self.connection.get('dim_of(_s)').data()
-					self.yunits = self.connection.get('units_of(dim_of(_s))').data()
-					if self.yunits == '' or self.yunits == ' ':
- 						self.yunits     = self.connection.get('units(dim_of(_s))').data()
-				else:
-					self.xdata = self.connection.get('dim_of(_s)').data()
-					self.xunits = self.connection.get('units_of(dim_of(_s))').data()
-					if self.xunits == '' or self.xunits == ' ': 
-						self.xunits = self.connection.get('units(dim_of(_s))').data()
-				#print 'zdata: ' + str(self.zdata)
-				self.found = True
+                self.connection.openTree(fstree, shot)
+                self.zdata = self.connection.get('_s = ' + tag).data()
+                self.zunits = self.connection.get('units_of(_s)').data()
+                self.rank = numpy.ndim(self.zdata)
+                if self.rank > 1:
+                    self.xdata = self.connection.get('dim_of(_s,1)').data()
+                    self.xunits = self.connection.get(
+                        'units_of(dim_of(_s,1))').data()
+                    if self.xunits == '' or self.xunits == ' ':
+                        self.xunits = self.connection.get(
+                            'units(dim_of(_s,1))').data()
 
-				# MDSplus seems to return 2-D arrays transposed.  Change them back.
-				if numpy.ndim(self.zdata) == 2: self.zdata = numpy.transpose(self.zdata)
-				if numpy.ndim(self.ydata) == 2: self.ydata = numpy.transpose(self.ydata)
-				if numpy.ndim(self.xdata) == 2: self.xdata = numpy.transpose(self.xdata)
+                    self.ydata = self.connection.get('dim_of(_s)').data()
+                    self.yunits = self.connection.get(
+                        'units_of(dim_of(_s))').data()
+                    if self.yunits == '' or self.yunits == ' ':
+                        self.yunits = self.connection.get(
+                            'units(dim_of(_s))').data()
+                else:
+                    self.xdata = self.connection.get('dim_of(_s)').data()
+                    self.xunits = self.connection.get(
+                        'units_of(dim_of(_s))').data()
+                    if self.xunits == '' or self.xunits == ' ':
+                        self.xunits = self.connection.get(
+                            'units(dim_of(_s))').data()
+                # print('zdata: ' + str(self.zdata))
+                self.found = True
 
-			except Exception as e:
-				pass
+                # MDSplus seems to return 2-D arrays transposed.  Change them
+                # back.
+                if numpy.ndim(self.zdata) == 2:
+                    self.zdata = numpy.transpose(self.zdata)
+                if numpy.ndim(self.ydata) == 2:
+                    self.ydata = numpy.transpose(self.ydata)
+                if numpy.ndim(self.xdata) == 2:
+                    self.xdata = numpy.transpose(self.xdata)
 
-			# Retrieve data from PTDATA if node not found
-		if not self.found:
-			#print 'Trying ptdata: %s' % (signal,)
-			self.zdata = self.connection.get('_s = ptdata2("'+signal+'",'+str(shot)+')')
-			if len(self.zdata) != 1:
-				self.xdata = self.connection.get('dim_of(_s)')
-				self.rank = 1
-				self.found = True
+            except Exception as e:
+                print(e)
+                pass
 
-			# Retrieve data from Pseudo-pointname if not in ptdata
-		if not self.found:
-			#print '   Signal not in PTDATA: %s' % (signal,) 
-			self.zdata = self.connection.get('_s = pseudo("'+signal+'",'+str(shot)+')')
-			if len(self.zdata) != 1:
-				self.xdata = self.connection.get('dim_of(_s)')
-				self.rank = 1
-				self.found = True
+            # Retrieve data from PTDATA if node not found
+        if not self.found:
+            # print('Trying ptdata: %s' % (signal,))
+            self.zdata = self.connection.get(
+                '_s = ptdata2("' + signal+'",' + str(shot)+')')
+            if len(self.zdata) != 1:
+                self.xdata = self.connection.get('dim_of(_s)')
+                self.rank = 1
+                self.found = True
 
-		if not self.found:  #this means the signal wasn't found
-			pass
+            # Retrieve data from Pseudo-pointname if not in ptdata
+        if not self.found:
+            # print('   Signal not in PTDATA: %s' % (signal,))
+            self.zdata = self.connection.get(
+                '_s = pseudo("' + signal+'",' + str(shot)+')')
+            if len(self.zdata) != 1:
+                self.xdata = self.connection.get('dim_of(_s)')
+                self.rank = 1
+                self.found = True
 
-		return
+        if not self.found:  # this means the signal wasn't found
+            pass
+
+        return

--- a/data/get_mdsplus_data.py
+++ b/data/get_mdsplus_data.py
@@ -1,19 +1,18 @@
 from plasma.utils.downloading import download_all_shot_numbers
-from data.signals import *
 from plasma.conf import conf
 
 
-prepath = '/p/datad2/' #'/cscratch/share/frnn/'#'/p/datad2/'
+prepath = '/p/datad2/'  # '/cscratch/share/frnn/'
 shot_numbers_path = 'shot_lists/'
 save_path = 'signal_data_new/'
-machine = conf['paths']['all_machines'][0]# d3d#jet#d3d  #should match with data set from conf.yaml
-signals = conf['paths']['all_signals']#all_signals#jet_signals#d3d_signals
+# d3d, jet  # should match with data set from conf.yaml
+machine = conf['paths']['all_machines'][0]
+signals = conf['paths']['all_signals']  # jet_signals, d3d_signals
 print('using signals: ')
 print(signals)
 
 # shot_list_files = plasma.conf.jet_full
-#shot_list_files = plasma.conf.d3d_full
-shot_list_files = conf['paths']['shot_files'][0]#plasma.conf.d3d_100
+# shot_list_files = plasma.conf.d3d_full
+shot_list_files = conf['paths']['shot_files'][0]  # plasma.conf.d3d_100
 
-download_all_shot_numbers(prepath,save_path,shot_list_files,signals)
-
+download_all_shot_numbers(prepath, save_path, shot_list_files, signals)

--- a/data/jet_signals.py
+++ b/data/jet_signals.py
@@ -1,90 +1,101 @@
-#JET signal hierarchy
-#------------------------------------------------------------------------#
-#User only needs to look at 1st and last sections
+# JET signal hierarchy
+# ------------------------------------------------------------------------
+# User only needs to look at 1st and last sections
 #    - conf.py only needs to import signals_dirs and signals_masks
 #    - get_mdsplus_data.py only needs signals_dirs and download_masks
 #    - performance_analysis_utils.py needs :
 #         - signals_dirs, plot_masks, ppf_labels, jpf_labels
-#------------------------------------------------------------------------#
+# ------------------------------------------------------------------------
 ################
 # Signal names #
 ################
-#This section contains all the exact JET signal strings and their
-#groupings by type and dimensionality.
-#User should not touch this. Use for reference
+# This section contains all the exact JET signal strings and their
+# groupings by type and dimensionality.
+# User should not touch this. Use for reference
 
-#### 0D current signals ####
-da_current = ['c2-ipla'] # Plasma Current [A]
-da_lock =['c2-loca'] # Mode Lock Amplitude [A]
+#############################
+#     0D current signals    #
+#############################
+da_current = ['c2-ipla']  # Plasma Current [A]
+da_lock = ['c2-loca']  # Mode Lock Amplitude [A]
 
-#### Radiation signals ####
-#0D
-db_out = ['b5r-ptot>out'] #Radiated Power [W]
-#1D vertical signals, don't use signal 16 and 23
-db =[]
-db += ['b5vr-pbol:{:03d}'.format(i) for i in range(1,28) if (i != 16 and i != 23)]
-#1D horizontal signals
-db += ['b5hr-pbol:{:03d}'.format(i) for i in range(1,24)]
+############################
+#     Radiation signals    #
+############################
+# 0D
+db_out = ['b5r-ptot>out']  # Radiated Power [W]
+# 1D vertical signals, don't use signal 16 and 23
+db = []
+db += ['b5vr-pbol:{:03d}'.format(i)
+       for i in range(1, 28) if (i != 16 and i != 23)]
+# 1D horizontal signals
+db += ['b5hr-pbol:{:03d}'.format(i) for i in range(1, 24)]
 
-#### 1D density signals [m^-2] ####
-df = [] 
-#4 vertical channels and 4 horizontal channels, dont use signal 1
-df += ['g1r-lid:{:03d}'.format(i) for i in range(2,9)] 
+####################################
+#     1D density signals [m^-2]    #
+####################################
+df = []
+# 4 vertical channels and 4 horizontal channels, dont use signal 1
+df += ['g1r-lid:{:03d}'.format(i) for i in range(2, 9)]
 
-#### 0D signals et al ####
-gs_inductance = ['bl-li<s'] #Plasma Internal Inductance
-gs_fdwdt = ['bl-fdwdt<s'] #Stored Diamagnetic Energy (time derivative)
-gs_power_in = ['bl-ptot<s'] #Total input power [W]
-gs_wmhd = ['bl-wmhd<s'] #Stored Diamagnetic Energy (total)
-gs_gwdens = ['bl-gwdens<s'] #Greenwald density
-gs_torb0 = ['bl-torb0<s'] #Toroidal field on axis
-gs_minrad = ['bl-minrad<s'] #Minor radius
+###########################
+#     0D signals et al    #
+###########################
+gs_inductance = ['bl-li<s']  # Plasma Internal Inductance
+gs_fdwdt = ['bl-fdwdt<s']  # Stored Diamagnetic Energy (time derivative)
+gs_power_in = ['bl-ptot<s']  # Total input power [W]
+gs_wmhd = ['bl-wmhd<s']  # Stored Diamagnetic Energy (total)
+gs_gwdens = ['bl-gwdens<s']  # Greenwald density
+gs_torb0 = ['bl-torb0<s']  # Toroidal field on axis
+gs_minrad = ['bl-minrad<s']  # Minor radius
 
-#### ECE temperature profiles ####
+###################################
+#     ECE temperature profiles    #
+###################################
 kk3 = []
-#Temperature of channel i vs time
-kk3 += ['te{:02d}'.format(i) for i in range(1,97)]
-#Radial position of channel i vs time
-kk3 += ['ra{:02d}'.format(i) for i in range(1,97)]
-#Radial position of channel i mapped onto midplane vs time
-kk3 += ['rc{:02d}'.format(i) for i in range(1,97)]
-#General information (PPF)
+# Temperature of channel i vs time
+kk3 += ['te{:02d}'.format(i) for i in range(1, 97)]
+# Radial position of channel i vs time
+kk3 += ['ra{:02d}'.format(i) for i in range(1, 97)]
+# Radial position of channel i mapped onto midplane vs time
+kk3 += ['rc{:02d}'.format(i) for i in range(1, 97)]
+# General information (PPF)
 kk3 += ['gen']
 
 ###################################
 # Signal subsystems and groupings #
 ###################################
-#Signal groupings by type/dimensionality
+# Signal groupings by type/dimensionality
 jpf = [da_current,
        da_lock,
-       db_out, 
-       db, 
-       df, 
+       db_out,
+       db,
+       df,
        gs_inductance,
        gs_fdwdt,
        gs_power_in,
        gs_wmhd,
        gs_gwdens,
        gs_torb0,
-       gs_minrad] 
+       gs_minrad]
 
 ppf = [kk3]
 
-#Manually write strings of actual JET subsystems
-jpf_str = ['da', #magnetic diagnostic, essential subs
+# Manually write strings of actual JET subsystems
+jpf_str = ['da',  # magnetic diagnostic, essential subs
            'da',
-           'db', #diagnostic subsys, general pulse radiation
+           'db',  # diagnostic subsys, general pulse radiation
            'db',
-           'df', #density diagnostic, essential subsys          
-           'gs', #general services, essential subsys 
+           'df',  # density diagnostic, essential subsys
+           'gs',  # general services, essential subsys
            'gs',
            'gs',
            'gs',
            'gs',
            'gs',
            'gs']
-           
-ppf_str = ['kk3'] 
+
+ppf_str = ['kk3']
 subsys_str = [jpf_str, ppf_str]
 
 #################
@@ -98,17 +109,18 @@ signal_type_str = ['jpf', 'ppf']
 #########################################
 
 signals_dirs = []
-for i in range(0,len(signal_type)): #jpf or ppf
-    for j in range(0,len(signal_type[i])): #subsystem/grouping
+for i in range(0, len(signal_type)):  # jpf or ppf
+    for j in range(0, len(signal_type[i])):  # subsystem/grouping
         signal_group = []
-        for k in range(0,len(signal_type[i][j])): #signal name
-            signal_group += [signal_type_str[i] + "/" + subsys_str[i][j] + "/" + signal_type[i][j][k]]
+        for k in range(0, len(signal_type[i][j])):  # signal name
+            signal_group += [signal_type_str[i] + "/"
+                             + subsys_str[i][j] + "/" + signal_type[i][j][k]]
         signals_dirs += [signal_group]
-#Print out 2D hierarchy of the signals_dirs
+# Print out 2D hierarchy of the signals_dirs
 # for i, group in enumerate(signals_dirs):
 #     for j, signal in enumerate(group):
 #         print(i,j,signal)
- 
+
 ##################################################
 #             USER SELECTIONS                    #
 ##################################################
@@ -118,82 +130,90 @@ for i in range(0,len(signal_type)): #jpf or ppf
 # Select signals for downloading #
 ##################################
 
-#Default pass to get_mdsplus_data.py: download all above signals
+# Default pass to get_mdsplus_data.py: download all above signals
 download_masks = [[True]*len(sig_list) for sig_list in signals_dirs]
-download_masks[3] = [False]*len(signals_dirs[3]) #download all radiation signals
-download_masks[-1][-1] = [False] # enable/disable ppf/kk3/gen (only one column)
+# download all radiation signals
+download_masks[3] = [False]*len(signals_dirs[3])
+# enable/disable ppf/kk3/gen (only one column)
+download_masks[-1][-1] = [False]
 
 #######################################
 # Select signals for training/testing #
 #######################################
 
-#Default pass to conf.py: train with all above signals, minus gs_fdwdt
-#signals_masks = [[True]*len(sig_list) for sig_list in signals_dirs]
+# Default pass to conf.py: train with all above signals, minus gs_fdwdt
+# signals_masks = [[True]*len(sig_list) for sig_list in signals_dirs]
 signals_masks = [[False]*len(sig_list) for sig_list in signals_dirs]
 # jpf = [da_current,
 #        da_lock,
-#        db_out, 
-#        db, 
-#        df, 
+#        db_out,
+#        db,
+#        df,
 #        gs_inductance,
 #        gs_fdwdt,
 #        gs_power_in,
 #        gs_wmhd,
 #        gs_gwdens,
 #        gs_torb0,
-#        gs_minrad] 
+#        gs_minrad]
 
 
-#signals_masks[8] = [True] # total diamagnetic energy
-#signals_masks[7] = [False] # total input power
-signals_masks[6] = [False] # time derivative of diamagnetic energy
-#signals_masks[5] = [True] # inductance
-#signals_masks[4] = [False]*len(signals_dirs[4]) #density
-#signals_masks[4][1] = True #central denisty #this was automatically excluded!
-#signals_masks[3] = [True]*len(signals_dirs[3]) #radiation, vertical and horizontal channels
-signals_masks[2] = [False] # wout
-signals_masks[1] = [False] #locked mode
-signals_masks[0] = [True] #need to turn the current on for thresholding signal start/end
+# signals_masks[8] = [True] # total diamagnetic energy
+# signals_masks[7] = [False] # total input power
+signals_masks[6] = [False]  # time derivative of diamagnetic energy
+# signals_masks[5] = [True] # inductance
+# signals_masks[4] = [False]*len(signals_dirs[4]) #density
+# signals_masks[4][1] = True #central denisty #this was automatically excluded!
+# signals_masks[3] = [True]*len(signals_dirs[3]) #radiation, vertical and
+# horizontal channels
+signals_masks[2] = [False]  # wout
+signals_masks[1] = [False]  # locked mode
+# need to turn the current on for thresholding signal start/end
+signals_masks[0] = [True]
 
-#One way for user to disable a signal_group: know the exact index
-#signals_masks[6] = [False] #Disable time-derivative of stored diamagnetic energy
-#signals_masks[3] = [False]*len(signals_dirs[3]) #Disable all radiation signals
+# One way for user to disable a signal_group: know the exact index
+# signals_masks[6] = [False] # Disable time-derivative of stored diamagnetic
+#                              energy
+# signals_masks[3] = [False]*len(signals_dirs[3]) #Disable all radiation
+# signals
 
-#Another way for the user to disable individual signals within a group:
-#Disable 'radial position of channel i vs time' of ECE for all 96 channels
+# Another way for the user to disable individual signals within a group:
+# Disable 'radial position of channel i vs time' of ECE for all 96 channels
 for i, group in enumerate(signals_dirs):
     for j, signal in enumerate(group):
         if 'ra' in signal:
-            signals_masks[i][j] = False 
+            signals_masks[i][j] = False
 
 
-#num_signals = sum([group.count(True) for i,group in enumerate(jet_signals.signals_masks)]
+# num_signals = sum([group.count(True)
+#  for i, group in enumerate(jet_signals.signals_masks)]
 ###########################################
 # Select signals for performance analysis #
 ###########################################
 
-#User selects these by signal name
+# User selects these by signal name
 plot_masks = [[False]*len(sig_list) for sig_list in signals_dirs]
-#Default: 8 golden 0D signals, and all density channels
+# Default: 8 golden 0D signals, and all density channels
 plot_masks[0][0] = True
 
-#plot_masks[1][0] = True
+# plot_masks[1][0] = True
 # plot_masks[2][0] = True
-#plot_masks[4][1] = True
-#plot_masks[4] = [True]*len(signals_dirs[4]) #density
-#plot_masks[5][0] = True
+# plot_masks[4][1] = True
+# plot_masks[4] = [True]*len(signals_dirs[4]) #density
+# plot_masks[5][0] = True
 plot_masks[6][0] = True
-#plot_masks[7][0] = True
-#plot_masks[8][0] = True
-#LaTeX strings for performance analysis, sorted in lists by signal_group
+# plot_masks[7][0] = True
+# plot_masks[8][0] = True
+
+# LaTeX strings for performance analysis, sorted in lists by signal_group
 group_labels = [[r' $I_{plasma}$ [A]'],
-              [r' Mode L. A. [A]'],
-              [r' $P_{radiated}$ [W]'], #0d radiation, db/
-              [r' $P_{radiated}$ [W]'],#1d radiation, db/
-              [r' $\rho_{plasma}$ [m^-2]'],
-              [r' $L_{plasma,internal}$'],
-              [r'$\frac{d}{dt} E_{D}$ [W]'],
-              [r' $P_{input}$ [W]'],
-              [r'$E_{D}$'],
-#ppf signal labels
+                [r' Mode L. A. [A]'],
+                [r' $P_{radiated}$ [W]'],  # 0d radiation, db/
+                [r' $P_{radiated}$ [W]'],  # 1d radiation, db/
+                [r' $\rho_{plasma}$ [m^-2]'],
+                [r' $L_{plasma,internal}$'],
+                [r'$\frac{d}{dt} E_{D}$ [W]'],
+                [r' $P_{input}$ [W]'],
+                [r'$E_{D}$'],
+                # ppf signal labels
                 [r'ECE unit?']]

--- a/data/signals.py
+++ b/data/signals.py
@@ -1,274 +1,420 @@
 from __future__ import print_function
 import numpy as np
-import time
 import sys
 
-from plasma.primitives.data import Signal,ProfileSignal,ChannelSignal,Machine
+from plasma.primitives.data import (
+    Signal, ProfileSignal, ChannelSignal, Machine
+    )
+
 
 def create_missing_value_filler():
-	time = np.linspace(0,100,100)
-	vals = np.zeros_like(time)
-	return time,vals
+    time = np.linspace(0, 100, 100)
+    vals = np.zeros_like(time)
+    return time, vals
+
 
 def get_tree_and_tag(path):
-	spl = path.split('/')
-	tree = spl[0]
-	tag = '\\' + spl[1]
-	return tree,tag
+    spl = path.split('/')
+    tree = spl[0]
+    tag = '\\' + spl[1]
+    return tree, tag
+
 
 def get_tree_and_tag_no_backslash(path):
-	spl = path.split('/')
-	tree = spl[0]
-	tag = spl[1]
-	return tree,tag
-
-def fetch_d3d_data(signal_path,shot,c=None):
-	tree,signal = get_tree_and_tag_no_backslash(signal_path)
-	if tree == None:
-		signal = c.get('findsig("'+signal+'",_fstree)').value
-		tree = c.get('_fstree').value 
-	# if c is None:
-		# c = MDSplus.Connection('atlas.gat.com')
-
-	# ## Retrieve Data 
-	t0 =  time.time()
-	found = False
-	xdata = np.array([0])
-	ydata = None
-	data = np.array([0])
-
-	# Retrieve data from MDSplus (thin)
-	#first try, retrieve directly from tree andsignal 
-	def get_units(str):
-		units = c.get('units_of('+str+')').data()
-		if units == '' or units == ' ': 
-			units = c.get('units('+str+')').data()
-		return units
-
-	try:     
-		c.openTree(tree,shot)
-		data  = c.get('_s = '+signal).data()
-		data_units = c.get('units_of(_s)').data()  
-		rank = np.ndim(data)	
-		found = True
-
-	except Exception as e:
-		#print(e)
-		#sys.stdout.flush()
-		pass
-
-	# Retrieve data from PTDATA if node not found
-	if not found:
-		#print("not in full path {}".format(signal))
-		data = c.get('_s = ptdata2("'+signal+'",'+str(shot)+')').data()
-		if len(data) != 1:
-			rank = np.ndim(data)	
-			found = True
-	# Retrieve data from Pseudo-pointname if not in ptdata
-	if not found:
-		#print("not in PTDATA {}".format(signal))
-		data = c.get('_s = pseudo("'+signal+'",'+str(shot)+')').data()
-		if len(data) != 1:
-			rank = np.ndim(data)	
-			found = True
-	#this means the signal wasn't found
-	if not found:  
-		print ("No such signal: {}".format(signal))
-		pass
-
-	# get time base
-	if found:
-		if rank > 1:
-			xdata = c.get('dim_of(_s,1)').data()
-			xunits = get_units('dim_of(_s,1)')
-			ydata 	= c.get('dim_of(_s)').data()
-			yunits = get_units('dim_of(_s)')
-		else:
-			xdata = c.get('dim_of(_s)').data()
-			xunits = get_units('dim_of(_s)')
-
-	# MDSplus seems to return 2-D arrays transposed.  Change them back.
-	if np.ndim(data) == 2: data = np.transpose(data)
-	if np.ndim(ydata) == 2: ydata = np.transpose(ydata)
-	if np.ndim(xdata) == 2: xdata = np.transpose(xdata)
-
-    # print '   GADATA Retrieval Time : ',time.time() - t0
-	xdata = xdata*1e-3#time is measued in ms
-	return xdata,data,ydata,found
+    spl = path.split('/')
+    tree = spl[0]
+    tag = spl[1]
+    return tree, tag
 
 
-def fetch_jet_data(signal_path,shot_num,c):
-	found = False
-	time = np.array([0])
-	ydata = None
-	data = np.array([0])
-	try:
-		data = c.get('_sig=jet("{}/",{})'.format(signal_path,shot_num)).data()
-		if np.ndim(data) == 2:
-			data = np.transpose(data)
-			time = c.get('_sig=dim_of(jet("{}/",{}),1)'.format(signal_path,shot_num)).data()
-			ydata = c.get('_sig=dim_of(jet("{}/",{}),0)'.format(signal_path,shot_num)).data()
-		else:
-			time = c.get('_sig=dim_of(jet("{}/",{}))'.format(signal_path,shot_num)).data()
-		found = True
-	except Exception as e:
-		print(e)
-		sys.stdout.flush()
-		#pass
-	return time,data,ydata,found
+def fetch_d3d_data(signal_path, shot, c=None):
+    tree, signal = get_tree_and_tag_no_backslash(signal_path)
+    if tree is None:
+        signal = c.get('findsig("'+signal+'",_fstree)').value
+        tree = c.get('_fstree').value
+    # if c is None:
+        # c = MDSplus.Connection('atlas.gat.com')
 
-def fetch_nstx_data(signal_path,shot_num,c):
-	tree,tag = get_tree_and_tag(signal_path)
-	c.openTree(tree,shot_num)
-	data = c.get(tag).data()
-	time = c.get('dim_of('+tag+')').data()
-	found = True
-	return time,data,None,found
+    # Retrieve data
+    found = False
+    xdata = np.array([0])
+    ydata = None
+    data = np.array([0])
+
+    # Retrieve data from MDSplus (thin)
+    # first try, retrieve directly from tree andsignal
+    def get_units(str):
+        units = c.get('units_of('+str+')').data()
+        if units == '' or units == ' ':
+            units = c.get('units('+str+')').data()
+        return units
+
+    try:
+        c.openTree(tree, shot)
+        data = c.get('_s = '+signal).data()
+        # data_units = c.get('units_of(_s)').data()
+        rank = np.ndim(data)
+        found = True
+
+    except Exception as e:
+        print(e)
+        sys.stdout.flush()
+        pass
+
+    # Retrieve data from PTDATA if node not found
+    if not found:
+        # print("not in full path {}".format(signal))
+        data = c.get('_s = ptdata2("'+signal+'",'+str(shot)+')').data()
+        if len(data) != 1:
+            rank = np.ndim(data)
+            found = True
+    # Retrieve data from Pseudo-pointname if not in ptdata
+    if not found:
+        # print("not in PTDATA {}".format(signal))
+        data = c.get('_s = pseudo("'+signal+'",'+str(shot)+')').data()
+        if len(data) != 1:
+            rank = np.ndim(data)
+            found = True
+    # this means the signal wasn't found
+    if not found:
+        print("No such signal: {}".format(signal))
+        pass
+
+    # get time base
+    if found:
+        if rank > 1:
+            xdata = c.get('dim_of(_s,1)').data()
+            # xunits = get_units('dim_of(_s,1)')
+            ydata = c.get('dim_of(_s)').data()
+            # yunits = get_units('dim_of(_s)')
+        else:
+            xdata = c.get('dim_of(_s)').data()
+            # xunits = get_units('dim_of(_s)')
+
+    # MDSplus seems to return 2-D arrays transposed.  Change them back.
+    if np.ndim(data) == 2:
+        data = np.transpose(data)
+    if np.ndim(ydata) == 2:
+        ydata = np.transpose(ydata)
+    if np.ndim(xdata) == 2:
+        xdata = np.transpose(xdata)
+
+    # print('   GADATA Retrieval Time : ', time.time() - t0)
+    xdata = xdata*1e-3  # time is measued in ms
+    return xdata, data, ydata, found
 
 
+def fetch_jet_data(signal_path, shot_num, c):
+    found = False
+    time = np.array([0])
+    ydata = None
+    data = np.array([0])
+    try:
+        data = c.get('_sig=jet("{}/",{})'.format(signal_path, shot_num)).data()
+        if np.ndim(data) == 2:
+            data = np.transpose(data)
+            time = c.get(
+                '_sig=dim_of(jet("{}/",{}),1)'.format(
+                    signal_path, shot_num)).data()
+            ydata = c.get(
+                '_sig=dim_of(jet("{}/",{}),0)'.format(
+                    signal_path, shot_num)).data()
+        else:
+            time = c.get(
+                '_sig=dim_of(jet("{}/",{}))'.format(
+                    signal_path, shot_num)).data()
+        found = True
+    except Exception as e:
+        print(e)
+        sys.stdout.flush()
+        # pass
+    return time, data, ydata, found
 
 
+def fetch_nstx_data(signal_path, shot_num, c):
+    tree, tag = get_tree_and_tag(signal_path)
+    c.openTree(tree, shot_num)
+    data = c.get(tag).data()
+    time = c.get('dim_of(' + tag + ')').data()
+    found = True
+    return time, data, None, found
 
-d3d = Machine("d3d","atlas.gat.com",fetch_d3d_data,max_cores=32,current_threshold=2e-1)
-jet = Machine("jet","mdsplus.jet.efda.org",fetch_jet_data,max_cores=8,current_threshold=1e5)
-nstx = Machine("nstx","skylark.pppl.gov:8501::",fetch_nstx_data,max_cores=8)
 
-all_machines = [d3d,jet]
+d3d = Machine(
+    "d3d",
+    "atlas.gat.com",
+    fetch_d3d_data,
+    max_cores=32,
+    current_threshold=2e-1)
+jet = Machine(
+    "jet",
+    "mdsplus.jet.efda.org",
+    fetch_jet_data,
+    max_cores=8,
+    current_threshold=1e5)
+nstx = Machine("nstx", "skylark.pppl.gov:8501::", fetch_nstx_data, max_cores=8)
+
+all_machines = [d3d, jet]
 
 profile_num_channels = 64
-#ZIPFIT comes from actual measurements
-#etemp_profile = ProfileSignal("Electron temperature profile",["ppf/hrts/te","ZIPFIT01/PROFILES.ETEMPFIT"],[jet,d3d],mapping_paths=["ppf/hrts/rho",None],causal_shifts=[0,10],mapping_range=(0,1),num_channels=profile_num_channels,data_avail_tolerances=[0.05,0.02])
-#edens_profile = ProfileSignal("Electron density profile",["ppf/hrts/ne","ZIPFIT01/PROFILES.EDENSFIT"],[jet,d3d],mapping_paths=["ppf/hrts/rho",None],causal_shifts=[0,10],mapping_range=(0,1),num_channels=profile_num_channels,data_avail_tolerances=[0.05,0.02])
+# ZIPFIT comes from actual measurements
+# etemp_profile = ProfileSignal(
+#     "Electron temperature profile",
+#     ["ppf/hrts/te", "ZIPFIT01/PROFILES.ETEMPFIT"], [jet, d3d],
+#     mapping_paths=["ppf/hrts/rho", None], causal_shifts=[0, 10],
+#     mapping_range=(0, 1), num_channels=profile_num_channels,
+#     data_avail_tolerances=[0.05, 0.02])
+# edens_profile = ProfileSignal(
+#     "Electron density profile",
+#     ["ppf/hrts/ne", "ZIPFIT01/PROFILES.EDENSFIT"], [jet, d3d],
+#     mapping_paths=["ppf/hrts/rho", None], causal_shifts=[0, 10],
+#     mapping_range=(0, 1), num_channels=profile_num_channels,
+#     data_avail_tolerances=[0.05, 0.02])
 
-etemp_profile = ProfileSignal("Electron temperature profile",["ZIPFIT01/PROFILES.ETEMPFIT"],[d3d],mapping_paths=[None],causal_shifts=[10],mapping_range=(0,1),num_channels=profile_num_channels,data_avail_tolerances=[0.02])
-edens_profile = ProfileSignal("Electron density profile",["ZIPFIT01/PROFILES.EDENSFIT"],[d3d],mapping_paths=[None],causal_shifts=[10],mapping_range=(0,1),num_channels=profile_num_channels,data_avail_tolerances=[0.02])
-itemp_profile = ProfileSignal("Ion temperature profile",["ZIPFIT01/PROFILES.ITEMPFIT"],[d3d],causal_shifts=[10],mapping_range=(0,1),num_channels=profile_num_channels,data_avail_tolerances=[0.02])
-zdens_profile = ProfileSignal("Impurity density profile",["ZIPFIT01/PROFILES.ZDENSFIT"],[d3d],causal_shifts=[10],mapping_range=(0,1),num_channels=profile_num_channels,data_avail_tolerances=[0.02])
-trot_profile = ProfileSignal("Rotation profile",["ZIPFIT01/PROFILES.TROTFIT"],[d3d],causal_shifts=[10],mapping_range=(0,1),num_channels=profile_num_channels,data_avail_tolerances=[0.02])
-pthm_profile = ProfileSignal("Thermal pressure profile",["ZIPFIT01/PROFILES.PTHMFIT"],[d3d],causal_shifts=[10],mapping_range=(0,1),num_channels=profile_num_channels,data_avail_tolerances=[0.02])# thermal pressure doesn't include fast ions
-neut_profile = ProfileSignal("Neutrals profile",["ZIPFIT01/PROFILES.NEUTFIT"],[d3d],causal_shifts=[10],mapping_range=(0,1),num_channels=profile_num_channels,data_avail_tolerances=[0.02])
+etemp_profile = ProfileSignal(
+    "Electron temperature profile", ["ZIPFIT01/PROFILES.ETEMPFIT"], [d3d],
+    mapping_paths=[None], causal_shifts=[10], mapping_range=(0, 1),
+    num_channels=profile_num_channels, data_avail_tolerances=[0.02])
+edens_profile = ProfileSignal(
+    "Electron density profile", ["ZIPFIT01/PROFILES.EDENSFIT"], [d3d],
+    mapping_paths=[None], causal_shifts=[10], mapping_range=(0, 1),
+    num_channels=profile_num_channels, data_avail_tolerances=[0.02])
+itemp_profile = ProfileSignal(
+    "Ion temperature profile", ["ZIPFIT01/PROFILES.ITEMPFIT"], [d3d],
+    causal_shifts=[10], mapping_range=(0, 1),
+    num_channels=profile_num_channels, data_avail_tolerances=[0.02])
+zdens_profile = ProfileSignal(
+    "Impurity density profile", ["ZIPFIT01/PROFILES.ZDENSFIT"], [d3d],
+    causal_shifts=[10], mapping_range=(0, 1),
+    num_channels=profile_num_channels, data_avail_tolerances=[0.02])
+trot_profile = ProfileSignal(
+    "Rotation profile", ["ZIPFIT01/PROFILES.TROTFIT"], [d3d],
+    causal_shifts=[10], mapping_range=(0, 1),
+    num_channels=profile_num_channels, data_avail_tolerances=[0.02])
+# note, thermal pressure doesn't include fast ions
+pthm_profile = ProfileSignal(
+    "Thermal pressure profile", ["ZIPFIT01/PROFILES.PTHMFIT"], [d3d],
+    causal_shifts=[10], mapping_range=(0, 1),
+    num_channels=profile_num_channels, data_avail_tolerances=[0.02])
+neut_profile = ProfileSignal(
+    "Neutrals profile", ["ZIPFIT01/PROFILES.NEUTFIT"], [d3d],
+    causal_shifts=[10], mapping_range=(0, 1),
+    num_channels=profile_num_channels, data_avail_tolerances=[0.02])
+# compare the following profile to just q95 0D signal
+q_profile = ProfileSignal(
+    "Q profile", ["ZIPFIT01/PROFILES.BOOTSTRAP.QRHO"], [d3d],
+    causal_shifts=[10], mapping_range=(0, 1),
+    num_channels=profile_num_channels, data_avail_tolerances=[0.02])
+bootstrap_current_profile = ProfileSignal(
+    "Rotation profile", ["ZIPFIT01/PROFILES.BOOTSTRAP.JBS_SAUTER"], [d3d],
+    causal_shifts=[10], mapping_range=(0, 1),
+    num_channels=profile_num_channels, data_avail_tolerances=[0.02])
 
-q_profile = ProfileSignal("Q profile",["ZIPFIT01/PROFILES.BOOTSTRAP.QRHO"],[d3d],causal_shifts=[10],mapping_range=(0,1),num_channels=profile_num_channels,data_avail_tolerances=[0.02])#compare to just q95
-bootstrap_current_profile = ProfileSignal("Rotation profile",["ZIPFIT01/PROFILES.BOOTSTRAP.JBS_SAUTER"],[d3d],causal_shifts=[10],mapping_range=(0,1),num_channels=profile_num_channels,data_avail_tolerances=[0.02])
+# equilibrium_image = 2DSignal(
+#     "2D Magnetic Equilibrium", ["EFIT01/RESULTS.GEQDSK.PSIRZ"], [d3d],
+#     causal_shifts=[10], mapping_range=(0, 1),
+#     num_channels=profile_num_channels, data_avail_tolerances=[0.02])
 
-#equilibrium_image = 2DSignal("2D Magnetic Equilibrium",["EFIT01/RESULTS.GEQDSK.PSIRZ"],[d3d],causal_shifts=[10],mapping_range=(0,1),num_channels=profile_num_channels,data_avail_tolerances=[0.02])
+# EFIT is the solution to the inverse problem from external magnetic
+# measurements
 
-#EFIT is the inverse problem from external magnetic measurements
-#pressure_profile = ProfileSignal("Pressure profile",["EFIT01/RESULTS.GEQDSK.PRES"],[d3d],causal_shifts=[10],mapping_range=(0,1),num_channels=profile_num_channels,data_avail_tolerances=[0.02])# pressure might be unphysical since it is not constrained by measurements, only the EFIT which does not know about density and temperature
-q_psi_profile = ProfileSignal("Q(psi) profile",["EFIT01/RESULTS.GEQDSK.QPSI"],[d3d],causal_shifts=[10],mapping_range=(0,1),num_channels=profile_num_channels,data_avail_tolerances=[0.02])
+# pressure might be unphysical since it is not constrained by measurements,
+# only the EFIT which does not know about density and temperature
 
+# pressure_profile = ProfileSignal(
+#     "Pressure profile", ["EFIT01/RESULTS.GEQDSK.PRES"], [d3d],
+#     causal_shifts=[10], mapping_range=(0, 1),
+#     num_channels=profile_num_channels, data_avail_tolerances=[0.02])
 
-# epress_profile_spatial = ProfileSignal("Electron pressure profile",["ppf/hrts/pe/"],[jet],causal_shifts=[25],mapping_range=(2,4),num_channels=profile_num_channels)
-etemp_profile_spatial = ProfileSignal("Electron temperature profile",["ppf/hrts/te"],[jet],causal_shifts=[25],mapping_range=(2,4),num_channels=profile_num_channels,data_avail_tolerances=[0.05])
-edens_profile_spatial = ProfileSignal("Electron density profile",["ppf/hrts/ne"],[jet],causal_shifts=[25],mapping_range=(2,4),num_channels=profile_num_channels,data_avail_tolerances=[0.05])
-rho_profile_spatial = ProfileSignal("Rho at spatial positions",["ppf/hrts/rho"],[jet],causal_shifts=[25],mapping_range=(2,4),num_channels=profile_num_channels,data_avail_tolerances=[0.05])
+q_psi_profile = ProfileSignal(
+    "Q(psi) profile", ["EFIT01/RESULTS.GEQDSK.QPSI"], [d3d],
+    causal_shifts=[10], mapping_range=(0, 1),
+    num_channels=profile_num_channels, data_avail_tolerances=[0.02])
 
-etemp = Signal("electron temperature",["ppf/hrtx/te0"],[jet],causal_shifts=[25],data_avail_tolerances=[0.05])
-# epress = Signal("electron pressure",["ppf/hrtx/pe0/"],[jet],causal_shifts=[25])
+# epress_profile_spatial = ProfileSignal(
+#     "Electron pressure profile", ["ppf/hrts/pe/"], [jet], causal_shifts=[25],
+#     mapping_range=(2, 4), num_channels=profile_num_channels)
 
-q95 = Signal("q95 safety factor",['ppf/efit/q95',"EFIT01/RESULTS.AEQDSK.Q95"],[jet,d3d],causal_shifts=[15,10],normalize=False,data_avail_tolerances=[0.03,0.02])
+etemp_profile_spatial = ProfileSignal(
+    "Electron temperature profile", ["ppf/hrts/te"], [jet],
+    causal_shifts=[25], mapping_range=(2, 4),
+    num_channels=profile_num_channels, data_avail_tolerances=[0.05])
+edens_profile_spatial = ProfileSignal(
+    "Electron density profile", ["ppf/hrts/ne"], [jet],
+    causal_shifts=[25], mapping_range=(2, 4),
+    num_channels=profile_num_channels, data_avail_tolerances=[0.05])
+rho_profile_spatial = ProfileSignal(
+    "Rho at spatial positions", ["ppf/hrts/rho"], [jet],
+    causal_shifts=[25], mapping_range=(2, 4),
+    num_channels=profile_num_channels, data_avail_tolerances=[0.05])
 
-ip = Signal("plasma current",["jpf/da/c2-ipla","d3d/ipspr15V"],[jet,d3d],is_ip=True) #"d3d/ipsip" was used before, ipspr15V seems to be available for a superset of shots.
-iptarget = Signal("plasma current target",["d3d/ipsiptargt"],[d3d])
-iperr = Signal("plasma current error",["d3d/ipeecoil"],[d3d])
+etemp = Signal("electron temperature", ["ppf/hrtx/te0"],
+               [jet], causal_shifts=[25], data_avail_tolerances=[0.05])
+# epress = Signal("electron pressure", ["ppf/hrtx/pe0/"], [jet],
+#                 causal_shifts=[25])
 
-li = Signal("internal inductance",["jpf/gs/bl-li<s","d3d/efsli"],[jet,d3d])
-lm = Signal("Locked mode amplitude",['jpf/da/c2-loca','d3d/dusbradial'],[jet,d3d])
-dens = Signal("Plasma density",['jpf/df/g1r-lid:003','d3d/dssdenest'],[jet,d3d],is_strictly_positive=True)
-energy = Signal("stored energy",['jpf/gs/bl-wmhd<s','d3d/efswmhd'],[jet,d3d])
-pin = Signal("Input Power (beam for d3d)",['jpf/gs/bl-ptot<s','d3d/bmspinj'],[jet,d3d]) #Total Beam Power
+q95 = Signal(
+    "q95 safety factor", ['ppf/efit/q95', "EFIT01/RESULTS.AEQDSK.Q95"],
+    [jet, d3d], causal_shifts=[15, 10], normalize=False,
+    data_avail_tolerances=[0.03, 0.02])
 
-pradtot = Signal("Radiated Power",['jpf/db/b5r-ptot>out'],[jet])
-#pradcore = ChannelSignal("Radiated Power Core",[ 'd3d/'+r'\bol_l15_p'],[d3d])
-#pradedge = ChannelSignal("Radiated Power Edge",['d3d/'+r'\bol_l03_p'],[d3d])
-pradcore = ChannelSignal("Radiated Power Core",['ppf/bolo/kb5h/channel14', 'd3d/'+r'\bol_l15_p'],[jet,d3d])
-pradedge = ChannelSignal("Radiated Power Edge",['ppf/bolo/kb5h/channel10','d3d/'+r'\bol_l03_p'],[jet,d3d])
-# pechin = Signal("ECH input power, not always on",['d3d/pcechpwrf'],[d3d])
-pechin = Signal("ECH input power, not always on",['RF/ECH.TOTAL.ECHPWRC'],[d3d])
+# "d3d/ipsip" was used before, ipspr15V seems to be available for a
+# superset of shots.
+ip = Signal("plasma current", ["jpf/da/c2-ipla", "d3d/ipspr15V"],
+            [jet, d3d], is_ip=True)
+iptarget = Signal("plasma current target", ["d3d/ipsiptargt"], [d3d])
+iperr = Signal("plasma current error", ["d3d/ipeecoil"], [d3d])
 
-#betan = Signal("Normalized Beta",['jpf/gs/bl-bndia<s','d3d/efsbetan'],[jet,d3d])
-betan = Signal("Normalized Beta",['d3d/efsbetan'],[d3d])
-energydt = Signal("stored energy time derivative",['jpf/gs/bl-fdwdt<s'],[jet])
+li = Signal("internal inductance", ["jpf/gs/bl-li<s", "d3d/efsli"], [jet, d3d])
+lm = Signal("Locked mode amplitude", ['jpf/da/c2-loca', 'd3d/dusbradial'],
+            [jet, d3d])
+dens = Signal("Plasma density", ['jpf/df/g1r-lid:003', 'd3d/dssdenest'],
+              [jet, d3d], is_strictly_positive=True)
+energy = Signal("stored energy", ['jpf/gs/bl-wmhd<s', 'd3d/efswmhd'],
+                [jet, d3d])
+# Total beam input power
+pin = Signal("Input Power (beam for d3d)", ['jpf/gs/bl-ptot<s', 'd3d/bmspinj'],
+             [jet, d3d])
 
-torquein = Signal("Input Beam Torque",['d3d/bmstinj'],[d3d]) #Total Beam Power
-tmamp1 = Signal("Tearing Mode amplitude (rotating 2/1)", ['d3d/nssampn1l'],[d3d])
-tmamp2 = Signal("Tearing Mode amplitude (rotating 3/2)", ['d3d/nssampn2l'],[d3d])
-tmfreq1 = Signal("Tearing Mode frequency (rotating 2/1)", ['d3d/nssfrqn1l'],[d3d])
-tmfreq2 = Signal("Tearing Mode frequency (rotating 3/2)", ['d3d/nssfrqn2l'],[d3d])
-ipdirect = Signal("plasma current direction",["d3d/iptdirect"],[d3d])
+pradtot = Signal("Radiated Power", ['jpf/db/b5r-ptot>out'], [jet])
+# pradcore = ChannelSignal("Radiated Power Core", [ 'd3d/' + r'\bol_l15_p']
+# ,[d3d])
+# pradedge = ChannelSignal("Radiated Power Edge", ['d3d/' + r'\bol_l03_p'],
+# [d3d])
+pradcore = ChannelSignal("Radiated Power Core",
+                         ['ppf/bolo/kb5h/channel14', 'd3d/' + r'\bol_l15_p'],
+                         [jet, d3d])
+pradedge = ChannelSignal("Radiated Power Edge",
+                         ['ppf/bolo/kb5h/channel10', 'd3d/' + r'\bol_l03_p'],
+                         [jet, d3d])
+# pechin = Signal("ECH input power, not always on", ['d3d/pcechpwrf'], [d3d])
+pechin = Signal("ECH input power, not always on",
+                ['RF/ECH.TOTAL.ECHPWRC'], [d3d])
 
-#for downloading #modify this to preprocess shots with only a subset of signals. This may produce more shots
-#since only those shots that contain all_signals contained here are used.
-#all_signals = {'q95':q95,'li':li,'ip':ip,
-#'betan':betan,'energy':energy,'lm':lm,'dens':dens,
-#'pradcore':pradcore,'pradedge':pradedge,'pradtot':pradtot,
-#'pin':pin,'torquein':torquein,
-#'tmamp1':tmamp1,'tmamp2':tmamp2,'tmfreq1':tmfreq1,'tmfreq2':tmfreq2,
-#'pechin':pechin,'energydt':energydt,
-#'etemp_profile':etemp_profile,'edens_profile':edens_profile,
-# 'ipdirect':ipdirect,'iptarget':iptarget,'iperr':iperr,
-# 'etemp_profile_spatial':etemp_profile_spatial,'edens_profile_spatial':edens_profile_spatial,
+# betan = Signal("Normalized Beta", ['jpf/gs/bl-bndia<s', 'd3d/efsbetan'],
+# [jet, d3d])
+betan = Signal("Normalized Beta", ['d3d/efsbetan'], [d3d])
+energydt = Signal(
+    "stored energy time derivative", ['jpf/gs/bl-fdwdt<s'], [jet])
+
+torquein = Signal("Input Beam Torque", ['d3d/bmstinj'], [d3d])
+tmamp1 = Signal("Tearing Mode amplitude (rotating 2/1)", ['d3d/nssampn1l'],
+                [d3d])
+tmamp2 = Signal("Tearing Mode amplitude (rotating 3/2)", ['d3d/nssampn2l'],
+                [d3d])
+tmfreq1 = Signal("Tearing Mode frequency (rotating 2/1)", ['d3d/nssfrqn1l'],
+                 [d3d])
+tmfreq2 = Signal("Tearing Mode frequency (rotating 3/2)", ['d3d/nssfrqn2l'],
+                 [d3d])
+ipdirect = Signal("plasma current direction", ["d3d/iptdirect"], [d3d])
+
+# for downloading, modify this to preprocess shots with only a subset of
+# signals. This may produce more shots
+# since only those shots that contain all_signals contained here are used.
+# all_signals = {'q95':q95, 'li':li, 'ip':ip,
+# 'betan':betan, 'energy':energy, 'lm':lm, 'dens':dens,
+# 'pradcore':pradcore, 'pradedge':pradedge, 'pradtot':pradtot,
+# 'pin':pin, 'torquein':torquein,
+# 'tmamp1':tmamp1, 'tmamp2':tmamp2, 'tmfreq1':tmfreq1, 'tmfreq2':tmfreq2,
+# 'pechin':pechin, 'energydt':energydt,
+# 'etemp_profile':etemp_profile, 'edens_profile':edens_profile,
+# 'ipdirect':ipdirect, 'iptarget':iptarget, 'iperr':iperr,
+# 'etemp_profile_spatial':etemp_profile_spatial,
+# 'edens_profile_spatial':edens_profile_spatial,
 # 'etemp':etemp
-#}
+# }
 
-#Restricted subset to those signals that are present for most shots. The idea is to remove signals that cause many shots to be dropped from the dataset.
-all_signals = {'q95':q95,'li':li,'ip':ip,'betan':betan,'energy':energy,'lm':lm,'dens':dens,'pradcore':pradcore,
-'pradedge':pradedge,'pradtot':pradtot,'pin':pin,
-'torquein':torquein,
-'energydt':energydt,'ipdirect':ipdirect,'iptarget':iptarget,'iperr':iperr,
-#'tmamp1':tmamp1,'tmamp2':tmamp2,'tmfreq1':tmfreq1,'tmfreq2':tmfreq2,'pechin':pechin,
-# 'rho_profile_spatial':rho_profile_spatial,'etemp':etemp,
-'etemp_profile':etemp_profile,'edens_profile':edens_profile}
-#'itemp_profile':itemp_profile,'zdens_profile':zdens_profile,
-#'trot_profile':trot_profile,'pthm_profile':pthm_profile,
-#'neut_profile':neut_profile,'q_profile':q_profile,
-#'bootstrap_current_profile':bootstrap_current_profile,
-#'q_psi_profile':q_psi_profile}
-#}
+# Restricted subset to those signals that are present for most shots. The
+# idea is to remove signals that cause many shots to be dropped from the
+# dataset.
+all_signals = {
+    'q95': q95, 'li': li, 'ip': ip, 'betan': betan, 'energy': energy, 'lm': lm,
+    'dens': dens, 'pradcore': pradcore,
+    'pradedge': pradedge, 'pradtot': pradtot, 'pin': pin,
+    'torquein': torquein,
+    'energydt': energydt, 'ipdirect': ipdirect, 'iptarget': iptarget,
+    'iperr': iperr,
+    # 'tmamp1':tmamp1, 'tmamp2':tmamp2, 'tmfreq1':tmfreq1, 'tmfreq2':tmfreq2,
+    # 'pechin':pechin,
+    # 'rho_profile_spatial':rho_profile_spatial, 'etemp':etemp,
+    'etemp_profile': etemp_profile, 'edens_profile': edens_profile,
+    # 'itemp_profile':itemp_profile, 'zdens_profile':zdens_profile,
+    # 'trot_profile':trot_profile, 'pthm_profile':pthm_profile,
+    # 'neut_profile':neut_profile, 'q_profile':q_profile,
+    # 'bootstrap_current_profile':bootstrap_current_profile,
+    # 'q_psi_profile':q_psi_profile}
+}
 
-#new signals are not downloaded yet
+# new signals are not downloaded yet
 
 
-
-#for actual data analysis
-#all_signals_restricted = [q95,li,ip,energy,lm,dens,pradcore,pradtot,pin,etemp_profile,edens_profile]
+# for actual data analysis
+# all_signals_restricted = [q95, li, ip, energy, lm, dens, pradcore, pradtot,
+# pin, etemp_profile, edens_profile]
 
 all_signals_restricted = all_signals
 
-print('all signals (determines which signals are downloaded and preprocessed):')
+print('all signals (determines which signals are downloaded & preprocessed):')
 print(all_signals.values())
 
-fully_defined_signals = {sig_name: sig for (sig_name, sig) in all_signals_restricted.items() if sig.is_defined_on_machines(all_machines)}
-fully_defined_signals_0D = {sig_name: sig for (sig_name, sig) in all_signals_restricted.items() if ( sig.is_defined_on_machines(all_machines) and sig.num_channels == 1)  }
-fully_defined_signals_1D = {sig_name: sig for (sig_name, sig) in all_signals_restricted.items() if ( sig.is_defined_on_machines(all_machines) and sig.num_channels > 1)  }
+fully_defined_signals = {
+    sig_name: sig for (sig_name, sig) in all_signals_restricted.items() if (
+        sig.is_defined_on_machines(all_machines))
+}
+fully_defined_signals_0D = {
+    sig_name: sig for (sig_name, sig) in all_signals_restricted.items() if (
+        sig.is_defined_on_machines(all_machines) and sig.num_channels == 1)
+}
+fully_defined_signals_1D = {
+    sig_name: sig for (sig_name, sig) in all_signals_restricted.items() if (
+        sig.is_defined_on_machines(all_machines) and sig.num_channels > 1)
+}
+d3d_signals = {
+    sig_name: sig for (sig_name, sig) in all_signals_restricted.items() if (
+        sig.is_defined_on_machine(d3d))
+}
+d3d_signals_0D = {
+    sig_name: sig for (sig_name, sig) in all_signals_restricted.items() if (
+        (sig.is_defined_on_machine(d3d) and sig.num_channels == 1))
+}
+d3d_signals_1D = {
+    sig_name: sig for (sig_name, sig) in all_signals_restricted.items() if (
+        (sig.is_defined_on_machine(d3d) and sig.num_channels > 1))
+}
 
-d3d_signals = {sig_name: sig for (sig_name, sig) in all_signals_restricted.items() if sig.is_defined_on_machine(d3d)}
-d3d_signals_0D = {sig_name: sig for (sig_name, sig) in all_signals_restricted.items() if (sig.is_defined_on_machine(d3d) and sig.num_channels == 1)}
-d3d_signals_1D = {sig_name: sig for (sig_name, sig) in all_signals_restricted.items() if (sig.is_defined_on_machine(d3d) and sig.num_channels > 1)}
+jet_signals = {
+    sig_name: sig for (sig_name, sig) in all_signals_restricted.items() if (
+        sig.is_defined_on_machine(jet))
+}
+jet_signals_0D = {
+    sig_name: sig for (sig_name, sig) in all_signals_restricted.items() if (
+        (sig.is_defined_on_machine(jet) and sig.num_channels == 1))
+}
+jet_signals_1D = {
+    sig_name: sig for (sig_name, sig) in all_signals_restricted.items() if (
+        (sig.is_defined_on_machine(jet) and sig.num_channels > 1))
+}
 
-jet_signals = {sig_name: sig for (sig_name, sig) in all_signals_restricted.items() if sig.is_defined_on_machine(jet)}
-jet_signals_0D = {sig_name: sig for (sig_name, sig) in all_signals_restricted.items() if (sig.is_defined_on_machine(jet) and sig.num_channels == 1)}
-jet_signals_1D = {sig_name: sig for (sig_name, sig) in all_signals_restricted.items() if (sig.is_defined_on_machine(jet) and sig.num_channels > 1)}
+# ['pcechpwrf'] #Total ECH Power Not always on!
+# ## 0D EFIT signals ###
+# signal_paths += ['EFIT02/RESULTS.AEQDSK.Q95']
 
-#['pcechpwrf'] #Total ECH Power Not always on!
-### 0D EFIT signals ###
-#signal_paths += ['EFIT02/RESULTS.AEQDSK.Q95']
-  
-### 1D EFIT signals ###
-#the other signals give more reliable data
-#signal_paths += [
-#'AOT/EQU.t_e', #electron temperature profile vs rho (uniform mapping over time)
-#'AOT/EQU.dens_e'] #electron density profile vs rho (uniform mapping over time)
+# ## 1D EFIT signals ###
+# the other signals give more reliable data
+# signal_paths += [
+#  # Note, the following signals are uniformly mapped over time
+# 'AOT/EQU.t_e', # electron temperature profile vs rho
+# 'AOT/EQU.dens_e'] # electron density profile vs rho
 
 
 # [[' $I_{plasma}$ [A]'],
-#[' Mode L. A. [A]'],
-#[' $P_{radiated}$ [W]'],
-#[' $P_{radiated}$ [W]'],
-#[' $\rho_{plasma}$ [m^-2]'],
-#[' $L_{plasma,internal}$'],
-#['$\frac{d}{dt} E_{D}$ [W]'],
-#[' $P_{input}$ [W]'],
-#['$E_{D}$'],
-##ppf signal labels
-#['ECE unit?']]
+# [' Mode L. A. [A]'],
+# [' $P_{radiated}$ [W]'],
+# [' $P_{radiated}$ [W]'],
+# [' $\rho_{plasma}$ [m^-2]'],
+# [' $L_{plasma,internal}$'],
+# ['$\frac{d}{dt} E_{D}$ [W]'],
+# [' $P_{input}$ [W]'],
+# ['$E_{D}$'],
+# ppf signal labels
+# ['ECE unit?']]

--- a/examples/analyze_tuning.py
+++ b/examples/analyze_tuning.py
@@ -1,18 +1,22 @@
-from plasma.primitives.hyperparameters import CategoricalHyperparam,ContinuousHyperparam,LogContinuousHyperparam,HyperparamExperiment
+from plasma.primitives.hyperparameters import (
+    # CategoricalHyperparam, ContinuousHyperparam,
+    # LogContinuousHyperparam,
+    HyperparamExperiment
+)
 import matplotlib.pylab as plt
 
-from pprint import pprint
-import yaml
-import datetime
-import uuid
-import sys,os,getpass
-import shutil
-import subprocess as sp
-import pandas
+# from pprint import pprint
+# import yaml, datetime, uuid
+import sys
+import os
+import getpass
+# import shutil, pandas
+# import subprocess as sp
 import numpy as np
 import plasma.conf
 
-dir_path = "/{}/{}/hyperparams/".format(plasma.conf.conf['fs_path'],getpass.getuser())
+dir_path = "/{}/{}/hyperparams/".format(
+    plasma.conf.conf['fs_path'], getpass.getuser())
 
 if len(sys.argv) <= 1:
     dir_path = dir_path + os.listdir(dir_path)[0] + '/'
@@ -21,80 +25,85 @@ else:
     dir_path = sys.argv[1]
 
 
-def get_experiments(path,verbose=0):
+def get_experiments(path, verbose=0):
     experiments = []
     num_tot = 0
     num_finished = 0
     num_success = 0
     for name in sorted(os.listdir(path)):
-        if os.path.isdir(os.path.join(path,name)):
-            print(os.path.join(path,name))
-            exp= HyperparamExperiment(os.path.join(path,name))
+        if os.path.isdir(os.path.join(path, name)):
+            print(os.path.join(path, name))
+            exp = HyperparamExperiment(os.path.join(path, name))
             num_finished += 1 if exp.finished else 0
             num_success += 1 if exp.success else 0
             num_tot += 1
             experiments.append(exp)
-    if verbose: 
-        print("Read {} experiments, {} finished ({} success)".format(num_tot,num_finished,num_success))
+    if verbose:
+        print("Read {} experiments, {} finished ({} success)".format(
+            num_tot, num_finished, num_success))
     return experiments
 
+
 experiments = sorted(get_experiments(dir_path))
-best_experiments = np.argsort(np.array([e.get_maximum(False)[0] for e in experiments]))
-best = [] 
+best_experiments = np.argsort(
+    np.array([e.get_maximum(False)[0] for e in experiments]))
+best = []
 for e in np.array(experiments)[best_experiments][-5:]:
     best.append(e.get_number())
 
 bigdict = {}
 for base in best:
-    f = "/{}/{}/changed_params.out".format(dir_path,base)
+    f = "/{}/{}/changed_params.out".format(dir_path, base)
     data = open(f).readlines()
 
     for line in data:
         tuples = line.split(":")
-        #if len(tuples) == 2:
+        # if len(tuples) == 2:
         key, values = tuples[-2:]
-        key = key.strip() 
+        key = key.strip()
         try:
             bigdict[key] += [values]
         except KeyError:
             bigdict[key] = [values]
 
 
-def make_comparison_plot(key,tunable,trial):
-    values,edges = tunable
+def make_comparison_plot(key, tunable, trial):
+    values, edges = tunable
 
-    trial = list(map(lambda x: eval(x),trial))
-    trial_values,_ = np.histogram(trial,bins=edges)
+    trial = list(map(lambda x: eval(x), trial))
+    trial_values, _ = np.histogram(trial, bins=edges)
     total = trial_values.sum()
-    values_percentages =list(map(lambda x: x*100.0/total, trial_values))
+    values_percentages = list(map(lambda x: x*100.0/total, trial_values))
 
-    plt.bar(edges[:-1], values_percentages, width=np.diff(edges), ec="k", align="edge")
+    plt.bar(edges[:-1], values_percentages,
+            width=np.diff(edges), ec="k", align="edge")
     plt.xlabel(key, fontsize=20)
-    #plt.yscale('log')
+    # plt.yscale('log')
     plt.ylabel('Fraction of trials [%]/bin', fontsize=20)
 
     plt.bar(edges[:-1], values, width=np.diff(edges), ec="k", align="edge")
     plt.savefig(key+".png")
-    #plt.show()
+    # plt.show()
     plt.clf()
 
 
-#default tunables:
+# default tunables:
 defaults = {}
-defaults['lr'] = np.histogram([1e-7,1e-4])
-defaults['lr_decay'] = np.histogram([0.97,0.985,1.0])
-defaults['positive_example_penalty'] = np.histogram([1.0,4.0,16.0])
-#defaults['target'] = np.histogram([50,50,50],bins=['hinge','ttdinv','ttd'])
-defaults['batch_size'] = np.histogram([64,256,1024])
-defaults['dropout_prob'] = np.histogram([0.1,0.3,0.5])
-defaults['rnn_layers'] = np.histogram([1,4])
-defaults['rnn_size'] = np.histogram([100,200,300])
-defaults['num_conv_filters'] = np.histogram([5,10])
-defaults['num_conv_layers'] = np.histogram([2,4])
-defaults['T_warning'] = np.histogram([0.256,1.024,10.024])
-defaults['cut_shot_ends'] = np.histogram([False,True])
+defaults['lr'] = np.histogram([1e-7, 1e-4])
+defaults['lr_decay'] = np.histogram([0.97, 0.985, 1.0])
+defaults['positive_example_penalty'] = np.histogram([1.0, 4.0, 16.0])
+# defaults['target'] = np.histogram([50,50,50],bins=['hinge','ttdinv','ttd'])
+defaults['batch_size'] = np.histogram([64, 256, 1024])
+defaults['dropout_prob'] = np.histogram([0.1, 0.3, 0.5])
+defaults['rnn_layers'] = np.histogram([1, 4])
+defaults['rnn_size'] = np.histogram([100, 200, 300])
+defaults['num_conv_filters'] = np.histogram([5, 10])
+defaults['num_conv_layers'] = np.histogram([2, 4])
+defaults['T_warning'] = np.histogram([0.256, 1.024, 10.024])
+defaults['cut_shot_ends'] = np.histogram([False, True])
 
-#Histogram it
-for key,trial in bigdict.items():
-    if key == 'target': continue
-    make_comparison_plot(key,defaults[key],trial)
+# Histogram it
+for key, trial in bigdict.items():
+    if key == 'target':
+        continue
+    make_comparison_plot(key, defaults[key], trial)

--- a/examples/check_tuning.py
+++ b/examples/check_tuning.py
@@ -1,16 +1,15 @@
-from plasma.primitives.hyperparameters import CategoricalHyperparam,ContinuousHyperparam,LogContinuousHyperparam,HyperparamExperiment
-from pprint import pprint
-import yaml
-import datetime
-import uuid
-import sys,os,getpass
-import shutil
-import subprocess as sp
-import pandas
+from plasma.primitives.hyperparameters import (
+    # CategoricalHyperparam, ContinuousHyperparam, LogContinuousHyperparam,
+    HyperparamExperiment
+)
+import sys
+import os
+import getpass
 import numpy as np
 import plasma.conf
 
-dir_path = "/{}/{}/hyperparams/".format(plasma.conf.conf['fs_path'],getpass.getuser())
+dir_path = "/{}/{}/hyperparams/".format(
+    plasma.conf.conf['fs_path'], getpass.getuser())
 if len(sys.argv) <= 1:
     dir_path = dir_path + os.listdir(dir_path)[0] + '/'
     print("using default dir {}".format(dir_path))
@@ -24,19 +23,22 @@ def get_experiments(path):
     num_finished = 0
     num_success = 0
     for name in sorted(os.listdir(path)):
-        if os.path.isdir(os.path.join(path,name)):
-            print(os.path.join(path,name))
-            exp= HyperparamExperiment(os.path.join(path,name))
+        if os.path.isdir(os.path.join(path, name)):
+            print(os.path.join(path, name))
+            exp = HyperparamExperiment(os.path.join(path, name))
             num_finished += 1 if exp.finished else 0
             num_success += 1 if exp.success else 0
             num_tot += 1
             experiments.append(exp)
-    print("Read {} experiments, {} finished ({} success)".format(num_tot,num_finished,num_success))
+    print("Read {} experiments, {} finished ({} success)".format(
+        num_tot, num_finished, num_success))
     return experiments
+
 
 experiments = sorted(get_experiments(dir_path))
 print(len(experiments))
-best_experiments = np.argsort(np.array([e.get_maximum(False)[0] for e in experiments]))
+best_experiments = np.argsort(
+    np.array([e.get_maximum(False)[0] for e in experiments]))
 for e in experiments:
     e.summary()
 print("Best experiment so far: \n")

--- a/examples/compare_performance.py
+++ b/examples/compare_performance.py
@@ -1,10 +1,8 @@
-import os,sys
-import numpy as np
-
-from plasma.utils.performance import *
+import sys
+from plasma.utils.performance import PerformanceAnalyzer
 from plasma.conf import conf
 
-#mode = 'test'
+# mode = 'test'
 file_num = 0
 save_figure = True
 pred_ttd = False
@@ -12,51 +10,64 @@ pred_ttd = False
 # cut_shot_ends = conf['data']['cut_shot_ends']
 # dt = conf['data']['dt']
 # T_max_warn = int(round(conf['data']['T_warning']/dt))
-# T_min_warn = conf['data']['T_min_warn']#int(round(conf['data']['T_min_warn']/dt))
+# T_min_warn = conf['data']['T_min_warn']
+# T_min_warn = int(round(conf['data']['T_min_warn']/dt))
 # if cut_shot_ends:
 # 	T_max_warn = T_max_warn-T_min_warn
 # 	T_min_warn = 0
-T_min_warn = 30 #None #take value from conf #30
+T_min_warn = 30  # None #take value from conf #30
 
-verbose=False
+verbose = False
 assert(sys.argv > 1)
 results_dirs = sys.argv[1:]
 shots_dir = conf['paths']['processed_prepath']
 
-analyzers = [PerformanceAnalyzer(conf=conf,results_dir=results_dir,shots_dir=shots_dir,i = file_num,T_min_warn = T_min_warn, verbose = verbose, pred_ttd=pred_ttd) for results_dir in results_dirs]
+analyzers = [PerformanceAnalyzer(conf=conf, results_dir=results_dir,
+                                 shots_dir=shots_dir, i=file_num,
+                                 T_min_warn=T_min_warn,
+                                 verbose=verbose, pred_ttd=pred_ttd)
+             for results_dir in results_dirs]
 
 for analyzer in analyzers:
     analyzer.load_ith_file()
     analyzer.verbose = False
 
-P_threshs = [analyzer.compute_tradeoffs_and_print_from_training() for analyzer in analyzers]
+P_threshs = [analyzer.compute_tradeoffs_and_print_from_training()
+             for analyzer in analyzers]
 
 print('Test ROC:')
 for analyzer in analyzers:
     print(analyzer.get_roc_area_by_mode('test'))
-#P_thresh_opt = 0.566#0.566#0.92# analyzer.compute_tradeoffs_and_print_from_training()
-linestyle="-"
+# P_thresh_opt = 0.566#0.566#0.92#
+# analyzer.compute_tradeoffs_and_print_from_training()
+linestyle = "-"
 
-#analyzer.compute_tradeoffs_and_plot('test',save_figure=save_figure,plot_string='_test',linestyle=linestyle)
-#analyzer.compute_tradeoffs_and_plot('train',save_figure=save_figure,plot_string='_train',linestyle=linestyle)
-#analyzer.summarize_shot_prediction_stats_by_mode(P_thresh_opt,'test')
+# analyzer.compute_tradeoffs_and_plot('test', save_figure=save_figure,
+#     plot_string='_test',linestyle=linestyle)
+# analyzer.compute_tradeoffs_and_plot('train', save_figure=save_figure,
+#     plot_string='_train',linestyle=linestyle)
+# analyzer.summarize_shot_prediction_stats_by_mode(P_thresh_opt,'test')
 shots = analyzers[0].shot_list_test
 
 for shot in shots:
-    if all([(shot in analyzer.shot_list_test or shot in analyzer.shot_list_train) for analyzer in analyzers]):
-        types = [analyzers[i].get_prediction_type_for_individual_shot(P_threshs[i],shot,mode='test') for i in range(len(analyzers))]
-        #if len(set(types)) > 1:
-        if types == ['TP','late']:
+    if all([(shot in analyzer.shot_list_test
+             or shot in analyzer.shot_list_train)
+            for analyzer in analyzers]):
+        types = [
+            analyzers[i].get_prediction_type_for_individual_shot(
+                P_threshs[i], shot, mode='test')
+            for i in range(len(analyzers))]
+        if types == ['TP', 'late']:
             if shot in analyzers[1].shot_list_test:
                 print("TEST")
             else:
                 print("TRAIN")
             print(shot.number)
             print(types)
-            for i,analyzer in enumerate(analyzers):
-                analyzer.save_shot(shot,P_thresh_opt=P_threshs[i],extra_filename=['1D','0D'][i])
+            for i, analyzer in enumerate(analyzers):
+                analyzer.save_shot(shot, P_thresh_opt=P_threshs[i],
+                                   extra_filename=['1D', '0D'][i])
     else:
         pass
-        #print("shot {} not in train or test shot list (must be in validation)".format(shot))
-
-
+        # print("shot {} not in train or test shot list
+        #                 (must be in validation)".format(shot))

--- a/examples/custom_plot.py
+++ b/examples/custom_plot.py
@@ -1,16 +1,37 @@
 import numpy as np
-from bokeh.plotting import figure, show, output_file, save
+from bokeh.plotting import figure, output_file, save  # , show
 
 from tensorboard.backend.event_processing import event_accumulator
 
-ea1 = event_accumulator.EventAccumulator("/tigress/alexeys/worked_Graphs/Graph16_momSGD_new/events.out.tfevents.1502649990.tiger-i19g10")
+file_path = "/tigress/alexeys/worked_Graphs/Graph16_momSGD_new/"
+ea1 = event_accumulator.EventAccumulator(
+    file_path + "events.out.tfevents.1502649990.tiger-i19g10")
 ea1.Reload()
 
-ea2 = event_accumulator.EventAccumulator("/tigress/alexeys/worked_Graphs/Graph32_momSGD_new/events.out.tfevents.1502652797.tiger-i19g10")
+ea2 = event_accumulator.EventAccumulator(
+    file_path + "events.out.tfevents.1502652797.tiger-i19g10")
 ea2.Reload()
 
 histograms = ea1.Tags()['histograms']
-#ages': [], 'audio': [], 'histograms': ['input_2_out', 'time_distributed_1_out', 'lstm_1/kernel_0', 'lstm_1/kernel_0_grad', 'lstm_1/recurrent_kernel_0', 'lstm_1/recurrent_kernel_0_grad', 'lstm_1/bias_0', 'lstm_1/bias_0_grad', 'lstm_1_out', 'dropout_1_out', 'lstm_2/kernel_0', 'lstm_2/kernel_0_grad', 'lstm_2/recurrent_kernel_0', 'lstm_2/recurrent_kernel_0_grad', 'lstm_2/bias_0', 'lstm_2/bias_0_grad', 'lstm_2_out', 'dropout_2_out', 'time_distributed_2/kernel_0', 'time_distributed_2/kernel_0_grad', 'time_distributed_2/bias_0', 'time_distributed_2/bias_0_grad', 'time_distributed_2_out'], 'scalars': ['val_roc', 'val_loss', 'train_loss'], 'distributions': ['input_2_out', 'time_distributed_1_out', 'lstm_1/kernel_0', 'lstm_1/kernel_0_grad', 'lstm_1/recurrent_kernel_0', 'lstm_1/recurrent_kernel_0_grad', 'lstm_1/bias_0', 'lstm_1/bias_0_grad', 'lstm_1_out', 'dropout_1_out', 'lstm_2/kernel_0', 'lstm_2/kernel_0_grad', 'lstm_2/recurrent_kernel_0', 'lstm_2/recurrent_kernel_0_grad', 'lstm_2/bias_0', 'lstm_2/bias_0_grad', 'lstm_2_out', 'dropout_2_out', 'time_distributed_2/kernel_0', 'time_distributed_2/kernel_0_grad', 'time_distributed_2/bias_0', 'time_distributed_2/bias_0_grad', 'time_distributed_2_out'], 'tensors': [], 'graph': True, 'meta_graph': True, 'run_metadata': []}
+# ages': [], 'audio': [], 'histograms': ['input_2_out',
+# 'time_distributed_1_out', 'lstm_1/kernel_0', 'lstm_1/kernel_0_grad',
+# 'lstm_1/recurrent_kernel_0', 'lstm_1/recurrent_kernel_0_grad',
+# 'lstm_1/bias_0', 'lstm_1/bias_0_grad', 'lstm_1_out', 'dropout_1_out',
+# 'lstm_2/kernel_0', 'lstm_2/kernel_0_grad', 'lstm_2/recurrent_kernel_0',
+# 'lstm_2/recurrent_kernel_0_grad', 'lstm_2/bias_0', 'lstm_2/bias_0_grad',
+# 'lstm_2_out', 'dropout_2_out', 'time_distributed_2/kernel_0',
+# 'time_distributed_2/kernel_0_grad', 'time_distributed_2/bias_0',
+# 'time_distributed_2/bias_0_grad', 'time_distributed_2_out'], 'scalars':
+# ['val_roc', 'val_loss', 'train_loss'], 'distributions': ['input_2_out',
+# 'time_distributed_1_out', 'lstm_1/kernel_0', 'lstm_1/kernel_0_grad',
+# 'lstm_1/recurrent_kernel_0', 'lstm_1/recurrent_kernel_0_grad',
+# 'lstm_1/bias_0', 'lstm_1/bias_0_grad', 'lstm_1_out', 'dropout_1_out',
+# 'lstm_2/kernel_0', 'lstm_2/kernel_0_grad', 'lstm_2/recurrent_kernel_0',
+# 'lstm_2/recurrent_kernel_0_grad', 'lstm_2/bias_0', 'lstm_2/bias_0_grad',
+# 'lstm_2_out', 'dropout_2_out', 'time_distributed_2/kernel_0',
+# 'time_distributed_2/kernel_0_grad', 'time_distributed_2/bias_0',
+# 'time_distributed_2/bias_0_grad', 'time_distributed_2_out'], 'tensors':
+# [], 'graph': True, 'meta_graph': True, 'run_metadata': []}
 
 for h in histograms:
     x1 = np.array(ea1.Histograms(h)[0].histogram_value.bucket_limit[:-1])
@@ -18,18 +39,19 @@ for h in histograms:
     x2 = np.array(ea2.Histograms(h)[0].histogram_value.bucket_limit[:-1])
     y2 = ea2.Histograms(h)[0].histogram_value.bucket[:-1]
 
-    h = h.replace("/","_")
+    h = h.replace("/", "_")
 
-    p = figure(title=h, y_axis_label="Arbitrary units", x_axis_label="Arbitrary units")
-    #           ,y_axis_type="log")
+    p = figure(title=h, y_axis_label="Arbitrary units",
+               x_axis_label="Arbitrary units")
+    #           , y_axis_type="log")
 
     p.line(x1, y1, legend="float16, SGD with momentum",
-       line_color="green", line_width=2)
+           line_color="green", line_width=2)
 
     p.line(x2, y2, legend="float32, SGD with momentum",
-       line_color="indigo", line_width=2)
+           line_color="indigo", line_width=2)
 
     p.legend.location = "top_right"
 
-    output_file("plot"+h+".html", title=h)
+    output_file("plot" + h + ".html", title=h)
     save(p)  # open a browser

--- a/examples/distributed_job.sh
+++ b/examples/distributed_job.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #SBATCH -t 0-2:00
-#SBATCH -N 10 #how many nodes. The number of GPUs is this times 4.
+#SBATCH -N 10  # how many nodes. The totla number of GPUs is equal to this x4
 #SBATCH --ntasks-per-node=16
 #SBATCH --ntasks-per-socket=8
 #SBATCH --gres=gpu:4
@@ -13,4 +13,3 @@ echo "Removing old model checkpoints."
 rm /tigress/jk7/data/model_checkpoints/*
 echo "Running distributed learning"
 mpirun -npernode 4 python mpi_learn.py
-

--- a/examples/extract_best_overtime.py
+++ b/examples/extract_best_overtime.py
@@ -1,9 +1,6 @@
+import matplotlib.pylab as plt
 import pandas as pd
 import glob
-from subprocess import Popen
-import yaml
-import os
-import math
 import numpy as np
 from random import shuffle
 from joblib import Parallel, delayed
@@ -11,11 +8,9 @@ import multiprocessing
 
 import matplotlib
 matplotlib.use('Agg')
-import matplotlib.pylab as plt
 
-import pdb
 
-def arrangeTrialsAtRandom(filenames,scale=1.0):
+def arrangeTrialsAtRandom(filenames, scale=1.0):
     shuffle(filenames)
     previous = pd.read_csv(filenames[0])
     previous['times'] = previous['times'].apply(lambda x: x/60.0/scale)
@@ -23,26 +18,29 @@ def arrangeTrialsAtRandom(filenames,scale=1.0):
     for filename in filenames[1:]:
         shift = max(previous['times'].values)
         current = pd.read_csv(filename)
-        current['times'] = current['times'].apply(lambda x: x/60.0/scale+shift)
+        current['times'] = current['times'].apply(
+            lambda x: x/60.0/scale + shift)
         dataframes.append(current)
         previous = current
     return pd.concat(dataframes)
 
-def getOneBestValidationAUC(T_of_test,dataset):
-    #select subset of dataframe by time for all
+
+def getOneBestValidationAUC(T_of_test, dataset):
+    # select subset of dataframe by time for all
     dataset = dataset[dataset.times <= T_of_test]
- 
-    #apply emulate_converge script
+
+    # apply emulate_converge script
     aucs = dataset['val_roc'].values
     if len(aucs) > 0:
         return max(aucs)
     else:
         return 0.0
 
+
 def doPlot(parallel_aucs, serial_aucs, times, errors):
     times = list(times)
-    times_histo = np.histogram(parallel_aucs,bins=times)
-    #values,edges = times_histo
+    np.histogram(parallel_aucs, bins=times)
+    # values,edges = times_histo
     parallel_values = parallel_aucs[1:]
     edges = times
     print(len(parallel_values))
@@ -54,106 +52,120 @@ def doPlot(parallel_aucs, serial_aucs, times, errors):
     print(edges.shape)
     print(serial_values.shape)
 
-
     plt.figure()
-    plt.plot(edges, parallel_values,label = "Distributed search") #, width=np.diff(edges), ec="k", align="edge")
-    plt.plot(edges, serial_values, label="Sequential search") #, width=np.diff(edges), ec="k", align="edge")
-    #plt.fill_between(edges, serial_values-errors,serial_values+errors)
-    plt.legend(loc = (0.6,0.7))
+    # , width=np.diff(edges), ec="k", align="edge")
+    plt.plot(edges, parallel_values, label="Distributed search")
+    # , width=np.diff(edges), ec="k", align="edge")
+    plt.plot(edges, serial_values, label="Sequential search")
+    # plt.fill_between(edges, serial_values-errors,serial_values+errors)
+    plt.legend(loc=(0.6, 0.7))
     plt.xlabel("Time [minutes]", fontsize=20)
-    #plt.yscale('log')
+    # plt.yscale('log')
     plt.ylabel('Best validation AUC', fontsize=20)
     plt.savefig("times.png")
 
     plt.figure()
-    plt.plot(edges, parallel_values,label = "Distributed search") #, width=np.diff(edges), ec="k", align="edge")
-    plt.plot(edges, serial_values, label="Sequential search") #, width=np.diff(edges), ec="k", align="edge")
-    #plt.fill_between(edges, serial_values-errors,serial_values+errors)
-    plt.legend(loc = (0.6,0.7))
+    # , width=np.diff(edges), ec="k", align="edge")
+    plt.plot(edges, parallel_values, label="Distributed search")
+    # , width=np.diff(edges), ec="k", align="edge")
+    plt.plot(edges, serial_values, label="Sequential search")
+    # plt.fill_between(edges, serial_values-errors,serial_values+errors)
+    plt.legend(loc=(0.6, 0.7))
     plt.xlabel("Time [minutes]", fontsize=20)
     plt.xscale('log')
-    plt.xlim([0,100])
+    plt.xlim([0, 100])
     plt.ylabel('Best validation AUC', fontsize=20)
     plt.savefig("times_logx_start.png")
 
     plt.figure()
-    plt.plot(edges, parallel_values,label = "Distributed search") #, width=np.diff(edges), ec="k", align="edge")
-    plt.plot(edges, serial_values, label="Sequential search") #, width=np.diff(edges), ec="k", align="edge")
-    #plt.fill_between(edges, serial_values-errors,serial_values+errors)
-    plt.legend(loc = (0.6,0.7))
+    # , width=np.diff(edges), ec="k", align="edge")
+    plt.plot(edges, parallel_values, label="Distributed search")
+    # , width=np.diff(edges), ec="k", align="edge")
+    plt.plot(edges, serial_values, label="Sequential search")
+    # plt.fill_between(edges, serial_values-errors,serial_values+errors)
+    plt.legend(loc=(0.6, 0.7))
     plt.xlabel("Time [minutes]", fontsize=20)
     plt.xscale('log')
-    plt.xlim([100,10000])
+    plt.xlim([100, 10000])
     plt.ylabel('Best validation AUC', fontsize=20)
     plt.savefig("times_logx.png")
 
 
 def getReplica(filenames, times):
-    serial_auc_replica = arrangeTrialsAtRandom(filenames,100.0)
+    serial_auc_replica = arrangeTrialsAtRandom(filenames, 100.0)
 
     best_serial_aucs_over_time = []
     for T in times:
         current_best = 0
-        ##pass AUCs and real epoch counts to emulate_converge
-        auc = getOneBestValidationAUC(T,serial_auc_replica)
-        if auc > current_best: current_best = auc
+        # pass AUCs and real epoch counts to emulate_converge
+        auc = getOneBestValidationAUC(T, serial_auc_replica)
+        if auc > current_best:
+            current_best = auc
 
         best_serial_aucs_over_time.append(current_best)
 
-    #replicas.append(best_serial_aucs_over_time)
+    # replicas.append(best_serial_aucs_over_time)
     return best_serial_aucs_over_time
 
-def getTimeReplica(filenames,T):
+
+def getTimeReplica(filenames, T):
     current_best = 0
     for filename in filenames:
-        #get AUCs for this trial, one per effective epoch
+        # get AUCs for this trial, one per effective epoch
         try:
             dataset = pd.read_csv(filename)
             dataset['times'] = dataset['times'].apply(lambda x: x/60.0)
-        except:
+        except BaseException:
             print("No data in {}".format(filename))
             continue
-        ##pass AUCs and real epoch counts to emulate_converge
-        auc = getOneBestValidationAUC(T,dataset)
-        if auc > current_best: current_best = auc
+        # pass AUCs and real epoch counts to emulate_converge
+        auc = getOneBestValidationAUC(T, dataset)
+        if auc > current_best:
+            current_best = auc
     return current_best
 
-def getTimeReplicaSerial(serial_auc_replica,T):
-    current_best = 0
-    ##pass AUCs and real epoch counts to emulate_converge
-    auc = getOneBestValidationAUC(T,serial_auc_replica)
-    if auc > current_best: current_best = auc
 
-    #replicas.append(best_serial_aucs_over_time)
+def getTimeReplicaSerial(serial_auc_replica, T):
+    current_best = 0
+    # pass AUCs and real epoch counts to emulate_converge
+    auc = getOneBestValidationAUC(T, serial_auc_replica)
+    if auc > current_best:
+        current_best = auc
+
+    # replicas.append(best_serial_aucs_over_time)
     return current_best
 
 
 if __name__ == '__main__':
 
-    filenames = glob.glob("/tigress/FRNN/JET_Titan_hyperparameter_run/*/temporal_csv_log.csv")
+    filenames = glob.glob(
+        "/tigress/FRNN/JET_Titan_hyperparameter_run/*/temporal_csv_log.csv")
     patience = 5
 
-    times = np.linspace(0,310*30,186*30)
+    times = np.linspace(0, 310*30, 186*30)
 
     best_parallel_aucs_over_time = []
     num_cores = multiprocessing.cpu_count()
-    print ("Running on ", num_cores, " CPU cores")
-    best_parallel_aucs_over_time = Parallel(n_jobs=num_cores)(delayed(getTimeReplica)(filenames, T) for T in times) 
+    print("Running on ", num_cores, " CPU cores")
+    best_parallel_aucs_over_time = Parallel(n_jobs=num_cores)(
+        delayed(getTimeReplica)(filenames, T) for T in times)
 
     Nreplicas = 20
     replicas = []
 
-
     for i in range(Nreplicas):
-        serial_auc_replica = arrangeTrialsAtRandom(filenames,100.0)
+        serial_auc_replica = arrangeTrialsAtRandom(filenames, 100.0)
 
-        #replicas = Parallel(n_jobs=num_cores)(delayed(getReplica)(filenames, times) for i in range(Nreplicas)) 
-        best_serial_aucs_over_time = Parallel(n_jobs=num_cores)(delayed(getTimeReplicaSerial)(serial_auc_replica, T) for T in times)
+        # replicas = Parallel(n_jobs=num_cores)(delayed(getReplica)(filenames,
+        #               times) for i in range(Nreplicas))
+        best_serial_aucs_over_time = Parallel(n_jobs=num_cores)(
+            delayed(getTimeReplicaSerial)(serial_auc_replica,
+                                          T) for T in times)
         replicas.append(best_serial_aucs_over_time)
 
-
-    from statistics import mean,stdev
+    from statistics import mean, stdev
     best_serial_aucs_over_time = list(map(mean, zip(*replicas)))
     errors = list(map(stdev, zip(*replicas)))
 
-    doPlot(best_parallel_aucs_over_time, best_serial_aucs_over_time, times, errors)
+    doPlot(best_parallel_aucs_over_time, best_serial_aucs_over_time, times,
+           errors)

--- a/examples/guarantee_preprocessed.py
+++ b/examples/guarantee_preprocessed.py
@@ -1,18 +1,13 @@
-from __future__ import print_function
-import os
-import sys 
-import time
-import datetime
+from plasma.preprocessor.preprocess import guarantee_preprocessed
 import random
 import numpy as np
 
 from plasma.conf import conf
 from pprint import pprint
 pprint(conf)
-from plasma.preprocessor.preprocess import guarantee_preprocessed
 
 #####################################################
-####################PREPROCESSING####################
+#                PREPROCESSING                      #
 #####################################################
 np.random.seed(0)
 random.seed(0)

--- a/examples/hyper_learn.py
+++ b/examples/hyper_learn.py
@@ -1,4 +1,5 @@
-from __future__ import print_function
+from plasma.models import runner
+from plasma.models.loader import Loader
 
 import numpy as np
 from hyperopt import Trials, tpe
@@ -6,37 +7,41 @@ from hyperopt import Trials, tpe
 from plasma.conf import conf
 from pprint import pprint
 pprint(conf)
-#from plasma.primitives.shots import Shot, ShotList
-from plasma.preprocessor.normalize import Normalizer
-from plasma.models.loader import Loader
-#from plasma.models.runner import train, make_predictions,make_predictions_gpu
+# from plasma.primitives.shots import Shot, ShotList
+# from plasma.models.runner import train, make_predictions,make_predictions_gpu
 
 if conf['data']['normalizer'] == 'minmax':
     from plasma.preprocessor.normalize import MinMaxNormalizer as Normalizer
 elif conf['data']['normalizer'] == 'meanvar':
     from plasma.preprocessor.normalize import MeanVarNormalizer as Normalizer
 elif conf['data']['normalizer'] == 'var':
-    from plasma.preprocessor.normalize import VarNormalizer as Normalizer #performs !much better than minmaxnormalizer
+    # performs !much better than minmaxnormalizer
+    from plasma.preprocessor.normalize import VarNormalizer as Normalizer
 elif conf['data']['normalizer'] == 'averagevar':
-    from plasma.preprocessor.normalize import AveragingVarNormalizer as Normalizer #performs !much better than minmaxnormalizer
+    # performs !much better than minmaxnormalizer
+    from plasma.preprocessor.normalize import (
+        AveragingVarNormalizer as Normalizer
+    )
 else:
     print('unkown normalizer. exiting')
     exit(1)
 
 np.random.seed(1)
 
-print("normalization",end='')
+print("normalization", end='')
 nn = Normalizer(conf)
 nn.train()
-loader = Loader(conf,nn)
-shot_list_train,shot_list_validate,shot_list_test = loader.load_shotlists(conf)
+loader = Loader(conf, nn)
+shot_list_train, shot_list_validate, shot_list_test = loader.load_shotlists(
+    conf)
 print("...done")
 
-print('Training on {} shots, testing on {} shots'.format(len(shot_list_train),len(shot_list_test)))
-from plasma.models import runner
+print('Training on {} shots, testing on {} shots'.format(
+    len(shot_list_train), len(shot_list_test)))
 
-specific_runner = runner.HyperRunner(conf,loader,shot_list_train)
+specific_runner = runner.HyperRunner(conf, loader, shot_list_train)
 
-best_run, best_model = specific_runner.frnn_minimize(algo=tpe.suggest,max_evals=2,trials=Trials())
-print (best_run)
-print (best_model)
+best_run, best_model = specific_runner.frnn_minimize(
+    algo=tpe.suggest, max_evals=2, trials=Trials())
+print(best_run)
+print(best_model)

--- a/examples/individual_shot_performance.py
+++ b/examples/individual_shot_performance.py
@@ -1,17 +1,15 @@
-import os,sys
-import numpy as np
-
-from plasma.utils.performance import *
+import sys
+from plasma.utils.performance import PerformanceAnalyzer
 from plasma.conf import conf
 
-#mode = 'test'
+# mode = 'test'
 file_num = 0
 save_figure = True
 pred_ttd = False
 
-T_min_warn = 30 #None #take value from conf #30
+T_min_warn = 30  # None #take value from conf #30
 
-verbose=False
+verbose = False
 if len(sys.argv) == 3:
     results_dir = sys.argv[1]
     num = int(sys.argv[2])
@@ -23,10 +21,11 @@ print("loading results from {}".format(results_dir))
 print("Plotting shot {}".format(num))
 shots_dir = conf['paths']['processed_prepath']
 
-analyzer = PerformanceAnalyzer(conf=conf,results_dir=results_dir,shots_dir=shots_dir,i = file_num,
-T_min_warn = T_min_warn, verbose = verbose, pred_ttd=pred_ttd) 
+analyzer = PerformanceAnalyzer(conf=conf, results_dir=results_dir,
+                               shots_dir=shots_dir, i=file_num,
+                               T_min_warn=T_min_warn, verbose=verbose,
+                               pred_ttd=pred_ttd)
 
 analyzer.load_ith_file()
 P_thresh_opt = analyzer.compute_tradeoffs_and_print_from_training()
-analyzer.plot_individual_shot(P_thresh_opt,num)
-
+analyzer.plot_individual_shot(P_thresh_opt, num)

--- a/examples/learn.py
+++ b/examples/learn.py
@@ -1,3 +1,9 @@
+from plasma.models.loader import Loader
+from plasma.preprocessor.preprocess import guarantee_preprocessed
+from pprint import pprint
+from plasma.conf import conf
+import multiprocessing as old_mp
+import numpy as np
 '''
 #########################################################
 This file trains a deep learning model to predict
@@ -14,38 +20,35 @@ This work was supported by the DOE CSGF program.
 #########################################################
 '''
 
-from __future__ import print_function
-import datetime,time,random
-import sys,os
-import dill
-from functools import partial
+import datetime
+import random
+import sys
+import os
 
 import matplotlib
 matplotlib.use('Agg')
-import numpy as np
-import multiprocessing as old_mp
 
-from plasma.conf import conf
-from pprint import pprint
 pprint(conf)
-from plasma.primitives.shots import Shot, ShotList
-from plasma.preprocessor.normalize import Normalizer
-from plasma.preprocessor.preprocess import Preprocessor, guarantee_preprocessed
-from plasma.models.loader import Loader
 
 if conf['model']['shallow']:
-    from plasma.models.shallow_runner import train, make_predictions_and_evaluate_gpu
+    from plasma.models.shallow_runner import (
+        train, make_predictions_and_evaluate_gpu
+        )
 else:
     from plasma.models.runner import train, make_predictions_and_evaluate_gpu
 
 if conf['data']['normalizer'] == 'minmax':
     from plasma.preprocessor.normalize import MinMaxNormalizer as Normalizer
 elif conf['data']['normalizer'] == 'meanvar':
-    from plasma.preprocessor.normalize import MeanVarNormalizer as Normalizer 
+    from plasma.preprocessor.normalize import MeanVarNormalizer as Normalizer
 elif conf['data']['normalizer'] == 'var':
-    from plasma.preprocessor.normalize import VarNormalizer as Normalizer #performs !much better than minmaxnormalizer
+    # performs !much better than minmaxnormalizer
+    from plasma.preprocessor.normalize import VarNormalizer as Normalizer
 elif conf['data']['normalizer'] == 'averagevar':
-    from plasma.preprocessor.normalize import AveragingVarNormalizer as Normalizer #performs !much better than minmaxnormalizer
+    # performs !much better than minmaxnormalizer
+    from plasma.preprocessor.normalize import (
+        AveragingVarNormalizer as Normalizer
+    )
 else:
     print('unkown normalizer. exiting')
     exit(1)
@@ -55,7 +58,7 @@ shot_files = conf['paths']['shot_files']
 shot_files_test = conf['paths']['shot_files_test']
 train_frac = conf['training']['train_frac']
 stateful = conf['model']['stateful']
-# if stateful: 
+# if stateful:
 #     batch_size = conf['model']['length']
 # else:
 #     batch_size = conf['training']['batch_size_large']
@@ -70,37 +73,43 @@ if only_predict:
     print("predicting using path {}".format(custom_path))
 
 #####################################################
-####################PREPROCESSING####################
+#                   PREPROCESSING                   #
 #####################################################
-shot_list_train,shot_list_validate,shot_list_test = guarantee_preprocessed(conf)
+# TODO(KGF): check tuple unpack
+(shot_list_train, shot_list_validate,
+ shot_list_test) = guarantee_preprocessed(conf)
 
 #####################################################
-####################Normalization####################
+#                   NORMALIZATION                   #
 #####################################################
 
-print("normalization",end='')
+print("normalization", end='')
 nn = Normalizer(conf)
 nn.train()
-loader = Loader(conf,nn)
+loader = Loader(conf, nn)
 print("...done")
-print('Training on {} shots, testing on {} shots'.format(len(shot_list_train),len(shot_list_test)))
+print('Training on {} shots, testing on {} shots'.format(
+    len(shot_list_train), len(shot_list_test)))
 
 
 #####################################################
-######################TRAINING#######################
+#                    TRAINING                       #
 #####################################################
-#train(conf,shot_list_train,loader)
+# train(conf,shot_list_train,loader)
 if not only_predict:
-    p = old_mp.Process(target = train,args=(conf,shot_list_train,shot_list_validate,loader))
+    p = old_mp.Process(target=train,
+                       args=(conf, shot_list_train,
+                             shot_list_validate, loader)
+                       )
     p.start()
     p.join()
 
 #####################################################
-####################PREDICTING#######################
+#                    PREDICTING                     #
 #####################################################
 loader.set_inference_mode(True)
 
-#load last model for testing
+# load last model for testing
 print('saving results')
 y_prime = []
 y_prime_test = []
@@ -110,15 +119,22 @@ y_gold = []
 y_gold_test = []
 y_gold_train = []
 
-disruptive= []
-disruptive_train= []
-disruptive_test= []
+disruptive = []
+disruptive_train = []
+disruptive_test = []
 
-# y_prime_train,y_gold_train,disruptive_train = make_predictions(conf,shot_list_train,loader)
-# y_prime_test,y_gold_test,disruptive_test = make_predictions(conf,shot_list_test,loader)
+# y_prime_train, y_gold_train, disruptive_train =
+#         make_predictions(conf, shot_list_train, loader)
+# y_prime_test, y_gold_test, disruptive_test =
+#         make_predictions(conf, shot_list_test, loader)
 
-y_prime_train,y_gold_train,disruptive_train,roc_train,loss_train = make_predictions_and_evaluate_gpu(conf,shot_list_train,loader,custom_path)
-y_prime_test,y_gold_test,disruptive_test,roc_test,loss_test = make_predictions_and_evaluate_gpu(conf,shot_list_test,loader,custom_path)
+# TODO(KGF): check tuple unpack
+(y_prime_train, y_gold_train, disruptive_train, roc_train,
+ loss_train) = make_predictions_and_evaluate_gpu(
+     conf, shot_list_train, loader, custom_path)
+(y_prime_test, y_gold_test, disruptive_test, roc_test,
+ loss_test) = make_predictions_and_evaluate_gpu(
+     conf, shot_list_test, loader, custom_path)
 print('=========Summary========')
 print('Train Loss: {:.3e}'.format(loss_train))
 print('Train ROC: {:.4f}'.format(roc_train))
@@ -126,13 +142,12 @@ print('Test Loss: {:.3e}'.format(loss_test))
 print('Test ROC: {:.4f}'.format(roc_test))
 
 
-
 disruptive_train = np.array(disruptive_train)
 disruptive_test = np.array(disruptive_test)
 
 y_gold = y_gold_train + y_gold_test
 y_prime = y_prime_train + y_prime_test
-disruptive = np.concatenate((disruptive_train,disruptive_test))
+disruptive = np.concatenate((disruptive_train, disruptive_test))
 
 shot_list_validate.make_light()
 shot_list_test.make_light()
@@ -142,11 +157,12 @@ save_str = 'results_' + datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
 result_base_path = conf['paths']['results_prepath']
 if not os.path.exists(result_base_path):
     os.makedirs(result_base_path)
-np.savez(result_base_path+save_str,
-    y_gold=y_gold,y_gold_train=y_gold_train,y_gold_test=y_gold_test,
-    y_prime=y_prime,y_prime_train=y_prime_train,y_prime_test=y_prime_test,
-    disruptive=disruptive,disruptive_train=disruptive_train,disruptive_test=disruptive_test,
-    shot_list_validate=shot_list_validate,shot_list_train=shot_list_train,shot_list_test=shot_list_test,
-    conf = conf)
+np.savez(result_base_path+save_str, y_gold=y_gold, y_gold_train=y_gold_train,
+         y_gold_test=y_gold_test, y_prime=y_prime, y_prime_train=y_prime_train,
+         y_prime_test=y_prime_test, disruptive=disruptive,
+         disruptive_train=disruptive_train, disruptive_test=disruptive_test,
+         shot_list_validate=shot_list_validate,
+         shot_list_train=shot_list_train, shot_list_test=shot_list_test,
+         conf=conf)
 
 print('finished.')

--- a/examples/mpi_augment_learn.py
+++ b/examples/mpi_augment_learn.py
@@ -1,6 +1,6 @@
 from plasma.models.mpi_runner import (
     mpi_train, mpi_make_predictions_and_evaluate
-    )
+)
 from mpi4py import MPI
 from plasma.preprocessor.preprocess import guarantee_preprocessed
 from plasma.preprocessor.augment import Augmentator

--- a/examples/mpi_augment_learn.py
+++ b/examples/mpi_augment_learn.py
@@ -1,3 +1,12 @@
+from plasma.models.mpi_runner import (
+    mpi_train, mpi_make_predictions_and_evaluate
+    )
+from mpi4py import MPI
+from plasma.preprocessor.preprocess import guarantee_preprocessed
+from plasma.preprocessor.augment import Augmentator
+from plasma.models.loader import Loader
+from plasma.conf import conf
+from pprint import pprint
 '''
 #########################################################
 This file trains a deep learning model to predict
@@ -16,10 +25,8 @@ This work was supported by the DOE CSGF program.
 #########################################################
 '''
 
-from __future__ import print_function
 import os
-import sys 
-import time
+import sys
 import datetime
 import random
 import numpy as np
@@ -27,38 +34,35 @@ import numpy as np
 import matplotlib
 matplotlib.use('Agg')
 
-from pprint import pprint
 sys.setrecursionlimit(10000)
 
-from plasma.conf import conf
-from plasma.models.loader import Loader
-from plasma.preprocessor.normalize import Normalizer
-from plasma.preprocessor.augment import Augmentator
-from plasma.preprocessor.preprocess import guarantee_preprocessed
 
 if conf['model']['shallow']:
-    print("Shallow learning using MPI is not supported yet. set conf['model']['shallow'] to false.")
+    print(
+        "Shallow learning using MPI is not supported yet. ",
+        "Set conf['model']['shallow'] to False.")
     exit(1)
 if conf['data']['normalizer'] == 'minmax':
     from plasma.preprocessor.normalize import MinMaxNormalizer as Normalizer
 elif conf['data']['normalizer'] == 'meanvar':
     from plasma.preprocessor.normalize import MeanVarNormalizer as Normalizer
 elif conf['data']['normalizer'] == 'var':
-    from plasma.preprocessor.normalize import VarNormalizer as Normalizer #performs !much better than minmaxnormalizer
+    # performs !much better than minmaxnormalizer
+    from plasma.preprocessor.normalize import VarNormalizer as Normalizer
 elif conf['data']['normalizer'] == 'averagevar':
-    from plasma.preprocessor.normalize import AveragingVarNormalizer as Normalizer #performs !much better than minmaxnormalizer
+    # performs !much better than minmaxnormalizer
+    from plasma.preprocessor.normalize import (
+        AveragingVarNormalizer as Normalizer)
 else:
     print('unkown normalizer. exiting')
     exit(1)
 
-from mpi4py import MPI
 comm = MPI.COMM_WORLD
 task_index = comm.Get_rank()
 num_workers = comm.Get_size()
 NUM_GPUS = 4
 MY_GPU = task_index % NUM_GPUS
 
-from plasma.models.mpi_runner import *
 
 np.random.seed(task_index)
 random.seed(task_index)
@@ -72,47 +76,54 @@ if only_predict:
     print("predicting using path {}".format(custom_path))
 
 #####################################################
-####################Normalization####################
+#                 NORMALIZATION                     #
 #####################################################
-if task_index == 0: #make sure preprocessing has been run, and is saved as a file
-    shot_list_train,shot_list_validate,shot_list_test = guarantee_preprocessed(conf)
+# TODO(KGF): identical in at least 3x files in examples/
+# make sure preprocessing has been run, and is saved as a file
+if task_index == 0:
+    # TODO(KGF): check tuple unpack
+    (shot_list_train, shot_list_validate,
+     shot_list_test) = guarantee_preprocessed(conf)
 comm.Barrier()
-shot_list_train,shot_list_validate,shot_list_test = guarantee_preprocessed(conf)
+(shot_list_train, shot_list_validate,
+ shot_list_test) = guarantee_preprocessed(conf)
 
 
-
-print("normalization",end='')
+print("normalization", end='')
 raw_normalizer = Normalizer(conf)
 raw_normalizer.train()
-is_inference= False
-normalizer = Augmentator(raw_normalizer,is_inference,conf)
-loader = Loader(conf,normalizer)
+is_inference = False
+normalizer = Augmentator(raw_normalizer, is_inference, conf)
+loader = Loader(conf, normalizer)
 print("...done")
 
 if not only_predict:
-    mpi_train(conf,shot_list_train,shot_list_validate,loader)
+    mpi_train(conf, shot_list_train, shot_list_validate, loader)
 
-#load last model for testing
+# load last model for testing
 print('saving results')
 y_prime = []
 y_gold = []
-disruptive= []
-
-# y_prime_train,y_gold_train,disruptive_train = make_predictions(conf,shot_list_train,loader)
-# y_prime_test,y_gold_test,disruptive_test = make_predictions(conf,shot_list_test,loader)
+disruptive = []
 
 normalizer.set_inference(True)
 
-y_prime_train,y_gold_train,disruptive_train,roc_train,loss_train = mpi_make_predictions_and_evaluate(conf,shot_list_train,loader,custom_path)
-y_prime_test,y_gold_test,disruptive_test,roc_test,loss_test = mpi_make_predictions_and_evaluate(conf,shot_list_test,loader,custom_path)
+# TODO(KGF): check tuple unpack
+(y_prime_train, y_gold_train, disruptive_train, roc_train,
+ loss_train) = mpi_make_predictions_and_evaluate(conf, shot_list_train,
+                                                 loader, custom_path)
+(y_prime_test, y_gold_test, disruptive_test, roc_test,
+ loss_test) = mpi_make_predictions_and_evaluate(conf, shot_list_test,
+                                                loader, custom_path)
 
 if task_index == 0:
-        print('=========Summary========')
-        print('Train Loss: {:.3e}'.format(loss_train))
-        print('Train ROC: {:.4f}'.format(roc_train))
-        print('Test Loss: {:.3e}'.format(loss_test))
-        print('Test ROC: {:.4f}'.format(roc_test))
-        if roc_test < 0.8: sys.exit(1)
+    print('=========Summary========')
+    print('Train Loss: {:.3e}'.format(loss_train))
+    print('Train ROC: {:.4f}'.format(roc_train))
+    print('Test Loss: {:.3e}'.format(loss_test))
+    print('Test ROC: {:.4f}'.format(roc_test))
+    if roc_test < 0.8:
+        sys.exit(1)
 
 
 if task_index == 0:
@@ -121,22 +132,25 @@ if task_index == 0:
 
     y_gold = y_gold_train + y_gold_test
     y_prime = y_prime_train + y_prime_test
-    disruptive = np.concatenate((disruptive_train,disruptive_test))
+    disruptive = np.concatenate((disruptive_train, disruptive_test))
 
     shot_list_test.make_light()
     shot_list_train.make_light()
 
-    save_str = 'results_' + datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+    save_str = 'results_' + datetime.datetime.now().strftime(
+        "%Y-%m-%d-%H-%M-%S")
     result_base_path = conf['paths']['results_prepath']
     if not os.path.exists(result_base_path):
         os.makedirs(result_base_path)
 
-    np.savez(result_base_path+save_str,
-        y_gold=y_gold,y_gold_train=y_gold_train,y_gold_test=y_gold_test,
-        y_prime=y_prime,y_prime_train=y_prime_train,y_prime_test=y_prime_test,
-        disruptive=disruptive,disruptive_train=disruptive_train,disruptive_test=disruptive_test,
-        shot_list_train=shot_list_train,shot_list_test=shot_list_test,
-        conf = conf)
+    np.savez(result_base_path+save_str, y_gold=y_gold,
+             y_gold_train=y_gold_train, y_gold_test=y_gold_test,
+             y_prime=y_prime, y_prime_train=y_prime_train,
+             y_prime_test=y_prime_test, disruptive=disruptive,
+             disruptive_train=disruptive_train,
+             disruptive_test=disruptive_test,
+             shot_list_train=shot_list_train, shot_list_test=shot_list_test,
+             conf=conf)
 
 sys.stdout.flush()
 if task_index == 0:

--- a/examples/mpi_learn.py
+++ b/examples/mpi_learn.py
@@ -1,3 +1,11 @@
+from plasma.models.mpi_runner import (
+    mpi_train, mpi_make_predictions_and_evaluate
+    )
+from mpi4py import MPI
+from plasma.preprocessor.preprocess import guarantee_preprocessed
+from plasma.models.loader import Loader
+from plasma.conf import conf
+from pprint import pprint
 '''
 #########################################################
 This file trains a deep learning model to predict
@@ -16,10 +24,8 @@ This work was supported by the DOE CSGF program.
 #########################################################
 '''
 
-from __future__ import print_function
 import os
-import sys 
-import time
+import sys
 import datetime
 import random
 import numpy as np
@@ -27,37 +33,36 @@ import numpy as np
 import matplotlib
 matplotlib.use('Agg')
 
-from pprint import pprint
 sys.setrecursionlimit(10000)
 
-from plasma.conf import conf
-from plasma.models.loader import Loader
-from plasma.preprocessor.normalize import Normalizer
-from plasma.preprocessor.preprocess import guarantee_preprocessed
 
 if conf['model']['shallow']:
-    print("Shallow learning using MPI is not supported yet. set conf['model']['shallow'] to false.")
+    print(
+        "Shallow learning using MPI is not supported yet. ",
+        "Set conf['model']['shallow'] to False.")
     exit(1)
 if conf['data']['normalizer'] == 'minmax':
     from plasma.preprocessor.normalize import MinMaxNormalizer as Normalizer
 elif conf['data']['normalizer'] == 'meanvar':
     from plasma.preprocessor.normalize import MeanVarNormalizer as Normalizer
 elif conf['data']['normalizer'] == 'var':
-    from plasma.preprocessor.normalize import VarNormalizer as Normalizer #performs !much better than minmaxnormalizer
+    # performs !much better than minmaxnormalizer
+    from plasma.preprocessor.normalize import VarNormalizer as Normalizer
 elif conf['data']['normalizer'] == 'averagevar':
-    from plasma.preprocessor.normalize import AveragingVarNormalizer as Normalizer #performs !much better than minmaxnormalizer
+    # performs !much better than minmaxnormalizer
+    from plasma.preprocessor.normalize import (
+        AveragingVarNormalizer as Normalizer
+        )
 else:
     print('unkown normalizer. exiting')
     exit(1)
 
-from mpi4py import MPI
 comm = MPI.COMM_WORLD
 task_index = comm.Get_rank()
 num_workers = comm.Get_size()
 NUM_GPUS = conf['num_gpus']
 MY_GPU = task_index % NUM_GPUS
 
-from plasma.models.mpi_runner import *
 
 np.random.seed(task_index)
 random.seed(task_index)
@@ -70,47 +75,53 @@ if only_predict:
     custom_path = sys.argv[1]
     print("predicting using path {}".format(custom_path))
 
+
 #####################################################
-####################Normalization####################
+#                 NORMALIZATION                     #
 #####################################################
-if task_index == 0: #make sure preprocessing has been run, and is saved as a file
-    shot_list_train,shot_list_validate,shot_list_test = guarantee_preprocessed(conf)
+# make sure preprocessing has been run, and is saved as a file
+if task_index == 0:
+    # TODO(KGF): check tuple unpack
+    (shot_list_train, shot_list_validate,
+     shot_list_test) = guarantee_preprocessed(conf)
 comm.Barrier()
-shot_list_train,shot_list_validate,shot_list_test = guarantee_preprocessed(conf)
+(shot_list_train, shot_list_validate,
+ shot_list_test) = guarantee_preprocessed(conf)
 
 
-
-print("normalization",end='')
+print("normalization", end='')
 normalizer = Normalizer(conf)
 normalizer.train()
-loader = Loader(conf,normalizer)
+loader = Loader(conf, normalizer)
 print("...done")
 
-#ensure training has a separate random seed for every worker
+# ensure training has a separate random seed for every worker
 np.random.seed(task_index)
 random.seed(task_index)
 if not only_predict:
-    mpi_train(conf,shot_list_train,shot_list_validate,loader)
+    mpi_train(conf, shot_list_train, shot_list_validate, loader)
 
-#load last model for testing
+# load last model for testing
 loader.set_inference_mode(True)
 print('saving results')
 y_prime = []
 y_gold = []
-disruptive= []
+disruptive = []
 
-# y_prime_train,y_gold_train,disruptive_train = make_predictions(conf,shot_list_train,loader)
-# y_prime_test,y_gold_test,disruptive_test = make_predictions(conf,shot_list_test,loader)
-
-y_prime_train,y_gold_train,disruptive_train,roc_train,loss_train = mpi_make_predictions_and_evaluate(conf,shot_list_train,loader,custom_path)
-y_prime_test,y_gold_test,disruptive_test,roc_test,loss_test = mpi_make_predictions_and_evaluate(conf,shot_list_test,loader,custom_path)
+# TODO(KGF): check tuple unpack
+(y_prime_train, y_gold_train, disruptive_train, roc_train,
+ loss_train) = mpi_make_predictions_and_evaluate(conf, shot_list_train,
+                                                 loader, custom_path)
+(y_prime_test, y_gold_test, disruptive_test, roc_test,
+ loss_test) = mpi_make_predictions_and_evaluate(conf, shot_list_test,
+                                                loader, custom_path)
 
 if task_index == 0:
-        print('=========Summary========')
-        print('Train Loss: {:.3e}'.format(loss_train))
-        print('Train ROC: {:.4f}'.format(roc_train))
-        print('Test Loss: {:.3e}'.format(loss_test))
-        print('Test ROC: {:.4f}'.format(roc_test))
+    print('=========Summary========')
+    print('Train Loss: {:.3e}'.format(loss_train))
+    print('Train ROC: {:.4f}'.format(roc_train))
+    print('Test Loss: {:.3e}'.format(loss_test))
+    print('Test ROC: {:.4f}'.format(roc_test))
 
 
 if task_index == 0:
@@ -119,22 +130,24 @@ if task_index == 0:
 
     y_gold = y_gold_train + y_gold_test
     y_prime = y_prime_train + y_prime_test
-    disruptive = np.concatenate((disruptive_train,disruptive_test))
+    disruptive = np.concatenate((disruptive_train, disruptive_test))
 
     shot_list_test.make_light()
     shot_list_train.make_light()
 
-    save_str = 'results_' + datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+    save_str = 'results_' + datetime.datetime.now().strftime(
+        "%Y-%m-%d-%H-%M-%S")
     result_base_path = conf['paths']['results_prepath']
     if not os.path.exists(result_base_path):
         os.makedirs(result_base_path)
 
-    np.savez(result_base_path+save_str,
-        y_gold=y_gold,y_gold_train=y_gold_train,y_gold_test=y_gold_test,
-        y_prime=y_prime,y_prime_train=y_prime_train,y_prime_test=y_prime_test,
-        disruptive=disruptive,disruptive_train=disruptive_train,disruptive_test=disruptive_test,
-        shot_list_train=shot_list_train,shot_list_test=shot_list_test,
-        conf = conf)
+    np.savez(result_base_path+save_str, y_gold=y_gold,
+             y_gold_train=y_gold_train, y_gold_test=y_gold_test,
+             y_prime=y_prime, y_prime_train=y_prime_train,
+             y_prime_test=y_prime_test, disruptive=disruptive,
+             disruptive_train=disruptive_train,
+             disruptive_test=disruptive_test, shot_list_train=shot_list_train,
+             shot_list_test=shot_list_test, conf=conf)
 
 sys.stdout.flush()
 if task_index == 0:

--- a/examples/performance_analysis.py
+++ b/examples/performance_analysis.py
@@ -1,66 +1,93 @@
-import os,sys
+import sys
 import numpy as np
 
-from plasma.utils.performance import *
+from plasma.utils.performance import PerformanceAnalyzer
 from plasma.conf import conf
 
-#mode = 'test'
+# mode = 'test'
 file_num = 0
 save_figure = True
 pred_ttd = False
 
-# cut_shot_ends = conf['data']['cut_shot_ends']
-# dt = conf['data']['dt']
-# T_max_warn = int(round(conf['data']['T_warning']/dt))
-# T_min_warn = conf['data']['T_min_warn']#int(round(conf['data']['T_min_warn']/dt))
-# if cut_shot_ends:
-# 	T_max_warn = T_max_warn-T_min_warn
-# 	T_min_warn = 0
-T_min_warn = 30 #None #take value from conf #30
+T_min_warn = 30  # None #take value from conf #30
 
-verbose=False
+verbose = False
 if len(sys.argv) > 1:
     results_dir = sys.argv[1]
 else:
     results_dir = conf['paths']['results_prepath']
 shots_dir = conf['paths']['processed_prepath']
 
-analyzer = PerformanceAnalyzer(conf=conf,results_dir=results_dir,shots_dir=shots_dir,i = file_num,
-T_min_warn = T_min_warn, verbose = verbose, pred_ttd=pred_ttd) 
+analyzer = PerformanceAnalyzer(
+    conf=conf,
+    results_dir=results_dir,
+    shots_dir=shots_dir,
+    i=file_num,
+    T_min_warn=T_min_warn,
+    verbose=verbose,
+    pred_ttd=pred_ttd)
 
 analyzer.load_ith_file()
 
 P_thresh_opt = analyzer.compute_tradeoffs_and_print_from_training()
-#P_thresh_opt = 0.566#0.566#0.92# analyzer.compute_tradeoffs_and_print_from_training()
-linestyle="-"
+# P_thresh_opt = 0.566 # 0.566 # 0.92
+# analyzer.compute_tradeoffs_and_print_from_training()
+linestyle = "-"
 
-P_thresh_range,missed_range,fp_range = analyzer.compute_tradeoffs_and_plot('test',save_figure=save_figure,plot_string='_test',linestyle=linestyle)
-np.savez('test_roc.npz',"P_thresh_range",P_thresh_range,"missed_range",missed_range,"fp_range",fp_range)
-analyzer.compute_tradeoffs_and_plot('train',save_figure=save_figure,plot_string='_train',linestyle=linestyle)
+P_thresh_range, missed_range, fp_range = analyzer.compute_tradeoffs_and_plot(
+    'test', save_figure=save_figure, plot_string='_test', linestyle=linestyle)
+np.savez(
+    'test_roc.npz',
+    "P_thresh_range",
+    P_thresh_range,
+    "missed_range",
+    missed_range,
+    "fp_range",
+    fp_range)
+analyzer.compute_tradeoffs_and_plot(
+    'train',
+    save_figure=save_figure,
+    plot_string='_train',
+    linestyle=linestyle)
 
-analyzer.summarize_shot_prediction_stats_by_mode(P_thresh_opt,'test')
+analyzer.summarize_shot_prediction_stats_by_mode(P_thresh_opt, 'test')
 
 normalize = True
-analyzer.example_plots(P_thresh_opt,'test','any',normalize=normalize)
-analyzer.example_plots(P_thresh_opt,'test',['FP'],extra_filename='test',normalize=normalize)
-analyzer.example_plots(P_thresh_opt,'test',['FN'],extra_filename='test',normalize=normalize)
-analyzer.example_plots(P_thresh_opt,'test',['TP'],extra_filename='test',normalize=normalize)
-analyzer.example_plots(P_thresh_opt,'test',['late'],extra_filename='test',normalize=normalize)
+analyzer.example_plots(P_thresh_opt, 'test', 'any', normalize=normalize)
+analyzer.example_plots(P_thresh_opt, 'test', ['FP'], extra_filename='test',
+                       normalize=normalize)
+analyzer.example_plots(P_thresh_opt, 'test', ['FN'], extra_filename='test',
+                       normalize=normalize)
+analyzer.example_plots(P_thresh_opt, 'test', ['TP'], extra_filename='test',
+                       normalize=normalize)
+analyzer.example_plots(P_thresh_opt, 'test', ['late'], extra_filename='test',
+                       normalize=normalize)
 
-analyzer.example_plots(P_thresh_opt,'train',['TN'],extra_filename='train',normalize=normalize)
-analyzer.example_plots(P_thresh_opt,'train',['FP'],extra_filename='train',normalize=normalize)
-analyzer.example_plots(P_thresh_opt,'train',['FN'],extra_filename='train',normalize=normalize)
-analyzer.example_plots(P_thresh_opt,'train',['TP'],extra_filename='train',normalize=normalize)
-analyzer.example_plots(P_thresh_opt,'train',['late'],extra_filename='train',normalize=normalize)
+analyzer.example_plots(P_thresh_opt, 'train', ['TN'], extra_filename='train',
+                       normalize=normalize)
+analyzer.example_plots(P_thresh_opt, 'train', ['FP'], extra_filename='train',
+                       normalize=normalize)
+analyzer.example_plots(P_thresh_opt, 'train', ['FN'], extra_filename='train',
+                       normalize=normalize)
+analyzer.example_plots(P_thresh_opt, 'train', ['TP'], extra_filename='train',
+                       normalize=normalize)
+analyzer.example_plots(P_thresh_opt, 'train', ['late'], extra_filename='train',
+                       normalize=normalize)
 
 
-alarms,disr_alarms,nondisr_alarms = analyzer.gather_first_alarms(P_thresh_opt,'test')
-analyzer.hist_alarms(disr_alarms,'disruptive alarms, P thresh = {}'.format(P_thresh_opt),save_figure=save_figure,linestyle=linestyle)
-np.savez('disruptive_alarms_test.npz',"disr_alarms",disr_alarms,"P_thresh_opt",P_thresh_opt)
+alarms, disr_alarms, nondisr_alarms = analyzer.gather_first_alarms(
+    P_thresh_opt, 'test')
+analyzer.hist_alarms(disr_alarms, 'disruptive alarms, P thresh = {}'.format(
+    P_thresh_opt), save_figure=save_figure, linestyle=linestyle)
+np.savez('disruptive_alarms_test.npz', "disr_alarms", disr_alarms,
+         "P_thresh_opt", P_thresh_opt)
 
 print('{} disruptive alarms'.format(len(disr_alarms)))
-print('{} seconds mean alarm time'.format(np.mean(disr_alarms[disr_alarms > 0])))
-print('{} seconds median alarm time'.format(np.median(disr_alarms[disr_alarms > 0])))
-analyzer.hist_alarms(nondisr_alarms,'nondisruptive alarms, P thresh = {}'.format(P_thresh_opt))
+print('{} seconds mean alarm time'.format(
+    np.mean(disr_alarms[disr_alarms > 0])))
+print('{} seconds median alarm time'.format(
+    np.median(disr_alarms[disr_alarms > 0])))
+analyzer.hist_alarms(nondisr_alarms,
+                     'nondisruptive alarms, P thresh = {}'.format(P_thresh_opt)
+                     )
 print('{} nondisruptive alarms'.format(len(nondisr_alarms)))
-

--- a/examples/prepare_pbs_configs_titan.py
+++ b/examples/prepare_pbs_configs_titan.py
@@ -3,76 +3,85 @@ import subprocess
 from subprocess import Popen
 from time import sleep
 
-def checkAndSchedule(configBaseName,nextGPUcount,GPUstep,maxGPUcount):
-    if nextGPUcount > maxGPUcount: return 
-    job_is_running = subprocess.check_output(['qstat','-u','alexeys'])
-    if len(job_is_running) > 0: 
-        #sleep 500 seconds
+
+def checkAndSchedule(configBaseName, nextGPUcount, GPUstep, maxGPUcount):
+    if nextGPUcount > maxGPUcount:
+        return
+    job_is_running = subprocess.check_output(['qstat', '-u', 'alexeys'])
+    if len(job_is_running) > 0:
+        # sleep 500 seconds
         sleep(500)
-        checkAndSchedule(configBaseName,nextGPUcount,GPUstep,maxGPUcount)
+        checkAndSchedule(configBaseName, nextGPUcount, GPUstep, maxGPUcount)
     else:
-        #create a config
-        nextConfigName = createOneConfig(configBaseName,nextGPUcount)
-        print "Submitting next PBS job {} to run on {} GPUs".format(configBaseName,nextGPUcount)
-        print "qsub "+nextConfigName
-        Popen("qsub "+nextConfigName,shell=True).wait() 
-        #update parameters
+        # create a config
+        nextConfigName = createOneConfig(configBaseName, nextGPUcount)
+        print("Submitting next PBS job {} to run on {} GPUs".format(
+            configBaseName, nextGPUcount))
+        print("qsub ", nextConfigName)
+        Popen("qsub " + nextConfigName, shell=True).wait()
+        # update parameters
         nextGPUcount += GPUstep
         sleep(10)
-        checkAndSchedule(configBaseName,nextGPUcount,GPUstep,maxGPUcount)
+        checkAndSchedule(configBaseName, nextGPUcount, GPUstep, maxGPUcount)
 
 
 def createOneConfig(configBaseName, GPUcount):
     configFullName = configBaseName+str(GPUcount)+".cmd"
-    with open(configFullName,"w") as f:
-	f.write('#!/bin/bash\n')
-	f.write('#PBS -A FUS117\n')
-	f.write('#PBS -l walltime=1:30:00\n') #FIXME this depends a lot on the number of GPUs 1900s/1epoch at 50, 2350s/1epoch at 4
-	f.write('#PBS -l nodes='+str(GPUcount)+'\n')
-	f.write('##PBS -l procs=1\n')
-	f.write('##PBS -l gres=atlas1%atlas2\n')
+    with open(configFullName, "w") as f:
+        f.write('#!/bin/bash\n')
+        f.write('#PBS -A FUS117\n')
+        # FIXME this depends a lot on the number of GPUs 1900s/1epoch at 50,
+        # 2350s/1epoch at 4
+        f.write('#PBS -l walltime=1:30:00\n')
+        f.write('#PBS -l nodes='+str(GPUcount)+'\n')
+        f.write('##PBS -l procs=1\n')
+        f.write('##PBS -l gres=atlas1%atlas2\n')
         f.write('\n\n')
-	f.write('export HOME=/lustre/atlas/proj-shared/fus117\n')
-	f.write('cd $HOME/PPPL/plasma-python/examples\n')
+        f.write('export HOME=/lustre/atlas/proj-shared/fus117\n')
+        f.write('cd $HOME/PPPL/plasma-python/examples\n')
         f.write('\n\n')
-	f.write('source $MODULESHOME/init/bash\n')
-	f.write('module switch PrgEnv-pgi PrgEnv-gnu\n')
+        f.write('source $MODULESHOME/init/bash\n')
+        f.write('module switch PrgEnv-pgi PrgEnv-gnu\n')
         f.write('\n\n')
-	f.write('module load cudatoolkit\n')
-	f.write('export LIBRARY_PATH=/opt/nvidia/cudatoolkit7.5/7.5.18-1.0502.10743.2.1/lib64:$LIBRARY_PATH\n')
+        f.write('module load cudatoolkit\n')
+        f.write(('export LIBRARY_PATH=/opt/nvidia/cudatoolkit7.5/'
+                 '7.5.18-1.0502.10743.2.1/lib64:$LIBRARY_PATH\n'))
         f.write('\n\n')
-	f.write('#This block is CuDNN module\n')
-	f.write('export LD_LIBRARY_PATH=$HOME/cuda/lib64:$LD_LIBRARY_PATH\n')
-	f.write('export LIBRARY_PATH=$HOME/cuda/lib64:$LIBRARY_PATH\n')
-	f.write('export LDFLAGS=$LDFLAGS:$HOME/cuda/lib64\n')
-	f.write('export INCLUDE=$INCLUDE:$HOME/cuda/include\n')
-	f.write('export CPATH=$CPATH:$HOME/cuda/include\n')
-	f.write('export FFLAGS=$FFLAGS:$HOME/cuda/include\n')
-	f.write('export LOCAL_LDFLAGS=$LOCAL_LDFLAGS:$HOME/cuda/lib64\n')
-	f.write('export LOCAL_INCLUDE=$LOCAL_INCLUDE:$HOME/cuda/include\n')
-	f.write('export LOCAL_CFLAGS=$LOCAL_CFLAGS:$HOME/cuda/include\n')
-	f.write('export LOCAL_FFLAGS=$LOCAL_FFLAGS:$HOME/cuda/include\n')
-	f.write('export LOCAL_CXXFLAGS=$LOCAL_CXXFLAGS:$HOME/cuda/include\n')
+        f.write('#This block is CuDNN module\n')
+        f.write('export LD_LIBRARY_PATH=$HOME/cuda/lib64:$LD_LIBRARY_PATH\n')
+        f.write('export LIBRARY_PATH=$HOME/cuda/lib64:$LIBRARY_PATH\n')
+        f.write('export LDFLAGS=$LDFLAGS:$HOME/cuda/lib64\n')
+        f.write('export INCLUDE=$INCLUDE:$HOME/cuda/include\n')
+        f.write('export CPATH=$CPATH:$HOME/cuda/include\n')
+        f.write('export FFLAGS=$FFLAGS:$HOME/cuda/include\n')
+        f.write('export LOCAL_LDFLAGS=$LOCAL_LDFLAGS:$HOME/cuda/lib64\n')
+        f.write('export LOCAL_INCLUDE=$LOCAL_INCLUDE:$HOME/cuda/include\n')
+        f.write('export LOCAL_CFLAGS=$LOCAL_CFLAGS:$HOME/cuda/include\n')
+        f.write('export LOCAL_FFLAGS=$LOCAL_FFLAGS:$HOME/cuda/include\n')
+        f.write('export LOCAL_CXXFLAGS=$LOCAL_CXXFLAGS:$HOME/cuda/include\n')
         f.write('\n\n')
-	f.write('#This sets new home and Anaconda module\n')
-	f.write('export PATH=$HOME/anaconda2/bin:$PATH\n')
-	f.write('export LD_LIBRARY_PATH=$HOME/anaconda2/lib:$LD_LIBRARY_PATH\n')
-	f.write('source activate PPPL\n')
+        f.write('#This sets new home and Anaconda module\n')
+        f.write('export PATH=$HOME/anaconda2/bin:$PATH\n')
+        f.write(
+            'export LD_LIBRARY_PATH=$HOME/anaconda2/lib:$LD_LIBRARY_PATH\n')
+        f.write('source activate PPPL\n')
         f.write('\n\n')
-	f.write('PYTHON=`which python`\n')
-	f.write('echo $PYTHON\n')
+        f.write('PYTHON=`which python`\n')
+        f.write('echo $PYTHON\n')
         f.write('\n\n')
-	f.write('export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH\n')
-	f.write('export MPICH_RDMA_ENABLED_CUDA=1\n')
+        f.write(
+            'export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH\n')
+        f.write('export MPICH_RDMA_ENABLED_CUDA=1\n')
         f.write('\n\n')
-	f.write('rm $HOME/tigress/alexeys/model_checkpoints/*\n')
-	f.write('aprun -n'+str(GPUcount)+' -N1 $PYTHON mpi_learn.py\n')
+        f.write('rm $HOME/tigress/alexeys/model_checkpoints/*\n')
+        f.write('aprun -n'+str(GPUcount)+' -N1 $PYTHON mpi_learn.py\n')
 
     return configFullName
 
-if __name__=='__main__':
+
+if __name__ == '__main__':
     nextGPUcount = 50
-    GPUstep = 50 
+    GPUstep = 50
     maxGPUcount = 101
     configBaseName = "FRNN_Titan"
-    checkAndSchedule(configBaseName,nextGPUcount,GPUstep,maxGPUcount)
+    checkAndSchedule(configBaseName, nextGPUcount, GPUstep, maxGPUcount)

--- a/examples/prepare_slurm_configs.py
+++ b/examples/prepare_slurm_configs.py
@@ -3,29 +3,34 @@ import subprocess
 from subprocess import Popen
 from time import sleep
 
-def checkAndSchedule(configBaseName,gpuNodeCountGrid,nextGPUNodeCount):
-    if nextGPUNodeCount > len(gpuNodeCountGrid)-1: return 
-    job_is_running = subprocess.check_output(['squeue','-u','alexeys']) #['qstat','-u','alexeys'])
+
+def checkAndSchedule(configBaseName, gpuNodeCountGrid, nextGPUNodeCount):
+    if nextGPUNodeCount > len(gpuNodeCountGrid)-1:
+        return
+    job_is_running = subprocess.check_output(
+        ['squeue', '-u', 'alexeys'])  # ['qstat','-u','alexeys'])
     if 'alexeys' in job_is_running:
-        #sleep 500 seconds
+        # sleep 500 seconds
         sleep(500)
-        checkAndSchedule(configBaseName,gpuNodeCountGrid,nextGPUNodeCount)
+        checkAndSchedule(configBaseName, gpuNodeCountGrid, nextGPUNodeCount)
     else:
-        #create a config
-        nextConfigName = createOneConfig(configBaseName,gpuNodeCountGrid[nextGPUNodeCount])
-        print "Submitting next PBS job {} to run on {} GPUs".format(configBaseName,gpuNodeCountGrid[nextGPUNodeCount])
-        print "sbatch "+nextConfigName
-        Popen("sbatch "+nextConfigName,shell=True).wait() 
-        #update parameters
+        # create a config
+        nextConfigName = createOneConfig(
+            configBaseName, gpuNodeCountGrid[nextGPUNodeCount])
+        print("Submitting next PBS job {} to run on {} GPUs".format(
+            configBaseName, gpuNodeCountGrid[nextGPUNodeCount]))
+        print("sbatch ", nextConfigName)
+        Popen("sbatch " + nextConfigName, shell=True).wait()
+        # update parameters
         nextGPUNodeCount += 1
         sleep(10)
-        checkAndSchedule(configBaseName,gpuNodeCountGrid,nextGPUNodeCount)
+        checkAndSchedule(configBaseName, gpuNodeCountGrid, nextGPUNodeCount)
 
 
 def createOneConfig(configBaseName, GPUcount):
-    configFullName = configBaseName+str(GPUcount)+".cmd"
-    with open(configFullName,"w") as f:
-	f.write('#!/bin/bash\n')
+    configFullName = configBaseName + str(GPUcount) + ".cmd"
+    with open(configFullName, "w") as f:
+        f.write('#!/bin/bash\n')
         f.write('#SBATCH -t 01:00:00\n')
         f.write('#SBATCH -N '+str(GPUcount)+'\n')
         f.write('#SBATCH --ntasks-per-node=4\n')
@@ -35,14 +40,15 @@ def createOneConfig(configBaseName, GPUcount):
         f.write('\n\n')
         f.write('module load anaconda\n')
         f.write('source activate PPPL\n')
-        f.write('module load cudatoolkit/8.0 cudann/cuda-8.0/5.1 openmpi/intel-17.0/1.10.2/64 intel/17.0/64/17.0.2.174\n')
-
+        f.write(('module load cudatoolkit/8.0 cudann/cuda-8.0/5.1 '
+                 'openmpi/intel-17.0/1.10.2/64 intel/17.0/64/17.0.2.174\n'))
         f.write('rm /tigress/alexeys/model_checkpoints/*\n')
-        f.write('srun python mpi_learn.py\n')	
+        f.write('srun python mpi_learn.py\n')
 
     return configFullName
 
-if __name__=='__main__':
-    gpuNodeCountGrid = [1,3,6,12,24,32,48]
+
+if __name__ == '__main__':
+    gpuNodeCountGrid = [1, 3, 6, 12, 24, 32, 48]
     configBaseName = "FRNN_TigerGPU"
-    checkAndSchedule(configBaseName,gpuNodeCountGrid,0)
+    checkAndSchedule(configBaseName, gpuNodeCountGrid, 0)

--- a/examples/signal_influence.py
+++ b/examples/signal_influence.py
@@ -1,3 +1,13 @@
+from plasma.models.mpi_runner import (
+    mpi_make_predictions
+    )
+from mpi4py import MPI
+from plasma.preprocessor.preprocess import guarantee_preprocessed
+from plasma.preprocessor.augment import ByShotAugmentator
+from plasma.primitives.shots import ShotList
+from plasma.models.loader import Loader
+from plasma.conf import conf
+from pprint import pprint
 '''
 #########################################################
 This file trains a deep learning model to predict
@@ -16,10 +26,8 @@ This work was supported by the DOE CSGF program.
 #########################################################
 '''
 
-from __future__ import print_function
 import os
-import sys 
-import time
+import sys
 import datetime
 import random
 import numpy as np
@@ -29,39 +37,36 @@ from functools import partial
 import matplotlib
 matplotlib.use('Agg')
 
-from pprint import pprint
 sys.setrecursionlimit(10000)
 
-from plasma.conf import conf
-from plasma.models.loader import Loader
-from plasma.primitives.shots import ShotList
-from plasma.preprocessor.normalize import Normalizer
-from plasma.preprocessor.augment import ByShotAugmentator
-from plasma.preprocessor.preprocess import guarantee_preprocessed
 
 if conf['model']['shallow']:
-    print("Shallow learning using MPI is not supported yet. set conf['model']['shallow'] to false.")
+    print(
+        "Shallow learning using MPI is not supported yet. ",
+        "Set conf['model']['shallow'] to False.")
     exit(1)
 if conf['data']['normalizer'] == 'minmax':
     from plasma.preprocessor.normalize import MinMaxNormalizer as Normalizer
 elif conf['data']['normalizer'] == 'meanvar':
     from plasma.preprocessor.normalize import MeanVarNormalizer as Normalizer
 elif conf['data']['normalizer'] == 'var':
-    from plasma.preprocessor.normalize import VarNormalizer as Normalizer #performs !much better than minmaxnormalizer
+    # performs !much better than minmaxnormalizer
+    from plasma.preprocessor.normalize import VarNormalizer as Normalizer
 elif conf['data']['normalizer'] == 'averagevar':
-    from plasma.preprocessor.normalize import AveragingVarNormalizer as Normalizer #performs !much better than minmaxnormalizer
+    # performs !much better than minmaxnormalizer
+    from plasma.preprocessor.normalize import (
+        AveragingVarNormalizer as Normalizer
+    )
 else:
     print('unkown normalizer. exiting')
     exit(1)
 
-from mpi4py import MPI
 comm = MPI.COMM_WORLD
 task_index = comm.Get_rank()
 num_workers = comm.Get_size()
 NUM_GPUS = conf['num_gpus']
 MY_GPU = task_index % NUM_GPUS
 
-from plasma.models.mpi_runner import *
 
 np.random.seed(task_index)
 random.seed(task_index)
@@ -73,102 +78,132 @@ custom_path = None
 if only_predict:
     custom_path = sys.argv[1]
 shot_num = int(sys.argv[2])
-print("predicting using path {} on shot {}".format(custom_path,shot_num))
+print("predicting using path {} on shot {}".format(custom_path, shot_num))
 
 assert(only_predict)
-#####################################################
-####################Normalization####################
-#####################################################
-if task_index == 0: #make sure preprocessing has been run, and is saved as a file
-    shot_list_train,shot_list_validate,shot_list_test = guarantee_preprocessed(conf)
-comm.Barrier()
-shot_list_train,shot_list_validate,shot_list_test = guarantee_preprocessed(conf)
 
-shot_list = sum([l.filter_by_number([shot_num]) for l in [shot_list_train,shot_list_validate,shot_list_test]],ShotList())
+#####################################################
+#                 NORMALIZATION                     #
+#####################################################
+# TODO(KGF): identical in at least 3x files in examples/
+# make sure preprocessing has been run, and is saved as a file
+if task_index == 0:
+    # TODO(KGF): check tuple unpack
+    (shot_list_train, shot_list_validate,
+     shot_list_test) = guarantee_preprocessed(conf)
+comm.Barrier()
+(shot_list_train, shot_list_validate,
+ shot_list_test) = guarantee_preprocessed(conf)
+
+shot_list = sum([l.filter_by_number([shot_num])
+                 for l in [shot_list_train, shot_list_validate,
+                           shot_list_test]], ShotList())
 assert(len(shot_list) == 1)
 # for s in shot_list.shots:
-    # s.restore()
+# s.restore()
+
 
 def chunks(l, n):
     """Yield successive n-sized chunks from l."""
-    return[ l[i:i + n] for i in range(0, len(l), n)]
+    return[l[i:i + n] for i in range(0, len(l), n)]
 
-def hide_signal_data(shot,t=0,sigs_to_hide=None):
+
+def hide_signal_data(shot, t=0, sigs_to_hide=None):
     for sig in shot.signals:
-        if sigs_to_hide is None or (sigs_to_hide is not None and sig in sigs_to_hide):
-            shot.signals_dict[sig][t:,:] = shot.signals_dict[sig][t,:]
+        if sigs_to_hide is None or (
+                sigs_to_hide is not None and sig in sigs_to_hide):
+            shot.signals_dict[sig][t:, :] = shot.signals_dict[sig][t, :]
 
-def create_shot_list_tmp(original_shot,time_points,sigs=None):
+
+def create_shot_list_tmp(original_shot, time_points, sigs=None):
     shot_list_tmp = ShotList()
     T = len(original_shot.ttd)
-    t_range = np.linspace(0,T-1,time_points,dtype=np.int)
+    t_range = np.linspace(0, T-1, time_points, dtype=np.int)
     for t in t_range:
         new_shot = copy.copy(original_shot)
-        assert(new_shot.augmentation_fn == None)
-        new_shot.augmentation_fn = partial(hide_signal_data,t = t,sigs_to_hide=sigs)
-        #new_shot.number = original_shot.number
+        assert(new_shot.augmentation_fn is None)
+        new_shot.augmentation_fn = partial(
+            hide_signal_data, t=t, sigs_to_hide=sigs)
+        # new_shot.number = original_shot.number
         shot_list_tmp.append(new_shot)
-    return shot_list_tmp,t_range
+    return shot_list_tmp, t_range
 
-def get_importance_measure(original_shot,loader,custom_path,metric,time_points=10,sig=None):
-    shot_list_tmp,t_range = create_shot_list_tmp(original_shot,time_points,sigs) 
-    y_prime,y_gold,disruptive = mpi_make_predictions(conf,shot_list_tmp,loader,custom_path)
+
+def get_importance_measure(
+        original_shot,
+        loader,
+        custom_path,
+        metric,
+        time_points=10,
+        sig=None):
+    shot_list_tmp, t_range = create_shot_list_tmp(
+        original_shot, time_points, sigs)
+    y_prime, y_gold, disruptive = mpi_make_predictions(
+        conf, shot_list_tmp, loader, custom_path)
     shot_list_tmp.make_light()
-    return t_range,get_importance_measure_given_y_prime(y_prime,metric),y_prime[-1]
-
-def difference_metric(y_prime,y_prime_orig):
-    idx = np.argmax(y_prime_orig) 
-    return (np.max(y_prime_orig) - y_prime[idx])/(np.max(y_prime_orig) - np.min(y_prime_orig))
-
-def get_importance_measure_given_y_prime(y_prime,metric):
-    differences = [metric(y_prime[i],y_prime[-1]) for i in range(len(y_prime))]
-    return 1.0-np.array(differences)#/np.max(differences)
+    return t_range, get_importance_measure_given_y_prime(
+        y_prime, metric), y_prime[-1]
 
 
+def difference_metric(y_prime, y_prime_orig):
+    idx = np.argmax(y_prime_orig)
+    return (np.max(y_prime_orig) - y_prime[idx]) / \
+        (np.max(y_prime_orig) - np.min(y_prime_orig))
+
+
+def get_importance_measure_given_y_prime(y_prime, metric):
+    differences = [metric(y_prime[i], y_prime[-1])
+                   for i in range(len(y_prime))]
+    return 1.0-np.array(differences)  # /np.max(differences)
 
 
 original_shot = shot_list[0]
 original_shot.augmentation_fn = None
 original_shot.restore(conf['paths']['processed_prepath'])
 
-#remove original shot
+# remove original shot
 
 
-print("normalization",end='')
+print("normalization", end='')
 normalizer = Normalizer(conf)
 normalizer.train()
 normalizer = ByShotAugmentator(normalizer)
-loader = Loader(conf,normalizer)
+loader = Loader(conf, normalizer)
 print("...done")
 
 # if not only_predict:
 #     mpi_train(conf,shot_list_train,shot_list_validate,loader)
 
-#load last model for testing
+# load last model for testing
 loader.set_inference_mode(True)
 use_signals = copy.copy(conf['paths']['use_signals'])
 use_signals.append(None)
 importances = dict()
 y_prime = 0
-use_signals = [[s] for s in use_signals[:-3]] + [use_signals[-3:-1]] + [use_signals[-1]]
+use_signals = [
+    [s] for s in use_signals[:-3]] + [use_signals[-3:-1]] + [use_signals[-1]]
 print(use_signals)
 for sigs in use_signals:
-    t_range,measure,y_prime = get_importance_measure(original_shot,loader,custom_path,difference_metric,time_points=128,sig=sigs)
+    t_range, measure, y_prime = get_importance_measure(original_shot, loader,
+                                                       custom_path,
+                                                       difference_metric,
+                                                       time_points=128,
+                                                       sig=sigs)
     if sigs is None:
         idx = None
     else:
         idx = tuple(sorted(sigs))
-    importances[idx] = (t_range,measure) 
-    
+    importances[idx] = (t_range, measure)
 
 
 if task_index == 0:
-    save_str = 'signal_influence_results_{}_'.format(shot_num) + datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+    save_str = 'signal_influence_results_{}_'.format(
+        shot_num) + datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
     result_base_path = conf['paths']['results_prepath']
     if not os.path.exists(result_base_path):
         os.makedirs(result_base_path)
-    np.savez(result_base_path+save_str,
-        original_shot=original_shot,importances=importances,y_prime=y_prime,conf = conf)
+    np.savez(result_base_path + save_str, original_shot=original_shot,
+             importances=importances, y_prime=y_prime, conf=conf)
     shot_list.make_light()
 
 sys.stdout.flush()

--- a/examples/simple_augmentation.py
+++ b/examples/simple_augmentation.py
@@ -1,6 +1,6 @@
 from plasma.models.mpi_runner import (
-    mpi_make_predictions_and_evaluate
-    )
+    mpi_make_predictions, mpi_make_predictions_and_evaluate
+)
 from mpi4py import MPI
 from plasma.preprocessor.preprocess import guarantee_preprocessed
 from plasma.preprocessor.augment import ByShotAugmentator
@@ -115,7 +115,7 @@ def create_shot_list_tmp(original_shot, time_points, sigs=None):
         assert(new_shot.augmentation_fn is None)
         new_shot.augmentation_fn = partial(
             hide_signal_data, t=t, sigs_to_hide=sigs)
-        #new_shot.number = original_shot.number
+        # new_shot.number = original_shot.number
         shot_list_tmp.append(new_shot)
     return shot_list_tmp, t_range
 
@@ -126,7 +126,7 @@ def get_importance_measure(
         custom_path,
         metric,
         time_points=10,
-        sig=None):
+        sigs=None):
     shot_list_tmp, t_range = create_shot_list_tmp(
         original_shot, time_points, sigs)
     y_prime, y_gold, disruptive = mpi_make_predictions(
@@ -138,8 +138,8 @@ def get_importance_measure(
 
 def difference_metric(y_prime, y_prime_orig):
     idx = np.argmax(y_prime_orig)
-    return (np.max(y_prime_orig) - y_prime[idx]) / \
-        (np.max(y_prime_orig) - np.min(y_prime_orig))
+    return ((np.max(y_prime_orig) - y_prime[idx])
+            / (np.max(y_prime_orig) - np.min(y_prime_orig)))
 
 
 def get_importance_measure_given_y_prime(y_prime, metric):
@@ -176,8 +176,9 @@ print(loss)
 
 # for sigs_to_hide in [[s] for s in use_signals[:-3]] +
 # [use_signals[-3:-1]] + [use_signals[-1]]:
-for sigs_to_hide in [[s] for s in use_signals[:-3]] + [[s]
-                                                       for s in use_signals[-3:-1]] + [use_signals[-3:-1]]:  # + [use_signals[-1]]:
+for sigs_to_hide in ([[s] for s in use_signals[:-3]]
+                     + [[s] for s in use_signals[-3:-1]]
+                     + [use_signals[-3:-1]]):
     for shot in shot_list_test:
         shot.augmentation_fn = partial(
             hide_signal_data, t=0, sigs_to_hide=sigs_to_hide)

--- a/examples/simple_augmentation.py
+++ b/examples/simple_augmentation.py
@@ -1,3 +1,13 @@
+from plasma.models.mpi_runner import (
+    mpi_make_predictions_and_evaluate
+    )
+from mpi4py import MPI
+from plasma.preprocessor.preprocess import guarantee_preprocessed
+from plasma.preprocessor.augment import ByShotAugmentator
+from plasma.primitives.shots import ShotList
+from plasma.models.loader import Loader
+from plasma.conf import conf
+from pprint import pprint
 '''
 #########################################################
 This file trains a deep learning model to predict
@@ -16,11 +26,7 @@ This work was supported by the DOE CSGF program.
 #########################################################
 '''
 
-from __future__ import print_function
-import os
-import sys 
-import time
-import datetime
+import sys
 import random
 import numpy as np
 import copy
@@ -29,39 +35,36 @@ from functools import partial
 import matplotlib
 matplotlib.use('Agg')
 
-from pprint import pprint
 sys.setrecursionlimit(10000)
 
-from plasma.conf import conf
-from plasma.models.loader import Loader
-from plasma.primitives.shots import ShotList
-from plasma.preprocessor.normalize import Normalizer
-from plasma.preprocessor.augment import ByShotAugmentator
-from plasma.preprocessor.preprocess import guarantee_preprocessed
 
 if conf['model']['shallow']:
-    print("Shallow learning using MPI is not supported yet. set conf['model']['shallow'] to false.")
+    print(
+        "Shallow learning using MPI is not supported yet. ",
+        "Set conf['model']['shallow'] to False.")
     exit(1)
 if conf['data']['normalizer'] == 'minmax':
     from plasma.preprocessor.normalize import MinMaxNormalizer as Normalizer
 elif conf['data']['normalizer'] == 'meanvar':
     from plasma.preprocessor.normalize import MeanVarNormalizer as Normalizer
 elif conf['data']['normalizer'] == 'var':
-    from plasma.preprocessor.normalize import VarNormalizer as Normalizer #performs !much better than minmaxnormalizer
+    # performs !much better than minmaxnormalizer
+    from plasma.preprocessor.normalize import VarNormalizer as Normalizer
 elif conf['data']['normalizer'] == 'averagevar':
-    from plasma.preprocessor.normalize import AveragingVarNormalizer as Normalizer #performs !much better than minmaxnormalizer
+    # performs !much better than minmaxnormalizer
+    from plasma.preprocessor.normalize import (
+        AveragingVarNormalizer as Normalizer
+    )
 else:
     print('unkown normalizer. exiting')
     exit(1)
 
-from mpi4py import MPI
 comm = MPI.COMM_WORLD
 task_index = comm.Get_rank()
 num_workers = comm.Get_size()
 NUM_GPUS = conf['num_gpus']
 MY_GPU = task_index % NUM_GPUS
 
-from plasma.models.mpi_runner import *
 
 np.random.seed(task_index)
 random.seed(task_index)
@@ -75,85 +78,114 @@ if only_predict:
 print("predicting using path {}".format(custom_path))
 
 assert(only_predict)
+
+
 #####################################################
-####################Normalization####################
+#                 NORMALIZATION                     #
 #####################################################
-if task_index == 0: #make sure preprocessing has been run, and is saved as a file
-    shot_list_train,shot_list_validate,shot_list_test = guarantee_preprocessed(conf)
+# TODO(KGF): identical in at least 3x files in examples/
+# make sure preprocessing has been run, and is saved as a file
+if task_index == 0:
+    # TODO(KGF): check tuple unpack
+    (shot_list_train, shot_list_validate,
+     shot_list_test) = guarantee_preprocessed(conf)
 comm.Barrier()
-shot_list_train,shot_list_validate,shot_list_test = guarantee_preprocessed(conf)
+(shot_list_train, shot_list_validate,
+ shot_list_test) = guarantee_preprocessed(conf)
 
 
 def chunks(l, n):
     """Yield successive n-sized chunks from l."""
-    return[ l[i:i + n] for i in range(0, len(l), n)]
+    return[l[i:i + n] for i in range(0, len(l), n)]
 
-def hide_signal_data(shot,t=0,sigs_to_hide=None):
+
+def hide_signal_data(shot, t=0, sigs_to_hide=None):
     for sig in shot.signals:
-        if sigs_to_hide is None or (sigs_to_hide is not None and sig in sigs_to_hide):
-            shot.signals_dict[sig][t:,:] = shot.signals_dict[sig][t,:]
+        if sigs_to_hide is None or (
+                sigs_to_hide is not None and sig in sigs_to_hide):
+            shot.signals_dict[sig][t:, :] = shot.signals_dict[sig][t, :]
 
-def create_shot_list_tmp(original_shot,time_points,sigs=None):
+
+def create_shot_list_tmp(original_shot, time_points, sigs=None):
     shot_list_tmp = ShotList()
     T = len(original_shot.ttd)
-    t_range = np.linspace(0,T-1,time_points,dtype=np.int)
+    t_range = np.linspace(0, T-1, time_points, dtype=np.int)
     for t in t_range:
         new_shot = copy.copy(original_shot)
-        assert(new_shot.augmentation_fn == None)
-        new_shot.augmentation_fn = partial(hide_signal_data,t = t,sigs_to_hide=sigs)
+        assert(new_shot.augmentation_fn is None)
+        new_shot.augmentation_fn = partial(
+            hide_signal_data, t=t, sigs_to_hide=sigs)
         #new_shot.number = original_shot.number
         shot_list_tmp.append(new_shot)
-    return shot_list_tmp,t_range
+    return shot_list_tmp, t_range
 
-def get_importance_measure(original_shot,loader,custom_path,metric,time_points=10,sig=None):
-    shot_list_tmp,t_range = create_shot_list_tmp(original_shot,time_points,sigs) 
-    y_prime,y_gold,disruptive = mpi_make_predictions(conf,shot_list_tmp,loader,custom_path)
+
+def get_importance_measure(
+        original_shot,
+        loader,
+        custom_path,
+        metric,
+        time_points=10,
+        sig=None):
+    shot_list_tmp, t_range = create_shot_list_tmp(
+        original_shot, time_points, sigs)
+    y_prime, y_gold, disruptive = mpi_make_predictions(
+        conf, shot_list_tmp, loader, custom_path)
     shot_list_tmp.make_light()
-    return t_range,get_importance_measure_given_y_prime(y_prime,metric),y_prime[-1]
-
-def difference_metric(y_prime,y_prime_orig):
-    idx = np.argmax(y_prime_orig) 
-    return (np.max(y_prime_orig) - y_prime[idx])/(np.max(y_prime_orig) - np.min(y_prime_orig))
-
-def get_importance_measure_given_y_prime(y_prime,metric):
-    differences = [metric(y_prime[i],y_prime[-1]) for i in range(len(y_prime))]
-    return 1.0-np.array(differences)#/np.max(differences)
+    return t_range, get_importance_measure_given_y_prime(
+        y_prime, metric), y_prime[-1]
 
 
-print("normalization",end='')
+def difference_metric(y_prime, y_prime_orig):
+    idx = np.argmax(y_prime_orig)
+    return (np.max(y_prime_orig) - y_prime[idx]) / \
+        (np.max(y_prime_orig) - np.min(y_prime_orig))
+
+
+def get_importance_measure_given_y_prime(y_prime, metric):
+    differences = [metric(y_prime[i], y_prime[-1])
+                   for i in range(len(y_prime))]
+    return 1.0-np.array(differences)  # /np.max(differences)
+
+
+print("normalization", end='')
 normalizer = Normalizer(conf)
 normalizer.train()
 normalizer = ByShotAugmentator(normalizer)
-loader = Loader(conf,normalizer)
+loader = Loader(conf, normalizer)
 print("...done")
 
 # if not only_predict:
 #     mpi_train(conf,shot_list_train,shot_list_validate,loader)
 
-#load last model for testing
+# load last model for testing
 loader.set_inference_mode(True)
 use_signals = copy.copy(conf['paths']['use_signals'])
 use_signals.append(None)
 
 
-
 for shot in shot_list_test:
-    shot.augmentation_fn = None# partial(hide_signal_data,t = 0,sigs_to_hide = sigs_to_hide)
+    # partial(hide_signal_data,t = 0,sigs_to_hide = sigs_to_hide)
+    shot.augmentation_fn = None
 
 print("All signals:")
-y_prime,y_gold,disruptive,roc,loss = mpi_make_predictions_and_evaluate(conf,shot_list_test,loader,custom_path)
+y_prime, y_gold, disruptive, roc, loss = mpi_make_predictions_and_evaluate(
+    conf, shot_list_test, loader, custom_path)
 print(roc)
 print(loss)
 
-#for sigs_to_hide in [[s] for s in use_signals[:-3]] + [use_signals[-3:-1]] + [use_signals[-1]]:
-for sigs_to_hide in [[s] for s in use_signals[:-3]] + [[s] for s in use_signals[-3:-1]] + [use_signals[-3:-1]]:# + [use_signals[-1]]:
+# for sigs_to_hide in [[s] for s in use_signals[:-3]] +
+# [use_signals[-3:-1]] + [use_signals[-1]]:
+for sigs_to_hide in [[s] for s in use_signals[:-3]] + [[s]
+                                                       for s in use_signals[-3:-1]] + [use_signals[-3:-1]]:  # + [use_signals[-1]]:
     for shot in shot_list_test:
-        shot.augmentation_fn = partial(hide_signal_data,t = 0,sigs_to_hide = sigs_to_hide)
+        shot.augmentation_fn = partial(
+            hide_signal_data, t=0, sigs_to_hide=sigs_to_hide)
     print("Hiding: {}".format(sigs_to_hide))
-    y_prime,y_gold,disruptive,roc,loss = mpi_make_predictions_and_evaluate(conf,shot_list_test,loader,custom_path)
+    y_prime, y_gold, disruptive, roc, loss = mpi_make_predictions_and_evaluate(
+        conf, shot_list_test, loader, custom_path)
     print(roc)
     print(loss)
-
 
 
 if task_index == 0:

--- a/examples/submit_batch_job.py
+++ b/examples/submit_batch_job.py
@@ -1,7 +1,10 @@
-from plasma.utils.batch_jobs import get_executable_name,generate_working_dirname,start_slurm_job,copy_files_to_environment
-from pprint import pprint
+from plasma.utils.batch_jobs import (
+    get_executable_name, generate_working_dirname,
+    start_slurm_job, copy_files_to_environment
+    )
 import yaml
-import sys,os,getpass
+import os
+import getpass
 import plasma.conf
 
 # tunables = []
@@ -10,49 +13,62 @@ num_nodes = 2
 num_trials = 1
 
 
-run_directory = "{}/{}/batch_jobs/".format(plasma.conf.conf['fs_path'],getpass.getuser())
-template_path = os.environ['PWD'] #"/home/{}/plasma-python/examples/".format(getpass.getuser())
+run_directory = "{}/{}/batch_jobs/".format(
+    plasma.conf.conf['fs_path'], getpass.getuser())
+# "/home/{}/plasma-python/examples/".format(getpass.getuser())
+template_path = os.environ['PWD']
 conf_name = "conf.yaml"
 
-def copy_conf_file(shallow,template_path = "../",save_path = "./",conf_name="conf.yaml"):
+
+def copy_conf_file(
+        shallow,
+        template_path="../",
+        save_path="./",
+        conf_name="conf.yaml"):
     assert(template_path != save_path)
 
-    pathsrc = os.path.join(template_path,conf_name)
-    pathdst = os.path.join(save_path,conf_name)
+    pathsrc = os.path.join(template_path, conf_name)
+    pathdst = os.path.join(save_path, conf_name)
 
     with open(pathsrc, 'r') as yaml_file:
         conf = yaml.load(yaml_file)
-    conf['training']['hyperparam_tuning'] = True #make sure all files like checkpoints and normalization are done locally
+    # make sure all files like checkpoints and normalization are done locally
+    conf['training']['hyperparam_tuning'] = True
     with open(pathdst, 'w') as outfile:
         yaml.dump(conf, outfile, default_flow_style=False)
 
-def get_conf(template_path,conf_name):
-    with open(os.path.join(template_path,conf_name), 'r') as yaml_file:
+
+def get_conf(template_path, conf_name):
+    with open(os.path.join(template_path, conf_name), 'r') as yaml_file:
         conf = yaml.load(yaml_file)
     return conf
 
-conf = get_conf(template_path,conf_name)
+
+conf = get_conf(template_path, conf_name)
 shallow = conf['model']['shallow']
 if shallow:
     num_nodes = 1
 working_directory = generate_working_dirname(run_directory)
 os.makedirs(working_directory)
 
-#copy conf and executable into directory
-executable_name,_ = get_executable_name(conf)
-os.system(" ".join(["cp -p",os.path.join(template_path,conf_name),working_directory]))
-os.system(" ".join(["cp -p",os.path.join(template_path,executable_name),working_directory]))
+# copy conf and executable into directory
+executable_name, _ = get_executable_name(conf)
+os.system(" ".join(["cp -p", os.path.join(template_path, conf_name),
+                    working_directory]))
+os.system(" ".join(["cp -p", os.path.join(template_path, executable_name),
+                    working_directory]))
 
 os.chdir(working_directory)
 print("Going into {}".format(working_directory))
 
 for i in range(num_trials):
-    subdir = working_directory + "/{}/".format(i) 
+    subdir = working_directory + "/{}/".format(i)
     os.makedirs(subdir)
     copy_files_to_environment(subdir)
     print("Making modified conf")
-    copy_conf_file(shallow,working_directory,subdir,conf_name)
+    copy_conf_file(shallow, working_directory, subdir, conf_name)
     print("Starting job")
-    start_slurm_job(subdir,num_nodes,i,conf,shallow,conf['env']['name'],conf['env']['type'])
+    start_slurm_job(subdir, num_nodes, i, conf,
+                    shallow, conf['env']['name'], conf['env']['type'])
 
 print("submitted {} jobs.".format(num_trials))

--- a/examples/test.py
+++ b/examples/test.py
@@ -1,65 +1,64 @@
-import keras
-from keras.models import Sequential, Model
+# import keras
+from keras.models import Model  # , Sequential
 from keras.layers import Input
-from keras.layers.core import Dense, Activation, Dropout, Lambda, Reshape, Flatten, Permute
-from keras.layers.recurrent import LSTM, SimpleRNN
-from keras.layers.convolutional import Convolution1D
-from keras.layers.pooling import MaxPooling1D
-from keras.utils.data_utils import get_file
-from keras.layers.wrappers import TimeDistributed
-from keras.layers.merge import Concatenate
-from keras.callbacks import Callback
-from keras.optimizers import *
-from keras.regularizers import l1,l2,l1_l2
+from keras.layers.core import Lambda, Reshape, Permute
+# Dense, Activation, Dropout, Flatten
+# from keras.layers.recurrent import LSTM, SimpleRNN
+# from keras.layers.convolutional import Convolution1D
+# from keras.layers.pooling import MaxPooling1D
+# from keras.utils.data_utils import get_file
+# from keras.layers.wrappers import TimeDistributed
+# from keras.layers.merge import Concatenate
+# from keras.callbacks import Callback
+# from keras.optimizers import *
+# from keras.regularizers import l1, l2, l1_l2
 
-
-import keras.backend as K
-
-import dill
-import re
-import os,sys
 import numpy as np
-from copy import deepcopy
 
 x = np.array(range(8))
 num_signals = len(x)
 x = np.atleast_2d(x)
-x = np.reshape(x,(1,num_signals))
+x = np.reshape(x, (1, num_signals))
 print(x.shape)
 print(x)
 
-indices_0d = np.array([0,1])
-indices_1d = np.array([2,3,4,5,6,7])
+indices_0d = np.array([0, 1])
+indices_1d = np.array([2, 3, 4, 5, 6, 7])
 
 num_1D = 2
 
 pre_rnn_input = Input(shape=(num_signals,))
-pre_rnn_1D = Lambda(lambda x: x[:,len(indices_0d):],output_shape=(len(indices_1d),))(pre_rnn_input)
-pre_rnn_0D = Lambda(lambda x: x[:,:len(indices_0d)],output_shape=(len(indices_0d),))(pre_rnn_input)# slicer(x,indices_0d),lambda s: slicer_output_shape(s,indices_0d))(pre_rnn_input)
-pre_rnn_1D = Reshape((num_1D,len(indices_1d)/num_1D)) (pre_rnn_1D)
-pre_rnn_1D = Permute((2,1)) (pre_rnn_1D)
-    
+pre_rnn_1D = Lambda(lambda x: x[:, len(indices_0d):], output_shape=(
+    len(indices_1d),))(pre_rnn_input)
+pre_rnn_0D = Lambda(lambda x: x[:, :len(indices_0d)],
+                    output_shape=(len(indices_0d),))(pre_rnn_input)
+# slicer(x, indices_0d),
+# lambda s: slicer_output_shape(s, indices_0d))(pre_rnn_input)
+pre_rnn_1D = Reshape((num_1D, len(indices_1d)/num_1D))(pre_rnn_1D)
+pre_rnn_1D = Permute((2, 1))(pre_rnn_1D)
+
 # for i in range(model_conf['num_conv_layers']):
-#     pre_rnn_1D = Convolution1D(num_conv_filters,size_conv_filters,padding='valid',activation='relu') (pre_rnn_1D)
+#     pre_rnn_1D = Convolution1D(num_conv_filters, size_conv_filters,
+#                      padding='valid',activation='relu') (pre_rnn_1D)
 #     pre_rnn_1D = MaxPooling1D(pool_size) (pre_rnn_1D)
 # pre_rnn_1D = Flatten() (pre_rnn_1D)
 # pre_rnn = Concatenate() ([pre_rnn_0D,pre_rnn_1D])
 
-model = Model(inputs = pre_rnn_input,outputs=pre_rnn_1D)
+model = Model(inputs=pre_rnn_input, outputs=pre_rnn_1D)
 # x_input = Input(batch_shape = batch_input_shape)
 # x_in = TimeDistributed(pre_rnn_model) (x_input)
 
 # if return_sequences:
-    #x_out = TimeDistributed(Dense(100,activation='tanh')) (x_in)
-    # x_out = TimeDistributed(Dense(1,activation=output_activation)) (x_in)
+# x_out = TimeDistributed(Dense(100, activation='tanh')) (x_in)
+# x_out = TimeDistributed(Dense(1, activation=output_activation)) (x_in)
 # else:
-    # x_out = Dense(1,activation=output_activation) (x_in)
-model.compile(loss='mse',optimizer='sgd')
+# x_out = Dense(1, activation=output_activation) (x_in)
+model.compile(loss='mse', optimizer='sgd')
 
 y = model.predict(x)
 print(model.layers)
 print(x)
 print(y)
 print(y.shape)
-print(y[0,:,0])
-#bug with tensorflow/Keras
+print(y[0, :, 0])
+# bug with tensorflow/Keras --- ?????

--- a/examples/tune_hyperparams.py
+++ b/examples/tune_hyperparams.py
@@ -1,8 +1,14 @@
-from plasma.primitives.hyperparameters import CategoricalHyperparam,ContinuousHyperparam,LogContinuousHyperparam,IntegerHyperparam
-from plasma.utils.batch_jobs import create_slurm_script,create_slurm_header,start_slurm_job,generate_working_dirname,copy_files_to_environment
-from pprint import pprint
+from plasma.primitives.hyperparameters import (
+    CategoricalHyperparam, ContinuousHyperparam,
+    LogContinuousHyperparam, IntegerHyperparam
+    )
+from plasma.utils.batch_jobs import (
+    # create_slurm_script, create_slurm_header,
+    start_slurm_job, generate_working_dirname, copy_files_to_environment
+    )
 import yaml
-import sys,os,getpass
+import os
+import getpass
 import plasma.conf
 
 tunables = []
@@ -10,61 +16,107 @@ shallow = False
 num_nodes = 1
 num_trials = 20
 
-t_warn = CategoricalHyperparam(['data','T_warning'],[0.256,1.024,10.024])
-cut_ends = CategoricalHyperparam(['data','cut_shot_ends'],[False,True])
-#for shallow
+t_warn = CategoricalHyperparam(['data', 'T_warning'], [0.256, 1.024, 10.024])
+cut_ends = CategoricalHyperparam(['data', 'cut_shot_ends'], [False, True])
+# for shallow
 if shallow:
     num_nodes = 1
-    shallow_model = CategoricalHyperparam(['model','shallow_model','type'],["svm","random_forest","xgboost","mlp"])
-    n_estimators = CategoricalHyperparam(['model','shallow_model','n_estimators'],[5,20,50,100,300,1000])
-    max_depth = CategoricalHyperparam(['model','shallow_model','max_depth'],[None,3,6,10,30,100])
-    C = LogContinuousHyperparam(['model','shallow_model','C'],1e-3,1e3)
-    kernel = CategoricalHyperparam(['model','shallow_model','kernel'],["rbf","sigmoid","linear","poly"])
-    xg_learning_rate = ContinuousHyperparam(['model','shallow_model','learning_rate'],0,1)
-    scale_pos_weight = CategoricalHyperparam(['model','shallow_model','scale_pos_weight'],[1,10.0,100.0])
-    num_samples = CategoricalHyperparam(['model','shallow_model','num_samples'],[30000,100000,1000000,2000000])
-    hidden_size = CategoricalHyperparam(['model','shallow_model','final_hidden_layer_size'],[5,10,20])
-    hidden_num = CategoricalHyperparam(['model','shallow_model','num_hidden_layers'],[2,4])
-    mlp_learning_rate = CategoricalHyperparam(['model','shallow_model','learning_rate_mlp'],[0.001,0.0001,0.00001])
-    mlp_regularization = CategoricalHyperparam(['model','shallow_model','mlp_regularization'],[0.1,0.003,0.0001])
-    tunables = [shallow_model,n_estimators,max_depth,C,kernel,xg_learning_rate,scale_pos_weight,num_samples,hidden_num,hidden_size,mlp_learning_rate,mlp_regularization] #target
+    shallow_model = CategoricalHyperparam(
+        ['model', 'shallow_model', 'type'],
+        ["svm", "random_forest", "xgboost", "mlp"])
+    n_estimators = CategoricalHyperparam(
+        ['model', 'shallow_model', 'n_estimators'],
+        [5, 20, 50, 100, 300, 1000])
+    max_depth = CategoricalHyperparam(
+        ['model', 'shallow_model', 'max_depth'],
+        [None, 3, 6, 10, 30, 100])
+    C = LogContinuousHyperparam(['model', 'shallow_model', 'C'], 1e-3, 1e3)
+    kernel = CategoricalHyperparam(['model', 'shallow_model', 'kernel'], [
+                                   "rbf", "sigmoid", "linear", "poly"])
+    xg_learning_rate = ContinuousHyperparam(
+        ['model', 'shallow_model', 'learning_rate'], 0, 1)
+    scale_pos_weight = CategoricalHyperparam(
+        ['model', 'shallow_model', 'scale_pos_weight'], [1, 10.0, 100.0])
+    num_samples = CategoricalHyperparam(
+        ['model', 'shallow_model', 'num_samples'],
+        [30000, 100000, 1000000, 2000000])
+    hidden_size = CategoricalHyperparam(
+        ['model', 'shallow_model', 'final_hidden_layer_size'], [5, 10, 20])
+    hidden_num = CategoricalHyperparam(
+        ['model', 'shallow_model', 'num_hidden_layers'], [2, 4])
+    mlp_learning_rate = CategoricalHyperparam(
+        ['model', 'shallow_model', 'learning_rate_mlp'],
+        [0.001, 0.0001, 0.00001])
+    mlp_regularization = CategoricalHyperparam(
+        ['model', 'shallow_model', 'mlp_regularization'], [0.1, 0.003, 0.0001])
+    tunables = [
+        shallow_model,
+        n_estimators,
+        max_depth,
+        C,
+        kernel,
+        xg_learning_rate,
+        scale_pos_weight,
+        num_samples,
+        hidden_num,
+        hidden_size,
+        mlp_learning_rate,
+        mlp_regularization]  # target
 else:
-    #for DL
-    lr = LogContinuousHyperparam(['model','lr'],1e-7,1e-4)
-    lr_decay = CategoricalHyperparam(['model','lr_decay'],[0.97,0.985,1.0])
-    fac = CategoricalHyperparam(['data','positive_example_penalty'],[1.0,4.0,16.0])
-    target = CategoricalHyperparam(['target'],['maxhinge','hinge','ttdinv','ttd'])
-    #target = CategoricalHyperparam(['target'],['hinge','ttdinv','ttd'])
-    batch_size = CategoricalHyperparam(['training','batch_size'],[128,256])
-    dropout_prob = CategoricalHyperparam(['model','dropout_prob'],[0.01,0.05,0.1])
-    conv_filters = CategoricalHyperparam(['model','num_conv_filters'],[128,256])
-    conv_layers = IntegerHyperparam(['model','num_conv_layers'],2,4)
-    rnn_layers = IntegerHyperparam(['model','rnn_layers'],1,3)
-    rnn_size = CategoricalHyperparam(['model','rnn_size'],[128,256])
-    dense_size = CategoricalHyperparam(['model','dense_size'],[128,256])
-    extra_dense_input = CategoricalHyperparam(['model','extra_dense_input'],[False,True])
-    equalize_classes = CategoricalHyperparam(['data','equalize_classes'],[False,True])
-    #rnn_length = CategoricalHyperparam(['model','length'],[32,128])
-    #tunables = [lr,lr_decay,fac,target,batch_size,dropout_prob]
-    tunables = [lr,lr_decay,fac,target,batch_size,equalize_classes,dropout_prob]
-    tunables += [conv_filters,conv_layers,rnn_layers,rnn_size,dense_size,extra_dense_input]
-tunables += [cut_ends,t_warn]
+    # for DL
+    lr = LogContinuousHyperparam(['model', 'lr'], 1e-7, 1e-4)
+    lr_decay = CategoricalHyperparam(['model', 'lr_decay'], [0.97, 0.985, 1.0])
+    fac = CategoricalHyperparam(
+        ['data', 'positive_example_penalty'], [1.0, 4.0, 16.0])
+    target = CategoricalHyperparam(
+        ['target'], ['maxhinge', 'hinge', 'ttdinv', 'ttd'])
+    # target = CategoricalHyperparam(['target'],['hinge','ttdinv','ttd'])
+    batch_size = CategoricalHyperparam(['training', 'batch_size'], [128, 256])
+    dropout_prob = CategoricalHyperparam(
+        ['model', 'dropout_prob'], [0.01, 0.05, 0.1])
+    conv_filters = CategoricalHyperparam(
+        ['model', 'num_conv_filters'], [128, 256])
+    conv_layers = IntegerHyperparam(['model', 'num_conv_layers'], 2, 4)
+    rnn_layers = IntegerHyperparam(['model', 'rnn_layers'], 1, 3)
+    rnn_size = CategoricalHyperparam(['model', 'rnn_size'], [128, 256])
+    dense_size = CategoricalHyperparam(['model', 'dense_size'], [128, 256])
+    extra_dense_input = CategoricalHyperparam(
+        ['model', 'extra_dense_input'], [False, True])
+    equalize_classes = CategoricalHyperparam(
+        ['data', 'equalize_classes'], [False, True])
+    # rnn_length = CategoricalHyperparam(['model', 'length'], [32, 128])
+    # tunables = [lr, lr_decay, fac, target, batch_size, dropout_prob]
+    tunables = [lr, lr_decay, fac, target, batch_size, equalize_classes,
+                dropout_prob]
+    tunables += [conv_filters, conv_layers, rnn_layers,
+                 rnn_size, dense_size, extra_dense_input]
+tunables += [cut_ends, t_warn]
 
 
-run_directory = "{}/{}/hyperparams/".format(plasma.conf.conf['fs_path'],getpass.getuser())
-template_path = os.environ['PWD'] #"/home/{}/plasma-python/examples/".format(getpass.getuser())
+run_directory = "{}/{}/hyperparams/".format(
+    plasma.conf.conf['fs_path'], getpass.getuser())
+# "/home/{}/plasma-python/examples/".format(getpass.getuser())
+template_path = os.environ['PWD']
 conf_name = "conf.yaml"
 
-def generate_conf_file(tunables,shallow,template_path = "../",save_path = "./",conf_name="conf.yaml"):
+
+def generate_conf_file(
+        tunables,
+        shallow,
+        template_path="../",
+        save_path="./",
+        conf_name="conf.yaml"):
     assert(template_path != save_path)
-    with open(os.path.join(template_path,conf_name), 'r') as yaml_file:
+    with open(os.path.join(template_path, conf_name), 'r') as yaml_file:
         conf = yaml.load(yaml_file)
     for tunable in tunables:
-        tunable.assign_to_conf(conf,save_path)
-    conf['training']['num_epochs'] = 1000 #rely on early stopping to terminate training
-    conf['training']['hyperparam_tuning'] = True #rely on early stopping to terminate training
+        tunable.assign_to_conf(conf, save_path)
+    # rely on early stopping to terminate training
+    conf['training']['num_epochs'] = 1000
+    # rely on early stopping to terminate training
+    conf['training']['hyperparam_tuning'] = True
     conf['model']['shallow'] = shallow
-    with open(os.path.join(save_path,conf_name), 'w') as outfile:
+    with open(os.path.join(save_path, conf_name), 'w') as outfile:
         yaml.dump(conf, outfile, default_flow_style=False)
     return conf
 
@@ -77,27 +129,30 @@ def get_executable_name_imposed_shallow(shallow):
     else:
         executable_name = conf['paths']['executable']
         use_mpi = True
-    return executable_name,use_mpi
-
+    return executable_name, use_mpi
 
 
 working_directory = generate_working_dirname(run_directory)
 os.makedirs(working_directory)
 
-executable_name,_ = get_executable_name_imposed_shallow(shallow)
-os.system(" ".join(["cp -p",os.path.join(template_path,conf_name),working_directory]))
-os.system(" ".join(["cp -p",os.path.join(template_path,executable_name),working_directory]))
+executable_name, _ = get_executable_name_imposed_shallow(shallow)
+os.system(" ".join(["cp -p", os.path.join(template_path, conf_name),
+                    working_directory]))
+os.system(" ".join(["cp -p", os.path.join(template_path, executable_name),
+                    working_directory]))
 
 os.chdir(working_directory)
 print("Going into {}".format(working_directory))
 
 for i in range(num_trials):
-    subdir = working_directory + "/{}/".format(i) 
+    subdir = working_directory + "/{}/".format(i)
     os.makedirs(subdir)
     copy_files_to_environment(subdir)
     print("Making modified conf")
-    conf = generate_conf_file(tunables,shallow,working_directory,subdir,conf_name)
+    conf = generate_conf_file(tunables, shallow, working_directory,
+                              subdir, conf_name)
     print("Starting job")
-    start_slurm_job(subdir,num_nodes,i,conf,shallow,conf['env']['name'],conf['env']['type'])
+    start_slurm_job(subdir, num_nodes, i, conf, shallow,
+                    conf['env']['name'], conf['env']['type'])
 
 print("submitted {} jobs.".format(num_trials))

--- a/jenkins-ci/jenkins.sh
+++ b/jenkins-ci/jenkins.sh
@@ -31,21 +31,3 @@ sed -i -e 's/data: jet_data/data: jenkins_jet/g' conf.yaml
 srun python mpi_learn.py
 
 echo "Jenkins test Python2.7"
-#rm /tigress/alexeys/model_checkpoints/*
-
-#source deactivate
-#module purge
-#module load anaconda/4.4.0
-#source activate /tigress/alexeys/jenkins/.conda/envs/jenkins2
-#module load cudatoolkit/8.0
-#module load cudnn/cuda-8.0/6.0
-#module load openmpi/cuda-8.0/intel-17.0/2.1.0/64
-#module load intel/17.0/64/17.0.4.196
-
-#cd ..
-#python setup.py install
-
-#echo $SLURM_NODELIST
-#cd examples
-#sed -i -e 's/data: jenkins_jet/data: jenkins_d3d/g' conf.yaml
-#srun python mpi_learn.py

--- a/jenkins-ci/run_jenkins.py
+++ b/jenkins-ci/run_jenkins.py
@@ -1,19 +1,28 @@
-from plasma.utils.batch_jobs import generate_working_dirname,copy_files_to_environment,start_jenkins_job
+from plasma.utils.batch_jobs import (
+    generate_working_dirname, copy_files_to_environment, start_jenkins_job
+    )
 import yaml
-import sys,os,getpass
+import os
+import getpass
 import plasma.conf
 
-num_nodes = 4 #Set in the Jenkins project area!!
-test_matrix = [("Python3","jet_data"),("Python2","jet_data")]
+num_nodes = 4  # Set in the Jenkins project area!!
+test_matrix = [("Python3", "jet_data"), ("Python2", "jet_data")]
 
-run_directory = "{}/{}/jenkins/".format(plasma.conf.conf['fs_path'],getpass.getuser())
+run_directory = "{}/{}/jenkins/".format(
+    plasma.conf.conf['fs_path'], getpass.getuser())
 template_path = os.environ['PWD']
 conf_name = "conf.yaml"
 executable_name = "mpi_learn.py"
 
-def generate_conf_file(test_configuration,template_path = "../",save_path = "./",conf_name="conf.yaml"):
+
+def generate_conf_file(
+        test_configuration,
+        template_path="../",
+        save_path="./",
+        conf_name="conf.yaml"):
     assert(template_path != save_path)
-    with open(os.path.join(template_path,conf_name), 'r') as yaml_file:
+    with open(os.path.join(template_path, conf_name), 'r') as yaml_file:
         conf = yaml.load(yaml_file)
     conf['training']['num_epochs'] = 2
     conf['paths']['data'] = test_configuration[1]
@@ -24,25 +33,30 @@ def generate_conf_file(test_configuration,template_path = "../",save_path = "./"
         conf['env']['name'] = "PPPL"
         conf['env']['type'] = "anaconda"
 
-    with open(os.path.join(save_path,conf_name), 'w') as outfile:
+    with open(os.path.join(save_path, conf_name), 'w') as outfile:
         yaml.dump(conf, outfile, default_flow_style=False)
     return conf
+
 
 working_directory = generate_working_dirname(run_directory)
 os.makedirs(working_directory)
 
-os.system(" ".join(["cp -p",os.path.join(template_path,conf_name),working_directory]))
-os.system(" ".join(["cp -p",os.path.join(template_path,executable_name),working_directory]))
+os.system(
+    " ".join(["cp -p", os.path.join(template_path, conf_name),
+              working_directory]))
+os.system(" ".join(
+    ["cp -p", os.path.join(template_path, executable_name),
+     working_directory]))
 
-#os.chdir(working_directory)
-#print("Going into {}".format(working_directory))
+# os.chdir(working_directory)
+# print("Going into {}".format(working_directory))
 
 for ci in test_matrix:
-    subdir = working_directory + "/{}/".format(ci[0]) 
+    subdir = working_directory + "/{}/".format(ci[0])
     os.makedirs(subdir)
     copy_files_to_environment(subdir)
     print("Making modified conf")
-    conf = generate_conf_file(ci,working_directory,subdir,conf_name)
+    conf = generate_conf_file(ci, working_directory, subdir, conf_name)
     print("Starting job")
     if ci[1] == "Python3":
         env_name = "PPPL_dev3"
@@ -50,7 +64,12 @@ for ci in test_matrix:
     else:
         env_name = "PPPL"
         env_type = "anaconda"
-    start_jenkins_job(subdir,num_nodes,executable_name,ci,env_name,env_type)
-
+    start_jenkins_job(
+        subdir,
+        num_nodes,
+        executable_name,
+        ci,
+        env_name,
+        env_type)
 
 print("submitted jobs.")

--- a/jenkins-ci/validate_jenkins.py
+++ b/jenkins-ci/validate_jenkins.py
@@ -1,16 +1,14 @@
 #!/usr/bin/env python
 
-import mpi4py as mmm
-print(mmm.__version__)
-
-import keras as kk
-print(kk.__version__)
-
-import tensorflow as tf
-print(tf.__version__)
-
-from mpi4py import MPI
 import sys
+from mpi4py import MPI
+import tensorflow as tf
+import keras as kk
+import mpi4py as mmm
+
+print(mmm.__version__)
+print(kk.__version__)
+print(tf.__version__)
 
 size = MPI.COMM_WORLD.Get_size()
 rank = MPI.COMM_WORLD.Get_rank()

--- a/makedocs.py
+++ b/makedocs.py
@@ -14,7 +14,7 @@ modules = [
     "plasma.preprocessor.preprocess",
     "plasma.utils.evaluation",
     "plasma.utils.performance",
-    "plasma.utils.processing"  
+    "plasma.utils.processing"
     ]
 
 modules = {name: importlib.import_module(name) for name in modules}
@@ -23,11 +23,13 @@ documented = []
 for moduleName, module in modules.items():
     for objName in dir(module):
         obj = getattr(module, objName)
-        if not objName.startswith("_") and callable(obj) and obj.__module__ == moduleName:
-            print objName, obj
+        if (not objName.startswith("_")
+                and callable(obj) and obj.__module__ == moduleName):
+            print(objName, obj)
             documented.append(moduleName + "." + objName)
             if inspect.isclass(obj):
-                open("docs/" + moduleName + "." + objName + ".rst", "w").write(''':orphan:
+                open("docs/" + moduleName + "." + objName + ".rst", "w").write(
+                    ''':orphan:
 
 {0}
 {1}
@@ -37,12 +39,13 @@ for moduleName, module in modules.items():
     :special-members: __init__, __add__
     :inherited-members:
     :show-inheritance:
-'''.format(moduleName + "." + objName, "=" * (len(moduleName) + len(objName) + 1)))
+'''.format(moduleName + "." + objName, "="*(len(moduleName)+len(objName)+1)))
             else:
-                open("docs/" + moduleName + "." + objName + ".rst", "w").write(''':orphan:
+                open("docs/" + moduleName + "." + objName + ".rst",
+                     "w").write(''':orphan:
 
 {0}
 {1}
 
 .. autofunction:: {0}
-'''.format(moduleName + "." + objName, "=" * (len(moduleName) + len(objName) + 1)))
+'''.format(moduleName + "." + objName, "="*(len(moduleName)+len(objName)+1)))

--- a/plasma/__init__.py
+++ b/plasma/__init__.py
@@ -1,15 +1,15 @@
-#from plasma.conf import *
-#from plasma.jet_signals import *
+# from plasma.conf import *
+# from plasma.jet_signals import *
 
-#from plasma.model.builder import *
-#from plasma.model.runner import *
-#from plasma.model.targets import *
+# from plasma.model.builder import *
+# from plasma.model.runner import *
+# from plasma.model.targets import *
 
-#from plasma.preprocessor.load import *
-#from plasma.preprocessor.normalize import *
-#from plasma.preprocessor.preprocess import *
+# from plasma.preprocessor.load import *
+# from plasma.preprocessor.normalize import *
+# from plasma.preprocessor.preprocess import *
 
-#from plasma.primitives.shots import *
+# from plasma.primitives.shots import *
 
-#from plasma.utils.preprocessing import *
-#from plasma.utils.performance_analysis_utils import *
+# from plasma.utils.preprocessing import *
+# from plasma.utils.performance_analysis_utils import *

--- a/plasma/conf.py
+++ b/plasma/conf.py
@@ -2,13 +2,16 @@ from plasma.conf_parser import parameters
 import os
 import errno
 
-if os.path.exists(os.path.join(os.path.abspath(os.path.dirname(__file__)), '../examples/conf.yaml')):
-    conf = parameters(os.path.join(os.path.abspath(os.path.dirname(__file__)), '../examples/conf.yaml'))
+if os.path.exists(os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                               '../examples/conf.yaml')):
+    conf = parameters(os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                                   '../examples/conf.yaml'))
 elif os.path.exists('./conf.yaml'):
     conf = parameters('./conf.yaml')
 elif os.path.exists('./examples/conf.yaml'):
     conf = parameters('./examples/conf.yaml')
 elif os.path.exists('../examples/conf.yaml'):
-    conf = parameters('../examples/conf.yaml')    
+    conf = parameters('../examples/conf.yaml')
 else:
-    raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), 'conf.yaml')
+    raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT),
+                            'conf.yaml')

--- a/plasma/conf_parser.py
+++ b/plasma/conf_parser.py
@@ -1,47 +1,62 @@
 from plasma.primitives.shots import ShotListFiles
-from data.signals import *
-
+import data.signals as sig
+# from data.signals import (
+#     all_signals, fully_defined_signals_1D,
+#     jet, d3d)  # nstx
 import getpass
-import uuid
 import yaml
 
 import hashlib
 
+
 def parameters(input_file):
     """Parse yaml file of configuration parameters."""
-    from plasma.models.targets import HingeTarget, MaxHingeTarget, BinaryTarget, TTDTarget, TTDInvTarget, TTDLinearTarget
-
+    from plasma.models.targets import (
+        HingeTarget, MaxHingeTarget, BinaryTarget,
+        TTDTarget, TTDInvTarget, TTDLinearTarget
+        )
     with open(input_file, 'r') as yaml_file:
         params = yaml.load(yaml_file)
-
 
         params['user_name'] = getpass.getuser()
         output_path = params['fs_path'] + "/" + params['user_name']
         base_path = output_path
 
         params['paths']['base_path'] = base_path
-        params['paths']['signal_prepath'] = base_path + params['paths']['signal_prepath']
-        params['paths']['shot_list_dir'] = base_path + params['paths']['shot_list_dir']
+        params['paths']['signal_prepath'] = base_path + \
+            params['paths']['signal_prepath']
+        params['paths']['shot_list_dir'] = base_path + \
+            params['paths']['shot_list_dir']
         params['paths']['output_path'] = output_path
-        h = get_unique_signal_hash(all_signals.values())
-        params['paths']['global_normalizer_path'] = output_path + '/normalization/normalization_signal_group_{}.npz'.format(h)
+        h = get_unique_signal_hash(sig.all_signals.values())
+        params['paths']['global_normalizer_path'] = output_path + \
+            '/normalization/normalization_signal_group_{}.npz'.format(h)
         if params['training']['hyperparam_tuning']:
-            # params['paths']['saved_shotlist_path'] = './normalization/shot_lists.npz'
-            params['paths']['normalizer_path'] = './normalization/normalization_signal_group_{}.npz'.format(h)
+            # params['paths']['saved_shotlist_path'] =
+            # './normalization/shot_lists.npz'
+            params['paths']['normalizer_path'] = (
+                './normalization/normalization_signal_group_{}.npz'.format(h))
             params['paths']['model_save_path'] = './model_checkpoints/'
             params['paths']['csvlog_save_path'] = './csv_logs/'
             params['paths']['results_prepath'] = './results/'
         else:
-            # params['paths']['saved_shotlist_path'] = output_path +'/normalization/shot_lists.npz'
-            params['paths']['normalizer_path'] = params['paths']['global_normalizer_path']
-            params['paths']['model_save_path'] = output_path + '/model_checkpoints/'
+            # params['paths']['saved_shotlist_path'] = output_path +
+            # '/normalization/shot_lists.npz'
+            params['paths']['normalizer_path'] = (
+                params['paths']['global_normalizer_path'])
+            params['paths']['model_save_path'] = (
+                output_path + '/model_checkpoints/')
             params['paths']['csvlog_save_path'] = output_path + '/csv_logs/'
             params['paths']['results_prepath'] = output_path + '/results/'
-        params['paths']['tensorboard_save_path'] = output_path + params['paths']['tensorboard_save_path']
-        params['paths']['saved_shotlist_path'] = params['paths']['base_path'] + '/processed_shotlists/' + params['paths']['data'] + '/shot_lists_signal_group_{}.npz'.format(h)
-        params['paths']['processed_prepath'] = output_path +'/processed_shots/' + 'signal_group_{}/'.format(h)
-
-        #ensure shallow model has +1 -1 target.
+        params['paths']['tensorboard_save_path'] = output_path + \
+            params['paths']['tensorboard_save_path']
+        params['paths']['saved_shotlist_path'] = (
+            params['paths']['base_path'] + '/processed_shotlists/'
+            + params['paths']['data']
+            + '/shot_lists_signal_group_{}.npz'.format(h))
+        params['paths']['processed_prepath'] = (
+            output_path + '/processed_shots/' + 'signal_group_{}/'.format(h))
+        # ensure shallow model has +1 -1 target.
         if params['model']['shallow'] or params['target'] == 'hinge':
             params['data']['target'] = HingeTarget
         elif params['target'] == 'maxhinge':
@@ -59,163 +74,279 @@ def parameters(input_file):
             print('Unkown type of target. Exiting')
             exit(1)
 
-        #params['model']['output_activation'] = params['data']['target'].activation
-        #binary crossentropy performs slightly better?
-        #params['model']['loss'] = params['data']['target'].loss
+        # params['model']['output_activation'] =
+        # params['data']['target'].activation
+        # binary crossentropy performs slightly better?
+        # params['model']['loss'] = params['data']['target'].loss
 
-        #signals
-        params['paths']['all_signals_dict'] = all_signals
-        #assert order q95,li,ip,lm,betan,energy,dens,pradcore,pradedge,pin,pechin,torquein,ipdirect,etemp_profile,edens_profile
+        # signals
+        params['paths']['all_signals_dict'] = sig.all_signals
+        # assert order
+        # q95, li, ip, lm, betan, energy, dens, pradcore, pradedge, pin,
+        # pechin, torquein, ipdirect, etemp_profile, edens_profile
 
-        #shot lists
-        jet_carbon_wall = ShotListFiles(jet,params['paths']['shot_list_dir'],['CWall_clear.txt','CFC_unint.txt'],'jet carbon wall data')
-        jet_iterlike_wall = ShotListFiles(jet,params['paths']['shot_list_dir'],['ILW_unint.txt','BeWall_clear.txt'],'jet iter like wall data')
+        # shot lists
+        jet_carbon_wall = ShotListFiles(
+            sig.jet, params['paths']['shot_list_dir'],
+            ['CWall_clear.txt', 'CFC_unint.txt'], 'jet carbon wall data')
+        jet_iterlike_wall = ShotListFiles(
+            sig.jet, params['paths']['shot_list_dir'],
+            ['ILW_unint.txt', 'BeWall_clear.txt'], 'jet iter like wall data')
 
-        jenkins_jet_carbon_wall = ShotListFiles(jet,params['paths']['shot_list_dir'],['jenkins_CWall_clear.txt','jenkins_CFC_unint.txt'],'Subset of jet carbon wall data for Jenkins tests')
-        jenkins_jet_iterlike_wall = ShotListFiles(jet,params['paths']['shot_list_dir'],['jenkins_ILW_unint.txt','jenkins_BeWall_clear.txt'],'Subset of jet iter like wall data for Jenkins tests')
+        jenkins_jet_carbon_wall = ShotListFiles(
+            sig.jet, params['paths']['shot_list_dir'],
+            ['jenkins_CWall_clear.txt', 'jenkins_CFC_unint.txt'],
+            'Subset of jet carbon wall data for Jenkins tests')
+        jenkins_jet_iterlike_wall = ShotListFiles(
+            sig.jet, params['paths']['shot_list_dir'],
+            ['jenkins_ILW_unint.txt', 'jenkins_BeWall_clear.txt'],
+            'Subset of jet iter like wall data for Jenkins tests')
 
-        jet_full = ShotListFiles(jet,params['paths']['shot_list_dir'],['ILW_unint.txt','BeWall_clear.txt','CWall_clear.txt','CFC_unint.txt'],'jet full data')
+        jet_full = ShotListFiles(
+            sig.jet, params['paths']['shot_list_dir'],
+            ['ILW_unint.txt', 'BeWall_clear.txt', 'CWall_clear.txt',
+             'CFC_unint.txt'], 'jet full data')
 
-        d3d_10000 = ShotListFiles(d3d,params['paths']['shot_list_dir'],['d3d_clear_10000.txt','d3d_disrupt_10000.txt'],'d3d data 10000 ND and D shots')
-        d3d_1000 = ShotListFiles(d3d,params['paths']['shot_list_dir'],['d3d_clear_1000.txt','d3d_disrupt_1000.txt'],'d3d data 1000 ND and D shots')
-        d3d_100 = ShotListFiles(d3d,params['paths']['shot_list_dir'],['d3d_clear_100.txt','d3d_disrupt_100.txt'],'d3d data 100 ND and D shots')
-        d3d_full = ShotListFiles(d3d,params['paths']['shot_list_dir'],['d3d_clear_data_avail.txt','d3d_disrupt_data_avail.txt'],'d3d data since shot 125500')
-        d3d_jenkins = ShotListFiles(d3d,params['paths']['shot_list_dir'],['jenkins_d3d_clear.txt','jenkins_d3d_disrupt.txt'],'Subset of d3d data for Jenkins test')
-        d3d_jb_full = ShotListFiles(d3d,params['paths']['shot_list_dir'],['shotlist_JaysonBarr_clear.txt','shotlist_JaysonBarr_disrupt.txt'],'d3d shots since 160000-170000')
+        # d3d_10000 = ShotListFiles(
+        #     sig.d3d, params['paths']['shot_list_dir'],
+        #     ['d3d_clear_10000.txt', 'd3d_disrupt_10000.txt'],
+        #     'd3d data 10000 ND and D shots')
+        # d3d_1000 = ShotListFiles(
+        #     sig.d3d, params['paths']['shot_list_dir'],
+        #     ['d3d_clear_1000.txt', 'd3d_disrupt_1000.txt'],
+        #     'd3d data 1000 ND and D shots')
+        # d3d_100 = ShotListFiles(
+        #     sig.d3d, params['paths']['shot_list_dir'],
+        #     ['d3d_clear_100.txt', 'd3d_disrupt_100.txt'],
+        #     'd3d data 100 ND and D shots')
+        d3d_full = ShotListFiles(
+            sig.d3d, params['paths']['shot_list_dir'],
+            ['d3d_clear_data_avail.txt', 'd3d_disrupt_data_avail.txt'],
+            'd3d data since shot 125500')
+        d3d_jenkins = ShotListFiles(
+            sig.d3d, params['paths']['shot_list_dir'],
+            ['jenkins_d3d_clear.txt', 'jenkins_d3d_disrupt.txt'],
+            'Subset of d3d data for Jenkins test')
+        # d3d_jb_full = ShotListFiles(
+        #     sig.d3d, params['paths']['shot_list_dir'],
+        #     ['shotlist_JaysonBarr_clear.txt',
+        #      'shotlist_JaysonBarr_disrupt.txt'],
+        #     'd3d shots since 160000-170000')
 
-        nstx_full = ShotListFiles(nstx,params['paths']['shot_list_dir'],['disrupt_nstx.txt'],'nstx shots (all are disruptive')
- 
+        # nstx_full = ShotListFiles(
+        #     nstx, params['paths']['shot_list_dir'],
+        #     ['disrupt_nstx.txt'], 'nstx shots (all are disruptive')
+
         if params['paths']['data'] == 'jet_data':
             params['paths']['shot_files'] = [jet_carbon_wall]
             params['paths']['shot_files_test'] = [jet_iterlike_wall]
-            params['paths']['use_signals_dict'] = jet_signals
+            params['paths']['use_signals_dict'] = sig.jet_signals
         elif params['paths']['data'] == 'jet_data_0D':
             params['paths']['shot_files'] = [jet_carbon_wall]
             params['paths']['shot_files_test'] = [jet_iterlike_wall]
-            params['paths']['use_signals_dict'] = jet_signals_0D
+            params['paths']['use_signals_dict'] = sig.jet_signals_0D
         elif params['paths']['data'] == 'jet_data_1D':
             params['paths']['shot_files'] = [jet_carbon_wall]
             params['paths']['shot_files_test'] = [jet_iterlike_wall]
-            params['paths']['use_signals_dict'] = jet_signals_1D
+            params['paths']['use_signals_dict'] = sig.jet_signals_1D
         elif params['paths']['data'] == 'jet_carbon_data':
             params['paths']['shot_files'] = [jet_carbon_wall]
             params['paths']['shot_files_test'] = []
-            params['paths']['use_signals_dict'] = jet_signals
+            params['paths']['use_signals_dict'] = sig.jet_signals
         elif params['paths']['data'] == 'jet_mixed_data':
             params['paths']['shot_files'] = [jet_full]
             params['paths']['shot_files_test'] = []
-            params['paths']['use_signals_dict'] = jet_signals
+            params['paths']['use_signals_dict'] = sig.jet_signals
         elif params['paths']['data'] == 'jenkins_jet':
             params['paths']['shot_files'] = [jenkins_jet_carbon_wall]
             params['paths']['shot_files_test'] = [jenkins_jet_iterlike_wall]
-            params['paths']['use_signals_dict'] = jet_signals
-        elif params['paths']['data'] == 'jet_data_fully_defined': #jet data but with fully defined signals
+            params['paths']['use_signals_dict'] = sig.jet_signals
+        # jet data but with fully defined signals
+        elif params['paths']['data'] == 'jet_data_fully_defined':
             params['paths']['shot_files'] = [jet_carbon_wall]
             params['paths']['shot_files_test'] = [jet_iterlike_wall]
-            params['paths']['use_signals_dict'] = fully_defined_signals
-        elif params['paths']['data'] == 'jet_data_fully_defined_0D': #jet data but with fully defined signals
+            params['paths']['use_signals_dict'] = sig.fully_defined_signals
+        # jet data but with fully defined signals
+        elif params['paths']['data'] == 'jet_data_fully_defined_0D':
             params['paths']['shot_files'] = [jet_carbon_wall]
             params['paths']['shot_files_test'] = [jet_iterlike_wall]
-            params['paths']['use_signals_dict'] = fully_defined_signals_0D
-
-
+            params['paths']['use_signals_dict'] = sig.fully_defined_signals_0D
 
         elif params['paths']['data'] == 'd3d_data':
             params['paths']['shot_files'] = [d3d_full]
-            params['paths']['shot_files_test'] = [] 
-            params['paths']['use_signals_dict'] = {'q95':q95,'li':li,'ip':ip,'lm':lm,'betan':betan,'energy':energy,'dens':dens,'pradcore':pradcore,'pradedge':pradedge,'pin':pin,'torquein':torquein,'ipdirect':ipdirect,'iptarget':iptarget,'iperr':iperr,
-'etemp_profile':etemp_profile ,'edens_profile':edens_profile}
+            params['paths']['shot_files_test'] = []
+            params['paths']['use_signals_dict'] = {
+                'q95': sig.q95,
+                'li': sig.li,
+                'ip': sig.ip,
+                'lm': sig.lm,
+                'betan': sig.betan,
+                'energy': sig.energy,
+                'dens': sig.dens,
+                'pradcore': sig.pradcore,
+                'pradedge': sig.pradedge,
+                'pin': sig.pin,
+                'torquein': sig.torquein,
+                'ipdirect': sig.ipdirect,
+                'iptarget': sig.iptarget,
+                'iperr': sig.iperr,
+                'etemp_profile': sig.etemp_profile,
+                'edens_profile': sig.edens_profile,
+            }
         elif params['paths']['data'] == 'd3d_data_1D':
             params['paths']['shot_files'] = [d3d_full]
-            params['paths']['shot_files_test'] = [] 
-            params['paths']['use_signals_dict'] = {'ipdirect':ipdirect,'etemp_profile':etemp_profile ,'edens_profile':edens_profile}
+            params['paths']['shot_files_test'] = []
+            params['paths']['use_signals_dict'] = {
+                'ipdirect': sig.ipdirect,
+                'etemp_profile': sig.etemp_profile,
+                'edens_profile': sig.edens_profile,
+            }
         elif params['paths']['data'] == 'd3d_data_all_profiles':
             params['paths']['shot_files'] = [d3d_full]
-            params['paths']['shot_files_test'] = [] 
-            params['paths']['use_signals_dict'] = {'ipdirect':ipdirect,'etemp_profile':etemp_profile ,'edens_profile':edens_profile,'itemp_profile':itemp_profile,'zdens_profile':zdens_profile,'trot_profile':trot_profile,'pthm_profile':pthm_profile,'neut_profile':neut_profile,'q_profile':q_profile,'bootstrap_current_profile':bootstrap_current_profile,'q_psi_profile':q_psi_profile}
+            params['paths']['shot_files_test'] = []
+            params['paths']['use_signals_dict'] = {
+                'ipdirect': sig.ipdirect,
+                'etemp_profile': sig.etemp_profile,
+                'edens_profile': sig.edens_profile,
+                'itemp_profile': sig.itemp_profile,
+                'zdens_profile': sig.zdens_profile,
+                'trot_profile': sig.trot_profile,
+                'pthm_profile': sig.pthm_profile,
+                'neut_profile': sig.neut_profile,
+                'q_profile': sig.q_profile,
+                'bootstrap_current_profile': sig.bootstrap_current_profile,
+                'q_psi_profile': sig.q_psi_profile,
+            }
         elif params['paths']['data'] == 'd3d_data_0D':
             params['paths']['shot_files'] = [d3d_full]
-            params['paths']['shot_files_test'] = [] 
-            params['paths']['use_signals_dict'] = {'q95':q95,'li':li,'ip':ip,'lm':lm,'betan':betan,'energy':energy,'dens':dens,'pradcore':pradcore,'pradedge':pradedge,'pin':pin,'torquein':torquein,'ipdirect':ipdirect,'iptarget':iptarget,'iperr':iperr}
+            params['paths']['shot_files_test'] = []
+            params['paths']['use_signals_dict'] = {
+                'q95': sig.q95,
+                'li': sig.li,
+                'ip': sig.ip,
+                'lm': sig.lm,
+                'betan': sig.betan,
+                'energy': sig.energy,
+                'dens': sig.dens,
+                'pradcore': sig.pradcore,
+                'pradedge': sig.pradedge,
+                'pin': sig.pin,
+                'torquein': sig.torquein,
+                'ipdirect': sig.ipdirect,
+                'iptarget': sig.iptarget,
+                'iperr': sig.iperr,
+            }
         elif params['paths']['data'] == 'd3d_data_all':
             params['paths']['shot_files'] = [d3d_full]
-            params['paths']['shot_files_test'] = [] 
-            params['paths']['use_signals_dict'] = d3d_signals
+            params['paths']['shot_files_test'] = []
+            params['paths']['use_signals_dict'] = sig.d3d_signals
         elif params['paths']['data'] == 'jenkins_d3d':
             params['paths']['shot_files'] = [d3d_jenkins]
             params['paths']['shot_files_test'] = []
-            params['paths']['use_signals_dict'] = {'q95':q95,'li':li,'ip':ip,'lm':lm,'betan':betan,'energy':energy,'dens':dens,'pradcore':pradcore,'pradedge':pradedge,'pin':pin,'torquein':torquein,'ipdirect':ipdirect,'iptarget':iptarget,'iperr':iperr,
-'etemp_profile':etemp_profile ,'edens_profile':edens_profile}
-        elif params['paths']['data'] == 'd3d_data_fully_defined': #jet data but with fully defined signals
+            params['paths']['use_signals_dict'] = {
+                'q95': sig.q95,
+                'li': sig.li,
+                'ip': sig.ip,
+                'lm': sig.lm,
+                'betan': sig.betan,
+                'energy': sig.energy,
+                'dens': sig.dens,
+                'pradcore': sig.pradcore,
+                'pradedge': sig.pradedge,
+                'pin': sig.pin,
+                'torquein': sig.torquein,
+                'ipdirect': sig.ipdirect,
+                'iptarget': sig.iptarget,
+                'iperr': sig.iperr,
+                'etemp_profile': sig.etemp_profile,
+                'edens_profile': sig.edens_profile,
+            }
+        # jet data but with fully defined signals
+        elif params['paths']['data'] == 'd3d_data_fully_defined':
             params['paths']['shot_files'] = [d3d_full]
             params['paths']['shot_files_test'] = []
-            params['paths']['use_signals_dict'] = fully_defined_signals
-        elif params['paths']['data'] == 'd3d_data_fully_defined_0D': #jet data but with fully defined signals
+            params['paths']['use_signals_dict'] = sig.fully_defined_signals
+        # jet data but with fully defined signals
+        elif params['paths']['data'] == 'd3d_data_fully_defined_0D':
             params['paths']['shot_files'] = [d3d_full]
             params['paths']['shot_files_test'] = []
-            params['paths']['use_signals_dict'] = fully_defined_signals_0D
+            params['paths']['use_signals_dict'] = sig.fully_defined_signals_0D
 
-        #cross-machine
+        # cross-machine
         elif params['paths']['data'] == 'jet_to_d3d_data':
             params['paths']['shot_files'] = [jet_full]
             params['paths']['shot_files_test'] = [d3d_full]
-            params['paths']['use_signals_dict'] = fully_defined_signals
+            params['paths']['use_signals_dict'] = sig.fully_defined_signals
         elif params['paths']['data'] == 'd3d_to_jet_data':
             params['paths']['shot_files'] = [d3d_full]
             params['paths']['shot_files_test'] = [jet_iterlike_wall]
-            params['paths']['use_signals_dict'] = fully_defined_signals
+            params['paths']['use_signals_dict'] = sig.fully_defined_signals
         elif params['paths']['data'] == 'jet_to_d3d_data_0D':
             params['paths']['shot_files'] = [jet_full]
             params['paths']['shot_files_test'] = [d3d_full]
-            params['paths']['use_signals_dict'] = fully_defined_signals_0D
+            params['paths']['use_signals_dict'] = sig.fully_defined_signals_0D
         elif params['paths']['data'] == 'd3d_to_jet_data_0D':
             params['paths']['shot_files'] = [d3d_full]
             params['paths']['shot_files_test'] = [jet_iterlike_wall]
-            params['paths']['use_signals_dict'] = fully_defined_signals_0D
+            params['paths']['use_signals_dict'] = sig.fully_defined_signals_0D
         elif params['paths']['data'] == 'jet_to_d3d_data_1D':
             params['paths']['shot_files'] = [jet_full]
             params['paths']['shot_files_test'] = [d3d_full]
-            params['paths']['use_signals_dict'] = fully_defined_signals_1D
+            params['paths']['use_signals_dict'] = sig.fully_defined_signals_1D
         elif params['paths']['data'] == 'd3d_to_jet_data_1D':
             params['paths']['shot_files'] = [d3d_full]
             params['paths']['shot_files_test'] = [jet_iterlike_wall]
-            params['paths']['use_signals_dict'] = fully_defined_signals_1D
+            params['paths']['use_signals_dict'] = sig.fully_defined_signals_1D
 
-
-
-        else: 
+        else:
             print("Unkown data set {}".format(params['paths']['data']))
             exit(1)
 
         if len(params['paths']['specific_signals']):
-            for sig in params['paths']['specific_signals']:
-                if sig not in params['paths']['use_signals_dict'].keys():
-                    print("Signal {} is not fully defined for {} machine. Skipping...".format(sig,params['paths']['data'].split("_")[0]))
-            params['paths']['specific_signals'] = list(filter(lambda x: x in params['paths']['use_signals_dict'].keys(), params['paths']['specific_signals']))
-            selected_signals = {k: params['paths']['use_signals_dict'][k] for k in params['paths']['specific_signals']}
-            params['paths']['use_signals'] = sort_by_channels(list(selected_signals.values()))
+            for s in params['paths']['specific_signals']:
+                if s not in params['paths']['use_signals_dict'].keys():
+                    print("Signal {} is not fully defined for {} machine. ",
+                          "Skipping...".format(
+                              s, params['paths']['data'].split("_")[0]))
+            params['paths']['specific_signals'] = list(
+                filter(
+                    lambda x: x in params['paths']['use_signals_dict'].keys(),
+                    params['paths']['specific_signals']))
+            selected_signals = {k: params['paths']['use_signals_dict'][k]
+                                for k in params['paths']['specific_signals']}
+            params['paths']['use_signals'] = sort_by_channels(
+                list(selected_signals.values()))
 
         else:
-            #default case
-            params['paths']['use_signals'] = sort_by_channels(list(params['paths']['use_signals_dict'].values()))
+            # default case
+            params['paths']['use_signals'] = sort_by_channels(
+                list(params['paths']['use_signals_dict'].values()))
 
-        params['paths']['all_signals'] = sort_by_channels(list(params['paths']['all_signals_dict'].values()))
+        params['paths']['all_signals'] = sort_by_channels(
+            list(params['paths']['all_signals_dict'].values()))
 
-        print("Selected signals (determines which signals training is run on):\n{}".format(params['paths']['use_signals']))
+        print("Selected signals (determines which signals are used for ",
+              "training):\n{}".format(params['paths']['use_signals']))
 
-        params['paths']['shot_files_all'] = params['paths']['shot_files']+params['paths']['shot_files_test']
-        params['paths']['all_machines'] = list(set([file.machine for file in params['paths']['shot_files_all']]))
+        params['paths']['shot_files_all'] = (
+            params['paths']['shot_files'] + params['paths']['shot_files_test'])
+        params['paths']['all_machines'] = list(
+            set([file.machine for file in params['paths']['shot_files_all']]))
 
-        #type assertations
-        assert type(params['data']['signal_to_augment']) == str or type(params['data']['signal_to_augment']) == None
-        assert type(params['data']['augment_during_training']) == bool
+        # type assertations
+        assert (isinstance(params['data']['signal_to_augment'], str)
+                or isinstance(params['data']['signal_to_augment'], None))
+        assert isinstance(params['data']['augment_during_training'], bool)
 
     return params
 
+
 def get_unique_signal_hash(signals):
-    return int(hashlib.md5(''.join(tuple(map(lambda x: x.description, sorted(signals)))).encode('utf-8')).hexdigest(),16)
+    return int(hashlib.md5(''.join(
+        tuple(map(lambda x: x.description, sorted(signals)))).encode(
+            'utf-8')).hexdigest(), 16)
 
-#make sure 1D signals come last! This is necessary for model builder.
+
 def sort_by_channels(list_of_signals):
-    return sorted(list_of_signals,key = lambda x: x.num_channels)
-
+    # make sure 1D signals come last! This is necessary for model builder.
+    return sorted(list_of_signals, key=lambda x: x.num_channels)

--- a/plasma/models/builder.py
+++ b/plasma/models/builder.py
@@ -1,27 +1,31 @@
 from __future__ import division
-import keras
 from keras.models import Sequential, Model
 from keras.layers import Input
-from keras.layers.core import Dense, Activation, Dropout, Lambda, Reshape, Flatten, Permute, RepeatVector
+from keras.layers.core import (
+    Dense, Activation, Dropout, Lambda,
+    Reshape, Flatten, Permute,  # RepeatVector
+    )
 from keras.layers import LSTM, SimpleRNN, Bidirectional, BatchNormalization
 from keras.layers.convolutional import Convolution1D
 from keras.layers.pooling import MaxPooling1D
-from keras.utils.data_utils import get_file
+# from keras.utils.data_utils import get_file
 from keras.layers.wrappers import TimeDistributed
 from keras.layers.merge import Concatenate
 from keras.callbacks import Callback
-from keras.regularizers import l1,l2,l1_l2
+from keras.regularizers import l2  # l1, l1_l2
 
 import keras.backend as K
 
 import dill
 import re
-import os,sys
+import os
+import sys
 import numpy as np
 from copy import deepcopy
 from plasma.utils.downloading import makedirs_process_safe
 
 import hashlib
+
 
 class LossHistory(Callback):
     def on_train_begin(self, logs=None):
@@ -32,44 +36,49 @@ class LossHistory(Callback):
 
 
 class ModelBuilder(object):
-    def __init__(self,conf):
+    def __init__(self, conf):
         self.conf = conf
 
     def get_unique_id(self):
-        num_epochs = self.conf['training']['num_epochs']
+        # num_epochs = self.conf['training']['num_epochs']
         this_conf = deepcopy(self.conf)
-        #don't make hash dependent on number of epochs.
+        # don't make hash dependent on number of epochs.
         this_conf['training']['num_epochs'] = 0
-        unique_id = int(hashlib.md5((dill.dumps(this_conf).decode('unicode_escape')).encode('utf-8')).hexdigest(),16)
+        unique_id = int(hashlib.md5((dill.dumps(this_conf).decode(
+            'unicode_escape')).encode('utf-8')).hexdigest(), 16)
         return unique_id
 
     def get_0D_1D_indices(self):
-        #make sure all 1D indices are contiguous in the end!
+        # make sure all 1D indices are contiguous in the end!
         use_signals = self.conf['paths']['use_signals']
         indices_0d = []
         indices_1d = []
         num_0D = 0
         num_1D = 0
         curr_idx = 0
-        is_1D_region = use_signals[0].num_channels > 1#do we have any 1D indices?
+        # do we have any 1D indices?
+        is_1D_region = use_signals[0].num_channels > 1
         for sig in use_signals:
             num_channels = sig.num_channels
-            indices = range(curr_idx,curr_idx+num_channels)
+            indices = range(curr_idx, curr_idx+num_channels)
             if num_channels > 1:
                 indices_1d += indices
                 num_1D += 1
                 is_1D_region = True
             else:
-                assert(not is_1D_region), "make sure all use_signals are ordered such that 1D signals come last!"
+                assert(not is_1D_region)
+                # , "make sure all use_signals are ordered such that 1D signals
+                # come last!"
                 assert(num_channels == 1)
                 indices_0d += indices
                 num_0D += 1
                 is_1D_region = False
             curr_idx += num_channels
-        return np.array(indices_0d).astype(np.int32), np.array(indices_1d).astype(np.int32),num_0D,num_1D
+        return np.array(indices_0d).astype(
+            np.int32), np.array(indices_1d).astype(
+            np.int32), num_0D, num_1D
 
-
-    def build_model(self,predict,custom_batch_size=None):
+    def build_model(self, predict, custom_batch_size=None):
         conf = self.conf
         model_conf = conf['model']
         use_bidirectional = model_conf['use_bidirectional']
@@ -82,25 +91,25 @@ class ModelBuilder(object):
         dropout_prob = model_conf['dropout_prob']
         length = model_conf['length']
         pred_length = model_conf['pred_length']
-        skip = model_conf['skip']
+        # skip = model_conf['skip']
         stateful = model_conf['stateful']
         return_sequences = model_conf['return_sequences']
-        output_activation = conf['data']['target'].activation#model_conf['output_activation']
+        # model_conf['output_activation']
+        output_activation = conf['data']['target'].activation
         use_signals = conf['paths']['use_signals']
         num_signals = sum([sig.num_channels for sig in use_signals])
         num_conv_filters = model_conf['num_conv_filters']
-        num_conv_layers = model_conf['num_conv_layers']
+        # num_conv_layers = model_conf['num_conv_layers']
         size_conv_filters = model_conf['size_conv_filters']
         pool_size = model_conf['pool_size']
         dense_size = model_conf['dense_size']
 
-
         batch_size = self.conf['training']['batch_size']
         if predict:
             batch_size = self.conf['model']['pred_batch_size']
-            #so we can predict with one time point at a time!
+            # so we can predict with one time point at a time!
             if return_sequences:
-                length =pred_length
+                length = pred_length
             else:
                 length = 1
 
@@ -110,20 +119,20 @@ class ModelBuilder(object):
         if rnn_type == 'LSTM':
             rnn_model = LSTM
         elif rnn_type == 'SimpleRNN':
-            rnn_model =SimpleRNN 
+            rnn_model = SimpleRNN
         else:
             print('Unkown Model Type, exiting.')
             exit(1)
-        
-        batch_input_shape=(batch_size,length, num_signals)
-        batch_shape_non_temporal=(batch_size,num_signals)
 
-        indices_0d,indices_1d,num_0D,num_1D = self.get_0D_1D_indices()
+        batch_input_shape = (batch_size, length, num_signals)
+        # batch_shape_non_temporal = (batch_size, num_signals)
 
-        def slicer(x,indices):
-            return x[:,indices]
+        indices_0d, indices_1d, num_0D, num_1D = self.get_0D_1D_indices()
 
-        def slicer_output_shape(input_shape,indices):
+        def slicer(x, indices):
+            return x[:, indices]
+
+        def slicer_output_shape(input_shape, indices):
             shape_curr = list(input_shape)
             assert len(shape_curr) == 2  # only valid for 3D tensors
             shape_curr[-1] = len(indices)
@@ -132,112 +141,178 @@ class ModelBuilder(object):
         pre_rnn_input = Input(shape=(num_signals,))
 
         if num_1D > 0:
-            pre_rnn_1D = Lambda(lambda x: x[:,len(indices_0d):],output_shape=(len(indices_1d),))(pre_rnn_input)
-            pre_rnn_0D = Lambda(lambda x: x[:,:len(indices_0d)],output_shape=(len(indices_0d),))(pre_rnn_input)# slicer(x,indices_0d),lambda s: slicer_output_shape(s,indices_0d))(pre_rnn_input)
-            pre_rnn_1D = Reshape((num_1D,len(indices_1d)//num_1D)) (pre_rnn_1D)
-            pre_rnn_1D = Permute((2,1)) (pre_rnn_1D)
-            
+            pre_rnn_1D = Lambda(lambda x: x[:, len(indices_0d):],
+                                output_shape=(len(indices_1d),))(pre_rnn_input)
+            pre_rnn_0D = Lambda(lambda x: x[:, :len(indices_0d)],
+                                output_shape=(len(indices_0d),))(pre_rnn_input)
+            # slicer(x,indices_0d),lambda s:
+            # slicer_output_shape(s,indices_0d))(pre_rnn_input)
+            pre_rnn_1D = Reshape((num_1D, len(indices_1d)//num_1D))(pre_rnn_1D)
+            pre_rnn_1D = Permute((2, 1))(pre_rnn_1D)
+
             for i in range(model_conf['num_conv_layers']):
                 div_fac = 2**i
-                '''The first conv layer learns `num_conv_filters//div_fac` filters (aka kernels), 
-                each of size `(size_conv_filters, num1D)``. Its output will have shape 
-                (None, len(indices_1d)//num_1D - size_conv_filters + 1, num_conv_filters//div_fac),
-                i.e., for each position in the input spatial series (direction along radius), 
-                the activation of each filter at that position.'''
+                '''The first conv layer learns `num_conv_filters//div_fac`
+                filters (aka kernels), each of size
+                `(size_conv_filters, num1D)`. Its output will have shape
+                (None, len(indices_1d)//num_1D - size_conv_filters + 1,
+                num_conv_filters//div_fac), i.e., for
+                each position in the input spatial series (direction along
+                radius), the activation of each filter at that position.
+
+                '''
 
                 '''For i=1 first conv layer would get:
-                (None, (len(indices_1d)//num_1D - size_conv_filters + 1)/pool_size-size_conv_filters+1,num_conv_filters//div_fac)'''
-                pre_rnn_1D = Convolution1D(num_conv_filters//div_fac,size_conv_filters,padding='valid') (pre_rnn_1D)
-                if use_batch_norm:  pre_rnn_1D = BatchNormalization()(pre_rnn_1D)
+                (None, (len(indices_1d)//num_1D - size_conv_filters
+                + 1)/pool_size-size_conv_filters + 1,num_conv_filters//div_fac)
+
+                '''
+                pre_rnn_1D = Convolution1D(
+                    num_conv_filters//div_fac, size_conv_filters,
+                    padding='valid')(pre_rnn_1D)
+                if use_batch_norm:
+                    pre_rnn_1D = BatchNormalization()(pre_rnn_1D)
                 pre_rnn_1D = Activation('relu')(pre_rnn_1D)
 
-                '''The output of the second conv layer will have shape 
-                (None, len(indices_1d)//num_1D - size_conv_filters + 1, num_conv_filters//div_fac),
-                i.e., for each position in the input spatial series (direction along radius), 
-                the activation of each filter at that position.
+                '''The output of the second conv layer will have shape
+                (None, len(indices_1d)//num_1D - size_conv_filters + 1,
+                num_conv_filters//div_fac),
+                i.e., for each position in the input spatial series
+                (direction along radius), the activation of each filter
+                at that position.
 
-                for i=1 second layer would output
-                (None, (len(indices_1d)//num_1D - size_conv_filters + 1)/pool_size-size_conv_filters+1,num_conv_filters//div_fac)'''  
-                pre_rnn_1D = Convolution1D(num_conv_filters//div_fac,1,padding='valid') (pre_rnn_1D)
-                if use_batch_norm: pre_rnn_1D = BatchNormalization()(pre_rnn_1D)
+                For i=1, the second layer would output
+                (None, (len(indices_1d)//num_1D - size_conv_filters + 1)/
+                pool_size-size_conv_filters + 1,num_conv_filters//div_fac)
+                '''
+                pre_rnn_1D = Convolution1D(
+                    num_conv_filters//div_fac, 1, padding='valid')(pre_rnn_1D)
+                if use_batch_norm:
+                    pre_rnn_1D = BatchNormalization()(pre_rnn_1D)
                 pre_rnn_1D = Activation('relu')(pre_rnn_1D)
-                '''Outputs (None, (len(indices_1d)//num_1D - size_conv_filters + 1)/pool_size, num_conv_filters//div_fac)
+                '''Outputs (None, (len(indices_1d)//num_1D - size_conv_filters
+                + 1)/pool_size, num_conv_filters//div_fac)
 
-                for i=1 pooling layer would output:
-                (None,((len(indices_1d)//num_1D- size_conv_filters + 1)/pool_size-size_conv_filters+1)/pool_size,num_conv_filters//div_fac)'''
-                pre_rnn_1D = MaxPooling1D(pool_size) (pre_rnn_1D)
-            pre_rnn_1D = Flatten() (pre_rnn_1D)
-            pre_rnn_1D = Dense(dense_size,kernel_regularizer=l2(dense_regularization),bias_regularizer=l2(dense_regularization),activity_regularizer=l2(dense_regularization)) (pre_rnn_1D)
-            if use_batch_norm: pre_rnn_1D = BatchNormalization()(pre_rnn_1D)
+                For i=1, the pooling layer would output:
+                (None,((len(indices_1d)//num_1D- size_conv_filters
+                + 1)/pool_size-size_conv_filters+1)/pool_size,
+                num_conv_filters//div_fac)
+
+                '''
+                pre_rnn_1D = MaxPooling1D(pool_size)(pre_rnn_1D)
+            pre_rnn_1D = Flatten()(pre_rnn_1D)
+            pre_rnn_1D = Dense(
+                dense_size,
+                kernel_regularizer=l2(dense_regularization),
+                bias_regularizer=l2(dense_regularization),
+                activity_regularizer=l2(dense_regularization))(pre_rnn_1D)
+            if use_batch_norm:
+                pre_rnn_1D = BatchNormalization()(pre_rnn_1D)
             pre_rnn_1D = Activation('relu')(pre_rnn_1D)
-            pre_rnn_1D = Dense(dense_size//4,kernel_regularizer=l2(dense_regularization),bias_regularizer=l2(dense_regularization),activity_regularizer=l2(dense_regularization)) (pre_rnn_1D)
-            if use_batch_norm: pre_rnn_1D = BatchNormalization()(pre_rnn_1D)
+            pre_rnn_1D = Dense(
+                dense_size//4,
+                kernel_regularizer=l2(dense_regularization),
+                bias_regularizer=l2(dense_regularization),
+                activity_regularizer=l2(dense_regularization))(pre_rnn_1D)
+            if use_batch_norm:
+                pre_rnn_1D = BatchNormalization()(pre_rnn_1D)
             pre_rnn_1D = Activation('relu')(pre_rnn_1D)
-            pre_rnn = Concatenate() ([pre_rnn_0D,pre_rnn_1D])
+            pre_rnn = Concatenate()([pre_rnn_0D, pre_rnn_1D])
         else:
-            pre_rnn = pre_rnn_input        
+            pre_rnn = pre_rnn_input
 
         if model_conf['rnn_layers'] == 0 or model_conf['extra_dense_input']:
-            pre_rnn = Dense(dense_size,activation='relu',kernel_regularizer=l2(dense_regularization),bias_regularizer=l2(dense_regularization),activity_regularizer=l2(dense_regularization)) (pre_rnn)
-            pre_rnn = Dense(dense_size//2,activation='relu',kernel_regularizer=l2(dense_regularization),bias_regularizer=l2(dense_regularization),activity_regularizer=l2(dense_regularization)) (pre_rnn)
-            pre_rnn = Dense(dense_size//4,activation='relu',kernel_regularizer=l2(dense_regularization),bias_regularizer=l2(dense_regularization),activity_regularizer=l2(dense_regularization)) (pre_rnn)
-        
-        pre_rnn_model = Model(inputs = pre_rnn_input,outputs=pre_rnn)
-        #pre_rnn_model.summary()
-        x_input = Input(batch_shape = batch_input_shape)
-        x_in = TimeDistributed(pre_rnn_model) (x_input)
+            pre_rnn = Dense(
+                dense_size,
+                activation='relu',
+                kernel_regularizer=l2(dense_regularization),
+                bias_regularizer=l2(dense_regularization),
+                activity_regularizer=l2(dense_regularization))(pre_rnn)
+            pre_rnn = Dense(
+                dense_size//2,
+                activation='relu',
+                kernel_regularizer=l2(dense_regularization),
+                bias_regularizer=l2(dense_regularization),
+                activity_regularizer=l2(dense_regularization))(pre_rnn)
+            pre_rnn = Dense(
+                dense_size//4,
+                activation='relu',
+                kernel_regularizer=l2(dense_regularization),
+                bias_regularizer=l2(dense_regularization),
+                activity_regularizer=l2(dense_regularization))(pre_rnn)
+
+        pre_rnn_model = Model(inputs=pre_rnn_input, outputs=pre_rnn)
+        # pre_rnn_model.summary()
+        x_input = Input(batch_shape=batch_input_shape)
+        x_in = TimeDistributed(pre_rnn_model)(x_input)
 
         if use_bidirectional:
             for _ in range(model_conf['rnn_layers']):
-                x_in = Bidirectional(rnn_model(rnn_size, return_sequences=return_sequences,
-                 stateful=stateful,kernel_regularizer=l2(regularization),recurrent_regularizer=l2(regularization),
-                 bias_regularizer=l2(regularization),dropout=dropout_prob,recurrent_dropout=dropout_prob)) (x_in)
-                x_in = Dropout(dropout_prob) (x_in)
+                x_in = Bidirectional(
+                    rnn_model(
+                        rnn_size,
+                        return_sequences=return_sequences,
+                        stateful=stateful,
+                        kernel_regularizer=l2(regularization),
+                        recurrent_regularizer=l2(regularization),
+                        bias_regularizer=l2(regularization),
+                        dropout=dropout_prob,
+                        recurrent_dropout=dropout_prob))(x_in)
+                x_in = Dropout(dropout_prob)(x_in)
         else:
             for _ in range(model_conf['rnn_layers']):
-                x_in = rnn_model(rnn_size, return_sequences=return_sequences,#batch_input_shape=batch_input_shape,
-                 stateful=stateful,kernel_regularizer=l2(regularization),recurrent_regularizer=l2(regularization),
-                 bias_regularizer=l2(regularization),dropout=dropout_prob,recurrent_dropout=dropout_prob) (x_in)
-                x_in = Dropout(dropout_prob) (x_in)
+                x_in = rnn_model(
+                    rnn_size,
+                    return_sequences=return_sequences,
+                    # batch_input_shape=batch_input_shape,
+                    stateful=stateful,
+                    kernel_regularizer=l2(regularization),
+                    recurrent_regularizer=l2(regularization),
+                    bias_regularizer=l2(regularization),
+                    dropout=dropout_prob,
+                    recurrent_dropout=dropout_prob)(x_in)
+                x_in = Dropout(dropout_prob)(x_in)
         if return_sequences:
-            #x_out = TimeDistributed(Dense(100,activation='tanh')) (x_in)
-            x_out = TimeDistributed(Dense(1,activation=output_activation)) (x_in)
+            # x_out = TimeDistributed(Dense(100,activation='tanh')) (x_in)
+            x_out = TimeDistributed(
+                Dense(1, activation=output_activation))(x_in)
         else:
-            x_out = Dense(1,activation=output_activation) (x_in)
-        model = Model(inputs=x_input,outputs=x_out)
-        #bug with tensorflow/Keras
-        if conf['model']['backend'] == 'tf' or conf['model']['backend'] == 'tensorflow':
-                first_time = "tensorflow" not in sys.modules
-                import tensorflow as tf
-                if first_time:
-                    K.get_session().run(tf.global_variables_initializer())
+            x_out = Dense(1, activation=output_activation)(x_in)
+        model = Model(inputs=x_input, outputs=x_out)
+        # bug with tensorflow/Keras
+        if (conf['model']['backend'] == 'tf'
+                or conf['model']['backend'] == 'tensorflow'):
+            first_time = "tensorflow" not in sys.modules
+            import tensorflow as tf
+            if first_time:
+                K.get_session().run(tf.global_variables_initializer())
 
         model.reset_states()
         return model
 
     def build_train_test_models(self):
-        return self.build_model(False),self.build_model(True)
+        return self.build_model(False), self.build_model(True)
 
-    def save_model_weights(self,model,epoch):
+    def save_model_weights(self, model, epoch):
         save_path = self.get_save_path(epoch)
-        model.save_weights(save_path,overwrite=True)
+        model.save_weights(save_path, overwrite=True)
 
-    def delete_model_weights(self,model,epoch):
+    def delete_model_weights(self, model, epoch):
         save_path = self.get_save_path(epoch)
         assert(os.path.exists(save_path))
         os.remove(save_path)
 
-
-    def get_save_path(self,epoch):
+    def get_save_path(self, epoch):
         unique_id = self.get_unique_id()
-        return self.conf['paths']['model_save_path'] + 'model.{}._epoch_.{}.h5'.format(unique_id,epoch)
+        return (self.conf['paths']['model_save_path']
+                + 'model.{}._epoch_.{}.h5'.format(unique_id, epoch))
 
     def ensure_save_directory(self):
         prepath = self.conf['paths']['model_save_path']
         makedirs_process_safe(prepath)
 
-    def load_model_weights(self,model,custom_path=None):
-        if custom_path == None:
+    def load_model_weights(self, model, custom_path=None):
+        if custom_path is None:
             epochs = self.get_all_saved_files()
             if len(epochs) == 0:
                 print('no previous checkpoint found')
@@ -248,7 +323,8 @@ class ModelBuilder(object):
                 model.load_weights(self.get_save_path(max_epoch))
                 return max_epoch
         else:
-            epoch = self.extract_id_and_epoch_from_filename(os.path.basename(custom_path))[1]
+            epoch = self.extract_id_and_epoch_from_filename(
+                os.path.basename(custom_path))[1]
             model.load_weights(custom_path)
             print("Loading from custom epoch {}".format(epoch))
             return epoch
@@ -263,14 +339,12 @@ class ModelBuilder(object):
             print('loading from epoch {}'.format(max_epoch))
             return self.get_save_path(max_epoch)
 
-
-    def extract_id_and_epoch_from_filename(self,filename):
+    def extract_id_and_epoch_from_filename(self, filename):
         regex = re.compile(r'-?\d+')
         numbers = [int(x) for x in regex.findall(filename)]
-        assert(len(numbers) == 3) #id,epoch number and extension
-        assert(numbers[2] == 5) #.h5 extension
-        return numbers[0],numbers[1]
-
+        assert(len(numbers) == 3)  # id,epoch number and extension
+        assert(numbers[2] == 5)  # .h5 extension
+        return numbers[0], numbers[1]
 
     def get_all_saved_files(self):
         self.ensure_save_directory()
@@ -278,16 +352,15 @@ class ModelBuilder(object):
         filenames = os.listdir(self.conf['paths']['model_save_path'])
         epochs = []
         for file in filenames:
-            curr_id,epoch = self.extract_id_and_epoch_from_filename(file)
+            curr_id, epoch = self.extract_id_and_epoch_from_filename(file)
             if curr_id == unique_id:
                 epochs.append(epoch)
         return epochs
 
-
-    #FIXME this is essentially the ModelBuilder.build_model
-        #in the long run we want to replace the space dictionary with the 
-        #regular conf file - I am sure there is a way to accomodate 
-    def hyper_build_model(self,space,predict,custom_batch_size=None):
+    # FIXME this is essentially the ModelBuilder.build_model
+        # in the long run we want to replace the space dictionary with the
+        # regular conf file - I am sure there is a way to accomodate
+    def hyper_build_model(self, space, predict, custom_batch_size=None):
         conf = self.conf
         model_conf = conf['model']
         rnn_size = model_conf['rnn_size']
@@ -297,19 +370,19 @@ class ModelBuilder(object):
         dropout_prob = model_conf['dropout_prob']
         length = model_conf['length']
         pred_length = model_conf['pred_length']
-        skip = model_conf['skip']
+        # skip = model_conf['skip']
         stateful = model_conf['stateful']
         return_sequences = model_conf['return_sequences']
-        output_activation = conf['data']['target'].activation#model_conf['output_activation']
+        # model_conf['output_activation']
+        output_activation = conf['data']['target'].activation
         num_signals = conf['data']['num_signals']
-
 
         batch_size = self.conf['training']['batch_size']
         if predict:
             batch_size = self.conf['model']['pred_batch_size']
-            #so we can predict with one time point at a time!
+            # so we can predict with one time point at a time!
             if return_sequences:
-                length =pred_length
+                length = pred_length
             else:
                 length = 1
 
@@ -319,23 +392,31 @@ class ModelBuilder(object):
         if rnn_type == 'LSTM':
             rnn_model = LSTM
         elif rnn_type == 'SimpleRNN':
-            rnn_model =SimpleRNN
+            rnn_model = SimpleRNN
         else:
             print('Unkown Model Type, exiting.')
             exit(1)
-        
-        batch_input_shape=(batch_size,length, num_signals)
+
+        batch_input_shape = (batch_size, length, num_signals)
         model = Sequential()
 
         for _ in range(model_conf['rnn_layers']):
-            model.add(rnn_model(rnn_size, return_sequences=return_sequences,batch_input_shape=batch_input_shape,
-                stateful=stateful,kernel_regularizer=l2(regularization),recurrent_regularizer=l2(regularization),
-                bias_regularizer=l2(regularization),dropout=dropout_prob,recurrent_dropout=dropout_prob))
+            model.add(
+                rnn_model(
+                    rnn_size,
+                    return_sequences=return_sequences,
+                    batch_input_shape=batch_input_shape,
+                    stateful=stateful,
+                    kernel_regularizer=l2(regularization),
+                    recurrent_regularizer=l2(regularization),
+                    bias_regularizer=l2(regularization),
+                    dropout=dropout_prob,
+                    recurrent_dropout=dropout_prob))
             model.add(Dropout(space['Dropout']))
         if return_sequences:
-            model.add(TimeDistributed(Dense(1,activation=output_activation)))
+            model.add(TimeDistributed(Dense(1, activation=output_activation)))
         else:
-            model.add(Dense(1,activation=output_activation))
+            model.add(Dense(1, activation=output_activation))
         model.reset_states()
 
         return model

--- a/plasma/models/custom_loss.py
+++ b/plasma/models/custom_loss.py
@@ -1,27 +1,30 @@
 import numpy as np
 
-from keras import objectives
+# from keras import objectives
 from keras import backend as K
-from keras.losses import hinge, squared_hinge
+from keras.losses import squared_hinge
 
 _EPSILON = K.epsilon()
 
+
 def _loss_tensor(y_true, y_pred):
-    max_val = K.max(y_pred,axis=-2) #temporal axis!
-    max_val = K.repeat(max_val,K.shape(y_pred)[-2])
+    max_val = K.max(y_pred, axis=-2)  # temporal axis!
+    max_val = K.repeat(max_val, K.shape(y_pred)[-2])
     print(K.eval(max_val))
-    mask = K.cast(K.equal(max_val,y_pred),K.floatx())
+    mask = K.cast(K.equal(max_val, y_pred), K.floatx())
     y_pred = mask * y_pred + (1-mask) * y_true
-    return squared_hinge(y_true,y_pred)
+    return squared_hinge(y_true, y_pred)
+
 
 def _loss_np(y_true, y_pred):
     print(y_pred.shape)
-    max_val = np.max(y_pred,axis=-2) #temporal axis!
-    max_val = np.reshape(max_val,max_val.shape[:-1] + (1,) + (max_val.shape[-1],))
-    max_val = np.tile(max_val,(1,y_pred.shape[-2],1))
+    max_val = np.max(y_pred, axis=-2)  # temporal axis!
+    max_val = np.reshape(
+        max_val, max_val.shape[:-1] + (1,) + (max_val.shape[-1],))
+    max_val = np.tile(max_val, (1, y_pred.shape[-2], 1))
     print(max_val.shape)
     print(max_val)
-    mask = np.equal(max_val,y_pred)
+    mask = np.equal(max_val, y_pred)
     mask = mask.astype(np.float32)
     y_pred = mask * y_pred + (1-mask) * y_true
     return np.mean(np.square(np.maximum(1. - y_true * y_pred, 0.)), axis=-1)
@@ -38,7 +41,7 @@ def check_loss(_shape):
         shape = (9, 8, 5, 6, 7)
 
     y_a = 1.0*np.ones(shape)
-    y_b = 0.5+np.random.random(shape)
+    y_b = 0.5 + np.random.random(shape)
 
     print(y_a)
     print(y_b)
@@ -55,10 +58,11 @@ def check_loss(_shape):
 
 
 def test_loss():
-    shape_list = ['3d']#, '3d', '4d', '5d']
+    shape_list = ['3d']  # , '3d', '4d', '5d']
     for _shape in shape_list:
         check_loss(_shape)
         print('======================')
+
 
 if __name__ == '__main__':
     test_loss()

--- a/plasma/models/loader.py
+++ b/plasma/models/loader.py
@@ -14,45 +14,55 @@ import numpy as np
 from plasma.primitives.shots import Shot
 import multiprocessing as mp
 
-import pdb
+# import pdb
+
 
 class Loader(object):
+    '''A Python class to ...
+
+    The length of shots in e.g. JET data varies by orders of magnitude. For
+    data parallel synchronous training it is essential that amounds of train
+    data passed to the model replica is about the same size.  Therefore, a
+    patching technique is introduced.
+
+    A patch is a subset of shot's time/signal profile having a fixed length,
+    equal among all patches.  Patch size is approximately equal to the minimum
+    shot length. More precisely: it is equal to the max(1,
+    min_len//rnn_length)*rnn_length - the largest number less or equal to the
+    minimum shot length divisible by the LSTM model length. If minimum shot
+    length is less than the rnn_length, then the patch length is equal to the
+    rnn_length
+
     '''
-    A Python class to ...
 
-    The length of shots in e.g. JET data varies by orders of magnitude. For data parallel 
-    synchronous training it is essential that amounds of train data passed to the model replica is about the same size.
-    Therefore, a patching technique is introduced.
-
-    A patch is a subset of shot's time/signal profile having a fixed length, equal among all patches. 
-    Patch size is approximately equal to the minimum shot length. More precisely: it is equal
-    to the max(1, min_len//rnn_length)*rnn_length - the largest number less or equal to the minimum shot length divisible by the LSTM model length. If minimum shot length is less than the rnn_length, then the patch length is equal to the rnn_length
-    '''
-
-    def __init__(self,conf,normalizer=None):
+    def __init__(self, conf, normalizer=None):
         self.conf = conf
         self.stateful = conf['model']['stateful']
         self.normalizer = normalizer
         self.verbose = True
 
-    def set_inference_mode(self,val):
+    def set_inference_mode(self, val):
         self.normalizer.set_inference_mode(val)
 
-    def training_batch_generator(self,shot_list):
-        """
-        The method implements a training batch generator as a Python generator with a while-loop.
-        It iterates indefinitely over the data set and returns one mini-batch of data at a time.
+    def training_batch_generator(self, shot_list):
+        """The method implements a training batch generator as a Python
+        generator with a while-loop.  It iterates indefinitely over the
+        data set and returns one mini-batch of data at a time.
 
-        NOTE: Can be inefficient during distributed training because one process loading data will
-        cause all other processes to stall.
+        NOTE: Can be inefficient during distributed training because one
+        process loading data will cause all other processes to stall.
 
-        Argument list: 
+        Argument list:
           - shot_list:
 
-        Returns:  
-          - One mini-batch of data and label as a Numpy array: X[start:end],y[start:end]
-          - reset_states_now: boolean flag indicating when to reset state during stateful RNN training
-          - num_so_far,num_total: number of samples generated so far and the total dataset size as per shot_list
+        Returns:
+          - One mini-batch of data and label as a Numpy array: X[start:end],
+        y[start:end]
+          - reset_states_now: boolean flag indicating when to reset state
+        during stateful RNN training
+          - num_so_far,num_total: number of samples generated so far and the
+        total dataset size as per shot_list
+
         """
         batch_size = self.conf['training']['batch_size']
         num_at_once = self.conf['training']['num_shots_at_once']
@@ -60,193 +70,238 @@ class Loader(object):
         num_so_far = 0
         while True:
             # the list of all shots
-            shot_list.shuffle() 
-            # split the list into equal-length sublists (random shots will be reused to make them equal length).
-            shot_sublists = shot_list.sublists(num_at_once,equal_size=True)
+            shot_list.shuffle()
+            # split the list into equal-length sublists (random shots will be
+            # reused to make them equal length).
+            shot_sublists = shot_list.sublists(num_at_once, equal_size=True)
             num_total = len(shot_list)
-            for (i,shot_sublist) in enumerate(shot_sublists):
-                #produce a list of equal-length chunks from this set of shots
-                X_list,y_list = self.load_as_X_y_list(shot_sublist)
-                #Each chunk will be a multiple of the batch size
-                for j,(X,y) in enumerate(zip(X_list,y_list)):
+            for (i, shot_sublist) in enumerate(shot_sublists):
+                # produce a list of equal-length chunks from this set of shots
+                X_list, y_list = self.load_as_X_y_list(shot_sublist)
+                # Each chunk will be a multiple of the batch size
+                for j, (X, y) in enumerate(zip(X_list, y_list)):
                     num_examples = X.shape[0]
                     assert(num_examples % batch_size == 0)
                     num_chunks = num_examples//batch_size
                     """
-                    The method produces batch-sized training data X and labels y as Numpy arrays to feed during training.
-                    Mini-batch dimensions are (num_examples, num_timesteps, num_dimensions_of_data)
-                    also num_examples has to be divisible by the batch_size. The i-th example and the
-                    (batchsize + 1)-th example are consecutive in time, so we do not reset the
-                    RNN internal state unless we start a new chunk.
+                    The method produces batch-sized training data X and labels
+                    y as Numpy arrays to feed during training.
+
+                    Mini-batch dimensions are (num_examples, num_timesteps,
+                    num_dimensions_of_data) also num_examples has to be
+                    divisible by the batch_size. The i-th example and the
+                    (batchsize + 1)-th example are consecutive in time, so we
+                    do not reset the RNN internal state unless we start a new
+                    chunk.
+
                     """
                     for k in range(num_chunks):
-                        #epoch_end = (i == len(shot_sublists) - 1 and j == len(X_list) -1 and k == num_chunks - 1)
+                        # epoch_end = (i == len(shot_sublists) - 1 and j ==
+                        # len(X_list) -1 and k == num_chunks - 1)
                         reset_states_now = (k == 0)
                         start = k*batch_size
                         end = (k + 1)*batch_size
-                        num_so_far += 1.0*len(shot_sublist)/(len(X_list)*num_chunks)
-                        yield X[start:end],y[start:end],reset_states_now,num_so_far,num_total
+                        num_so_far += 1.0 * \
+                            len(shot_sublist)/(len(X_list)*num_chunks)
+                        yield X[start:end], y[start:end], reset_states_now,
+                        num_so_far, num_total
             epoch += 1
 
-    def fill_training_buffer(self,Xbuff,Ybuff,end_indices,shot,is_first_fill=False):
-        sig,res = self.get_signal_result_from_shot(shot)
+    def fill_training_buffer(
+            self,
+            Xbuff,
+            Ybuff,
+            end_indices,
+            shot,
+            is_first_fill=False):
+        sig, res = self.get_signal_result_from_shot(shot)
         length = self.conf['model']['length']
-        if is_first_fill:#cut signal to random position
+        if is_first_fill:  # cut signal to random position
             cut_idx = np.random.randint(res.shape[0]-length+1)
             sig = sig[cut_idx:]
             res = res[cut_idx:]
 
         sig_len = res.shape[0]
-        sig_len = (sig_len // length)*length #make divisible by lenth
+        sig_len = (sig_len // length)*length  # make divisible by lenth
         assert(sig_len > 0)
         batch_idx = np.where(end_indices == 0)[0][0]
         if sig_len > Xbuff.shape[1]:
-            Xbuff = self.resize_buffer(Xbuff,sig_len+length)
-            Ybuff = self.resize_buffer(Ybuff,sig_len+length)
-        Xbuff[batch_idx,:sig_len,:] = sig[-sig_len:]
-        Ybuff[batch_idx,:sig_len,:] = res[-sig_len:]
+            Xbuff = self.resize_buffer(Xbuff, sig_len+length)
+            Ybuff = self.resize_buffer(Ybuff, sig_len+length)
+        Xbuff[batch_idx, :sig_len, :] = sig[-sig_len:]
+        Ybuff[batch_idx, :sig_len, :] = res[-sig_len:]
         end_indices[batch_idx] += sig_len
-        #print("Filling buffer at index {}".format(batch_idx))
-        return Xbuff,Ybuff,batch_idx
+        # print("Filling buffer at index {}".format(batch_idx))
+        return Xbuff, Ybuff, batch_idx
 
-    def return_from_training_buffer(self,Xbuff,Ybuff,end_indices):
+    def return_from_training_buffer(self, Xbuff, Ybuff, end_indices):
         length = self.conf['model']['length']
         end_indices -= length
         assert(np.all(end_indices >= 0))
-        X =  1.0*Xbuff[:,:length,:]
-        Y =  1.0*Ybuff[:,:length,:]
-        self.shift_buffer(Xbuff,length)
-        self.shift_buffer(Ybuff,length)
-        return X,Y
+        X = 1.0*Xbuff[:, :length, :]
+        Y = 1.0*Ybuff[:, :length, :]
+        self.shift_buffer(Xbuff, length)
+        self.shift_buffer(Ybuff, length)
+        return X, Y
 
-    def shift_buffer(self,buff,length):
-        buff[:,:-length,:] = buff[:,length:,:]
+    def shift_buffer(self, buff, length):
+        buff[:, :-length, :] = buff[:, length:, :]
 
-
-    def resize_buffer(self,buff,new_length):
+    def resize_buffer(self, buff, new_length):
         old_length = buff.shape[1]
         batch_size = buff.shape[0]
         num_signals = buff.shape[2]
-        new_buff = np.empty((batch_size,new_length,num_signals),dtype=self.conf['data']['floatx'])
-        new_buff[:,:old_length,:] = buff
-        #print("Resizing buffer to new length {}".format(new_length))
+        new_buff = np.empty(
+            (batch_size,
+             new_length,
+             num_signals),
+            dtype=self.conf['data']['floatx'])
+        new_buff[:, :old_length, :] = buff
+        # print("Resizing buffer to new length {}".format(new_length))
         return new_buff
 
-
-
-
-    def training_batch_generator_partial_reset(self,shot_list):
+    def training_batch_generator_partial_reset(self, shot_list):
         """
-        The method implements a training batch generator as a Python generator with a while-loop.
-        It iterates indefinitely over the data set and returns one mini-batch of data at a time.
+        The method implements a training batch generator as a Python generator
+        with a while-loop. It iterates indefinitely over the data set and
+        returns one mini-batch of data at a time.
 
-        NOTE: Can be inefficient during distributed training because one process loading data will
-        cause all other processes to stall.
+        NOTE: Can be inefficient during distributed training because one
+        process loading data will cause all other processes to stall.
 
-        Argument list: 
+        Argument list:
           - shot_list:
 
-        Returns:  
-          - One mini-batch of data and label as a Numpy array: X[start:end],y[start:end]
-          - reset_states_now: boolean flag indicating when to reset state during stateful RNN training
-          - num_so_far,num_total: number of samples generated so far and the total dataset size as per shot_list
+        Returns:
+          - One mini-batch of data and label as a Numpy array: X[start:end],
+        y[start:end]
+          - reset_states_now: boolean flag indicating when to reset state
+        during stateful RNN training
+          - num_so_far,num_total: number of samples generated so far and the
+        total dataset size as per shot_list
         """
         batch_size = self.conf['training']['batch_size']
-        length = self.conf['model']['length']
-        sig,res = self.get_signal_result_from_shot(shot_list.shots[0])
-        Xbuff = np.empty((batch_size,) + sig.shape,dtype=self.conf['data']['floatx'])
-        Ybuff = np.empty((batch_size,) + res.shape,dtype=self.conf['data']['floatx'])
-        end_indices = np.zeros(batch_size,dtype=np.int)
-        batches_to_reset = np.ones(batch_size,dtype=np.bool)
+        # length = self.conf['model']['length']
+        sig, res = self.get_signal_result_from_shot(shot_list.shots[0])
+        Xbuff = np.empty((batch_size,) + sig.shape,
+                         dtype=self.conf['data']['floatx'])
+        Ybuff = np.empty((batch_size,) + res.shape,
+                         dtype=self.conf['data']['floatx'])
+        end_indices = np.zeros(batch_size, dtype=np.int)
+        batches_to_reset = np.ones(batch_size, dtype=np.bool)
         # epoch = 0
         num_total = len(shot_list)
         num_so_far = 0
         returned = False
         num_steps = 0
         warmup_steps = self.conf['training']['batch_generator_warmup_steps']
-        is_warmup_period = num_steps < warmup_steps 
+        is_warmup_period = num_steps < warmup_steps
         is_first_fill = num_steps < batch_size
         while True:
             # the list of all shots
-            shot_list.shuffle() 
+            shot_list.shuffle()
             for i in range(len(shot_list)):
                 if self.conf['training']['ranking_difficulty_fac'] == 1.0:
                     if self.conf['data']['equalize_classes']:
                         shot = shot_list.sample_equal_classes()
                     else:
                         shot = shot_list.shots[i]
-                else: #draw the shot weighted
+                else:  # draw the shot weighted
                     shot = shot_list.sample_weighted()
                 while not np.any(end_indices == 0):
-                    X,Y = self.return_from_training_buffer(Xbuff,Ybuff,end_indices)
-                    yield X,Y,batches_to_reset,num_so_far,num_total,is_warmup_period
+                    X, Y = self.return_from_training_buffer(
+                        Xbuff, Ybuff, end_indices)
+                    yield (X, Y, batches_to_reset, num_so_far, num_total,
+                           is_warmup_period)
                     returned = True
                     num_steps += 1
                     is_warmup_period = num_steps < warmup_steps
                     is_first_fill = num_steps < batch_size
                     batches_to_reset[:] = False
 
-                Xbuff,Ybuff,batch_idx = self.fill_training_buffer(Xbuff,Ybuff,end_indices,shot,is_first_fill)
+                Xbuff, Ybuff, batch_idx = self.fill_training_buffer(
+                    Xbuff, Ybuff, end_indices, shot, is_first_fill)
                 batches_to_reset[batch_idx] = True
                 if returned and not is_warmup_period:
                     num_so_far += 1
             # epoch += 1
 
-    def fill_batch_queue(self,shot_list,queue):
+    def fill_batch_queue(self, shot_list, queue):
         print("Starting thread to fill queue")
         gen = self.training_batch_generator_partial_reset(shot_list)
         while True:
             ret = next(gen)
-            queue.put(ret,block=True,timeout=-1)
+            queue.put(ret, block=True, timeout=-1)
 
-
-    def training_batch_generator_process(self,shot_list):
+    def training_batch_generator_process(self, shot_list):
         queue = mp.Queue()
-        proc = mp.Process(target = self.fill_batch_queue,args=(shot_list,queue))
+        proc = mp.Process(
+            target=self.fill_batch_queue, args=(
+                shot_list, queue))
         proc.start()
         while True:
             yield queue.get(True)
         proc.join()
         queue.close()
 
-    def load_as_X_y_list(self,shot_list,verbose=False,prediction_mode=False):
+    def load_as_X_y_list(
+            self,
+            shot_list,
+            verbose=False,
+            prediction_mode=False):
         """
-        The method turns a ShotList into a set of equal-sized patches which contain a number of examples
-        that is a multiple of the batch size.
-        Initially, shots are "light" meaning signal amd disruption related attributes are not filled.
-        By invoking Loader.get_signals_results_from_shotlist the shot information is filled and stored in
-        the object in memory. Next, patches are made, finally patches are arranged into batch input shape expected by RNN model.
+        The method turns a ShotList into a set of equal-sized patches which
+        contain a number of examples that is a multiple of the batch size.
+        Initially, shots are "light" meaning signal amd disruption related
+        attributes are not filled.
+        By invoking Loader.get_signals_results_from_shotlist the
+        shot information is filled and stored in the object in memory. Next,
+        patches are made, finally patches are arranged into batch input shape
+        expected by RNN model.
 
-        Performs calls to: get_signals_results_from_shotlist, make_patches, arange_patches
+        Performs calls to: get_signals_results_from_shotlist, make_patches,
+        arange_patches
 
         Argument list:
           - shot_list: a ShotList
           - verbose: TO BE DEPRECATED, self.verbose data member is used instead
           - prediction_mode: unused
- 
+
         Returns:
           - X_list,y_list: lists of Numpy arrays of batch input shape
-        """
-        signals,results,total_length = self.get_signals_results_from_shotlist(shot_list) 
-        sig_patches, res_patches = self.make_patches(signals,results)
 
-        X_list,y_list = self.arange_patches(sig_patches,res_patches)
+        """
+        # TODO(KGF): check tuple unpack
+        (signals, results,
+         total_length) = self.get_signals_results_from_shotlist(shot_list)
+        sig_patches, res_patches = self.make_patches(signals, results)
+
+        X_list, y_list = self.arange_patches(sig_patches, res_patches)
 
         effective_length = len(res_patches)*len(res_patches[0])
         if self.verbose:
-            print('multiplication factor: {}'.format(1.0*effective_length/total_length))
-            print('effective/total length : {}/{}'.format(effective_length,total_length))
-            print('patch length: {} num patches: {}'.format(len(res_patches[0]),len(res_patches)))
-        return X_list,y_list
+            print('multiplication factor: {}'.format(
+                1.0 * effective_length / total_length))
+            print('effective/total length : {}/{}'.format(
+                effective_length, total_length))
+            print('patch length: {} num patches: {}'.format(
+                len(res_patches[0]), len(res_patches)))
+        return X_list, y_list
 
-    def load_as_X_y_pred(self,shot_list,verbose=False,custom_batch_size=None):
-        signals,results,shot_lengths,disruptive = self.get_signals_results_from_shotlist(shot_list,prediction_mode=True) 
-        sig_patches, res_patches = self.make_prediction_patches(signals,results)
-        X,y = self.arange_patches_single(sig_patches,res_patches,prediction_mode=True,custom_batch_size=custom_batch_size)
-        return X,y,shot_lengths,disruptive
+    def load_as_X_y_pred(self, shot_list, verbose=False,
+                         custom_batch_size=None):
+        (signals, results, shot_lengths,
+         disruptive) = self.get_signals_results_from_shotlist(
+             shot_list, prediction_mode=True)
+        sig_patches, res_patches = self.make_prediction_patches(signals,
+                                                                results)
+        X, y = self.arange_patches_single(sig_patches, res_patches,
+                                          prediction_mode=True,
+                                          custom_batch_size=custom_batch_size)
+        return X, y, shot_lengths, disruptive
 
-
-    def get_signals_results_from_shotlist(self,shot_list,prediction_mode=False):
+    def get_signals_results_from_shotlist(self, shot_list,
+                                          prediction_mode=False):
         prepath = self.conf['paths']['processed_prepath']
         use_signals = self.conf['paths']['use_signals']
         signals = []
@@ -255,20 +310,20 @@ class Loader(object):
         shot_lengths = []
         total_length = 0
         for shot in shot_list:
-            assert(isinstance(shot,Shot))
+            assert(isinstance(shot, Shot))
             assert(shot.valid)
             shot.restore(prepath)
 
             if self.normalizer is not None:
                 self.normalizer.apply(shot)
             else:
-                print('Warning, no normalization. Training data may be poorly conditioned')
-
-
+                print('Warning, no normalization. ',
+                      'Training data may be poorly conditioned')
 
             if self.conf['training']['use_mock_data']:
-                signal,ttd = self.get_mock_data()
-            ttd,signal = shot.get_data_arrays(use_signals,self.conf['data']['floatx'])
+                signal, ttd = self.get_mock_data()
+            ttd, signal = shot.get_data_arrays(
+                use_signals, self.conf['data']['floatx'])
             if len(ttd) < self.conf['model']['length']:
                 print(ttd)
                 print(shot)
@@ -279,29 +334,31 @@ class Loader(object):
             shot_lengths.append(len(ttd))
             disruptive.append(shot.is_disruptive)
             if len(ttd.shape) == 1:
-                results.append(np.expand_dims(ttd,axis=1))
+                results.append(np.expand_dims(ttd, axis=1))
             else:
                 results.append(ttd)
             shot.make_light()
         if not prediction_mode:
-            return signals,results,total_length
+            return signals, results, total_length
         else:
-            return signals,results,shot_lengths,disruptive
+            return signals, results, shot_lengths, disruptive
 
-    def get_signal_result_from_shot(self,shot,prediction_mode=False):
+    def get_signal_result_from_shot(self, shot, prediction_mode=False):
         prepath = self.conf['paths']['processed_prepath']
         use_signals = self.conf['paths']['use_signals']
-        assert(isinstance(shot,Shot))
+        assert(isinstance(shot, Shot))
         assert(shot.valid)
         shot.restore(prepath)
         if self.normalizer is not None:
             self.normalizer.apply(shot)
         else:
-            print('Warning, no normalization. Training data may be poorly conditioned')
+            print('Warning, no normalization. ',
+                  'Training data may be poorly conditioned')
 
         if self.conf['training']['use_mock_data']:
-            signal,ttd = self.get_mock_data()
-        ttd,signal = shot.get_data_arrays(use_signals,self.conf['data']['floatx'])
+            signal, ttd = self.get_mock_data()
+        ttd, signal = shot.get_data_arrays(
+            use_signals, self.conf['data']['floatx'])
         if len(ttd) < self.conf['model']['length']:
             print(ttd)
             print(shot)
@@ -310,15 +367,14 @@ class Loader(object):
             exit(1)
 
         if len(ttd.shape) == 1:
-            ttd = np.expand_dims(ttd,axis=1)
+            ttd = np.expand_dims(ttd, axis=1)
         shot.make_light()
         if not prediction_mode:
-            return signal,ttd
+            return signal, ttd
         else:
-            return signal,ttd,shot.is_disruptive
+            return signal, ttd, shot.is_disruptive
 
-
-    def batch_output_to_array(self,output,batch_size = None):
+    def batch_output_to_array(self, output, batch_size=None):
         if batch_size is None:
             batch_size = self.conf['model']['pred_batch_size']
         assert(output.shape[0] % batch_size == 0)
@@ -328,152 +384,171 @@ class Loader(object):
 
         outs = []
         for patch_idx in range(batch_size):
-            out = np.empty((num_chunks*num_timesteps,feature_size))
+            out = np.empty((num_chunks*num_timesteps, feature_size))
             for chunk in range(num_chunks):
-                out[chunk*num_timesteps:(chunk+1)*num_timesteps,:] = output[chunk*batch_size+patch_idx,:,:]
+                out[chunk*num_timesteps:(chunk + 1)*num_timesteps, :] = output[
+                    chunk * batch_size + patch_idx, :, :]
             outs.append(out)
-        return outs 
+        return outs
 
-
-    def make_deterministic_patches(self,signals,results):
+    def make_deterministic_patches(self, signals, results):
         num_timesteps = self.conf['model']['length']
         sig_patches = []
         res_patches = []
-        min_len = self.get_min_len(signals,num_timesteps)
-        for sig,res in zip(signals,results):
-            sig_patch, res_patch =  self.make_deterministic_patches_from_single_array(sig,res,min_len)
+        min_len = self.get_min_len(signals, num_timesteps)
+        for sig, res in zip(signals, results):
+            (sig_patch,
+             res_patch) = self.make_deterministic_patches_from_single_array(
+                sig, res, min_len)
             sig_patches += sig_patch
             res_patches += res_patch
         return sig_patches, res_patches
 
-    def make_deterministic_patches_from_single_array(self,sig,res,min_len):
+    def make_deterministic_patches_from_single_array(self, sig, res, min_len):
         sig_patches = []
         res_patches = []
         if len(sig) <= min_len:
             print('signal length: {}'.format(len(sig)))
         assert(min_len <= len(sig))
-        for start in range(0,len(sig)-min_len,min_len):
+        for start in range(0, len(sig)-min_len, min_len):
             sig_patches.append(sig[start:start+min_len])
             res_patches.append(res[start:start+min_len])
         sig_patches.append(sig[-min_len:])
         res_patches.append(res[-min_len:])
-        return sig_patches,res_patches
+        return sig_patches, res_patches
 
-    def make_random_patches(self,signals,results,num):
+    def make_random_patches(self, signals, results, num):
         num_timesteps = self.conf['model']['length']
         sig_patches = []
         res_patches = []
-        min_len = self.get_min_len(signals,num_timesteps)
+        min_len = self.get_min_len(signals, num_timesteps)
         for i in range(num):
-            idx= np.random.randint(len(signals))
-            sig_patch, res_patch =  self.make_random_patch_from_array(signals[idx],results[idx],min_len)
+            idx = np.random.randint(len(signals))
+            sig_patch, res_patch = self.make_random_patch_from_array(
+                signals[idx], results[idx], min_len)
             sig_patches.append(sig_patch)
             res_patches.append(res_patch)
-        return sig_patches,res_patches
+        return sig_patches, res_patches
 
-    def make_random_patch_from_array(self,sig,res,min_len):
+    def make_random_patch_from_array(self, sig, res, min_len):
         start = np.random.randint(len(sig) - min_len+1)
-        return sig[start:start+min_len],res[start:start+min_len]
-        
+        return sig[start:start+min_len], res[start:start+min_len]
 
-    def get_min_len(self,arrs,length):
-        min_len = min([len(a) for a in arrs] + [self.conf['training']['max_patch_length']])
-        min_len = max(1,min_len // length) * length 
+    def get_min_len(self, arrs, length):
+        min_len = min([len(a) for a in arrs]
+                      + [self.conf['training']['max_patch_length']])
+        min_len = max(1, min_len // length) * length
         return min_len
 
-
-    def get_max_len(self,arrs,length):
+    def get_max_len(self, arrs, length):
         max_len = max([len(a) for a in arrs])
-        max_len = int(np.ceil(1.0*max_len / length) * length )
+        max_len = int(np.ceil(1.0*max_len / length) * length)
         return max_len
 
-    def make_patches(self,signals,results):
-        """
-        A patch is a subset of shot's time/signal profile having a fixed length, equal among all patches. 
-        Patch size is approximately equal to the minimum shot length. More precisely: it is equal
-        to the max(1, min_len//rnn_length)*rnn_length - the largest number less or equal to the minimum shot length divisible by the LSTM model length. If minimum shot length is less than the rnn_length, then the patch length is equal to the rnn_length
+    def make_patches(self, signals, results):
+        """A patch is a subset of shot's time/signal profile having a fixed
+        length, equal among all patches.  Patch size is approximately equal to
+        the minimum shot length. More precisely: it is equal to the max(1,
+        min_len//rnn_length)*rnn_length - the largest number less or equal to
+        the minimum shot length divisible by the LSTM model length. If minimum
+        shot length is less than the rnn_length, then the patch length is equal
+        to the rnn_length
 
-        Since shot lengthes are not multiples of the minimum shot length in general, 
-        some non-deterministic fraction of patches is created. See:
+        Since shot lengthes are not multiples of the minimum shot length in
+        general, some non-deterministic fraction of patches is created. See:
 
         Deterministic patching:
 
         Random patching:
 
 
-        Argument list: 
-          - signals: a list of 1D Numpy array of doubles containing signal values (a plasma property). 
-                     Numpy arrays are shot-sized
-          - results: a list of 1D Numpy array of doubles containing disruption times or -1 if a shot 
-                     is non-disruptive. Numpy arrays are shot-sized
+        Argument list:
+          - signals: a list of 1D Numpy array of doubles containing signal
+        values (a plasma property). Numpy arrays are shot-sized
+          - results: a list of 1D Numpy array of doubles containing disruption
+        times or -1 if a shot is non-disruptive. Numpy arrays are shot-sized
 
-          NOTE: signals and results are parallel lists. Since Arrays are shot-sized, the shape veries across the list
+          NOTE: signals and results are parallel lists. Since Arrays are
+          shot-sized, the shape veries across the list
 
-        Returns:  
-          - sig_patches_det + sig_patches_rand: (concatenated) list of 1D Numpy arrays of doubles containing signal values. 
-                     Numpy arrays are patch-sized
-          - res_patches_det + res_patches_rand: (concatenated) a list of 1D Numpy array of doubles containing disruption times 
-                     or -1 if a shot is non-disruptive. Numpy arrays are patch-sized
-          NOTE: sig_patches_det + sig_patches_rand and res_patches_det + res_patches_rand are prallel lists
-                All arrays in the list have identical shapes.
+
+        Returns:
+          - sig_patches_det + sig_patches_rand: (concatenated) list of 1D Numpy
+        arrays of doubles containing signal values. Numpy arrays are
+        patch-sized
+          - res_patches_det + res_patches_rand: (concatenated) a list of 1D
+        Numpy array of doubles containing disruption times or -1 if a shot is
+        non-disruptive. Numpy arrays are patch-sized
+          NOTE: sig_patches_det + sig_patches_rand and res_patches_det +
+        res_patches_rand are prallel lists. All arrays in the list have
+        identical shapes.
+
         """
-        total_num = self.conf['training']['batch_size'] 
-        sig_patches_det,res_patches_det = self.make_deterministic_patches(signals,results)
+        total_num = self.conf['training']['batch_size']
+        sig_patches_det, res_patches_det = self.make_deterministic_patches(
+            signals, results)
         num_already = len(sig_patches_det)
-        
+
         total_num = int(np.ceil(1.0 * num_already / total_num)) * total_num
-        
+
         num_additional = total_num - num_already
         assert(num_additional >= 0)
-        sig_patches_rand,res_patches_rand = self.make_random_patches(signals,results,num_additional)
+        sig_patches_rand, res_patches_rand = self.make_random_patches(
+            signals, results, num_additional)
         if self.verbose:
-            print('random to deterministic ratio: {}/{}'.format(num_additional,num_already))
-        return sig_patches_det + sig_patches_rand,res_patches_det + res_patches_rand 
+            print(
+                'random to deterministic ratio: {}/{}'.format(num_additional,
+                                                              num_already))
+        return (sig_patches_det + sig_patches_rand,
+                res_patches_det + res_patches_rand)
 
-
-    def make_prediction_patches(self,signals,results):
-        #total_num = self.conf['training']['batch_size'] 
+    def make_prediction_patches(self, signals, results):
+        # total_num = self.conf['training']['batch_size']
         num_timesteps = self.conf['model']['pred_length']
         sig_patches = []
         res_patches = []
-        max_len = self.get_max_len(signals,num_timesteps)
-        for sig,res in zip(signals,results):
-            sig_patches.append(Loader.pad_array_to_length(sig,max_len))
-            res_patches.append(Loader.pad_array_to_length(res,max_len))
+        max_len = self.get_max_len(signals, num_timesteps)
+        for sig, res in zip(signals, results):
+            sig_patches.append(Loader.pad_array_to_length(sig, max_len))
+            res_patches.append(Loader.pad_array_to_length(res, max_len))
         return sig_patches, res_patches
 
     @staticmethod
-    def pad_array_to_length(arr,length):
-        dlength = max(0,length - arr.shape[0])
-        tuples = [(0,dlength)]
+    def pad_array_to_length(arr, length):
+        dlength = max(0, length - arr.shape[0])
+        tuples = [(0, dlength)]
         for l in arr.shape[1:]:
-            tuples.append((0,0))
-        return np.pad(arr,tuples,mode='constant',constant_values=0)
+            tuples.append((0, 0))
+        return np.pad(arr, tuples, mode='constant', constant_values=0)
 
-
-
-
-    def arange_patches(self,sig_patches,res_patches):
+    def arange_patches(self, sig_patches, res_patches):
         num_timesteps = self.conf['model']['length']
         batch_size = self.conf['training']['batch_size']
-        assert(len(sig_patches) % batch_size == 0) #fixed number of batches
-        assert(len(sig_patches[0]) % num_timesteps == 0) #divisible by length of RNN sequence
+        assert(len(sig_patches) % batch_size == 0)  # fixed number of batches
+        # divisible by length of RNN sequence
+        assert(len(sig_patches[0]) % num_timesteps == 0)
         num_batches = len(sig_patches) // batch_size
-        #patch_length = len(sig_patches[0])
+        # patch_length = len(sig_patches[0])
 
-        zipped = list(zip(sig_patches,res_patches))
+        zipped = list(zip(sig_patches, res_patches))
         np.random.shuffle(zipped)
-        sig_patches, res_patches = zip(*zipped) 
+        sig_patches, res_patches = zip(*zipped)
         X_list = []
         y_list = []
         for i in range(num_batches):
-            X,y = self.arange_patches_single(sig_patches[i*batch_size:(i+1)*batch_size],
-                                        res_patches[i*batch_size:(i+1)*batch_size])
+            X, y = self.arange_patches_single(
+                sig_patches[i*batch_size:(i+1)*batch_size],
+                res_patches[i*batch_size:(i+1)*batch_size])
             X_list.append(X)
             y_list.append(y)
-        return X_list,y_list
+        return X_list, y_list
 
-    def arange_patches_single(self,sig_patches,res_patches,prediction_mode=False,custom_batch_size=None):
+    def arange_patches_single(
+            self,
+            sig_patches,
+            res_patches,
+            prediction_mode=False,
+            custom_batch_size=None):
         if prediction_mode:
             num_timesteps = self.conf['model']['pred_length']
             batch_size = self.conf['model']['pred_batch_size']
@@ -492,27 +567,32 @@ class Loader(object):
             num_answers = 1
         else:
             num_answers = res_patches[0].shape[1]
-        
-        X = np.zeros((num_chunks*batch_size,num_timesteps,num_dimensions_of_data))
-        if return_sequences:
-            y = np.zeros((num_chunks*batch_size,num_timesteps,num_answers))
-        else:
-            y = np.zeros((num_chunks*batch_size,num_answers))
 
-        
+        X = np.zeros(
+            (num_chunks*batch_size,
+             num_timesteps,
+             num_dimensions_of_data))
+        if return_sequences:
+            y = np.zeros((num_chunks*batch_size, num_timesteps, num_answers))
+        else:
+            y = np.zeros((num_chunks*batch_size, num_answers))
+
         for chunk_idx in range(num_chunks):
             src_start = chunk_idx*num_timesteps
             src_end = (chunk_idx+1)*num_timesteps
             for patch_idx in range(batch_size):
-                X[chunk_idx*batch_size + patch_idx,:,:] = sig_patches[patch_idx][src_start:src_end]
+                X[chunk_idx*batch_size + patch_idx, :,
+                    :] = sig_patches[patch_idx][src_start:src_end]
                 if return_sequences:
-                    y[chunk_idx*batch_size + patch_idx,:,:] = res_patches[patch_idx][src_start:src_end]
+                    y[chunk_idx*batch_size + patch_idx, :,
+                        :] = res_patches[patch_idx][src_start:src_end]
                 else:
-                    y[chunk_idx*batch_size + patch_idx,:] = res_patches[patch_idx][src_end-1]
-        return X,y
+                    y[chunk_idx*batch_size + patch_idx,
+                        :] = res_patches[patch_idx][src_end-1]
+        return X, y
 
-    def load_as_X_y(self,shot,verbose=False,prediction_mode=False):
-        assert(isinstance(shot,Shot))
+    def load_as_X_y(self, shot, verbose=False, prediction_mode=False):
+        assert(isinstance(shot, Shot))
         assert(shot.valid)
         prepath = self.conf['paths']['processed_prepath']
         return_sequences = self.conf['model']['return_sequences']
@@ -521,111 +601,116 @@ class Loader(object):
         if self.normalizer is not None:
             self.normalizer.apply(shot)
         else:
-            print('Warning, no normalization. Training data may be poorly conditioned')
-
+            print('Warning, no normalization. ',
+                  'Training data may be poorly conditioned')
         signals = shot.signals
         ttd = shot.ttd
 
         if self.conf['training']['use_mock_data']:
-            signals,ttd = self.get_mock_data()
+            signals, ttd = self.get_mock_data()
 
         # if not self.stateful:
         #     X,y = self.array_to_path_and_external_pred(signals,ttd)
         # else:
-        X,y = self.array_to_path_and_external_pred_cut(signals,ttd,
-                return_sequences=return_sequences,prediction_mode=prediction_mode)
+        X, y = self.array_to_path_and_external_pred_cut(
+            signals, ttd, return_sequences=return_sequences,
+            prediction_mode=prediction_mode)
 
         shot.make_light()
-        return  X,y#X,y
+        return X, y  # X,y
 
     def get_mock_data(self):
-        signals = linspace(0,4*pi,10000)
-        rand_idx = randint(6000)
-        lgth = randint(1000,3000)
+        signals = np.linspace(0, 4*np.pi, 10000)
+        rand_idx = np.randint(6000)
+        lgth = np.randint(1000, 3000)
         signals = signals[rand_idx:rand_idx+lgth]
-        #ttd[-100:] = 1
-        signals = vstack([signals]*8)
+        # ttd[-100:] = 1
+        signals = np.vstack([signals]*8)
         signals = signals.T
-        signals[:,0] = 0.5 + 0.5*sin(signals[:,0])
-        signals[:,1] = 0.5# + 0.5*cos(signals[:,1])
-        signals[:,2] = 0.5 + 0.5*sin(2*signals[:,2])
-        signals[:,3:] *= 0
+        signals[:, 0] = 0.5 + 0.5*np.sin(signals[:, 0])
+        signals[:, 1] = 0.5  # + 0.5*cos(signals[:,1])
+        signals[:, 2] = 0.5 + 0.5*np.sin(2*signals[:, 2])
+        signals[:, 3:] *= 0
         offset = 100
-        ttd = 0.0*signals[:,0]
-        ttd[offset:] = 1.0*signals[:-offset,0]
-        mask = ttd > mean(ttd)
+        ttd = 0.0*signals[:, 0]
+        ttd[offset:] = 1.0*signals[:-offset, 0]
+        mask = ttd > np.mean(ttd)
         ttd[~mask] = 0
-        #mean(signals[:,:2],1)
-        return signals,ttd
+        # mean(signals[:,:2],1)
+        return signals, ttd
 
-    def array_to_path_and_external_pred_cut(self,arr,res,return_sequences=False,prediction_mode=False):
+    def array_to_path_and_external_pred_cut(
+            self,
+            arr,
+            res,
+            return_sequences=False,
+            prediction_mode=False):
         num_timesteps = self.conf['model']['length']
         skip = self.conf['model']['skip']
         if prediction_mode:
             num_timesteps = self.conf['model']['pred_length']
             if not return_sequences:
                 num_timesteps = 1
-            skip = num_timesteps #batchsize = 1!
-        assert(shape(arr)[0] == shape(res)[0])
+            skip = num_timesteps  # batchsize = 1!
+        assert(np.shape(arr)[0] == np.shape(res)[0])
         num_chunks = len(arr) // num_timesteps
         arr = arr[-num_chunks*num_timesteps:]
         res = res[-num_chunks*num_timesteps:]
-        assert(shape(arr)[0] == shape(res)[0])
+        assert(np.shape(arr)[0] == np.shape(res)[0])
         X = []
         y = []
         i = 0
 
         chunk_range = range(num_chunks-1)
-        i_range = range(1,num_timesteps+1,skip)
+        i_range = range(1, num_timesteps+1, skip)
         if prediction_mode:
             chunk_range = range(num_chunks)
             i_range = range(1)
-
 
         for chunk in chunk_range:
             for i in i_range:
                 start = chunk*num_timesteps + i
                 assert(start + num_timesteps <= len(arr))
-                X.append(arr[start:start+num_timesteps,:])
+                X.append(arr[start:start+num_timesteps, :])
                 if return_sequences:
                     y.append(res[start:start+num_timesteps])
                 else:
                     y.append(res[start+num_timesteps-1:start+num_timesteps])
-        X = array(X)
-        y = array(y)
-        if len(shape(X)) == 1:
-            X = np.expand_dims(X,axis=len(shape(X)))
+        X = np.array(X)
+        y = np.array(y)
+        if len(np.shape(X)) == 1:
+            X = np.expand_dims(X, axis=len(np.shape(X)))
         if return_sequences:
-            y = np.expand_dims(y,axis=len(shape(y)))
-        return X,y
+            y = np.expand_dims(y, axis=len(np.shape(y)))
+        return X, y
 
     @staticmethod
-    def get_batch_size(batch_size,prediction_mode):
+    def get_batch_size(batch_size, prediction_mode):
         if prediction_mode:
             return 1
         else:
-            return batch_size#Loader.get_num_skips(length,skip)
+            return batch_size  # Loader.get_num_skips(length,skip)
 
     @staticmethod
-    def get_num_skips(length,skip):
+    def get_num_skips(length, skip):
         return 1 + (length-1)//skip
 
 
 class ProcessGenerator(object):
-    def __init__(self,generator):
+    def __init__(self, generator):
         self.generator = generator
         self.proc = mp.Process(target=self.fill_batch_queue)
         self.queue = mp.Queue()
         self.proc.start()
-        
+
     def fill_batch_queue(self):
         print("Starting process to fetch data")
         while True:
-            self.queue.put(next(self.generator),True) 
+            self.queue.put(next(self.generator), True)
 
     def __next__(self):
         return self.queue.get(True)
-    
+
     def next(self):
         return self.__next__()
 

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -1,3 +1,16 @@
+from __future__ import print_function
+from plasma.primitives.ops import mpi_sum_f16
+from plasma.utils.performance import PerformanceAnalyzer
+from plasma.utils.processing import concatenate_sublists
+from plasma.utils.evaluation import get_loss_from_list
+from plasma.models import builder
+from plasma.models.loader import ProcessGenerator
+from plasma.utils.state_reset import reset_states  # , get_states
+from plasma.conf import conf
+from pprint import pprint
+from mpi4py import MPI
+# import mpi4py
+# import getpass
 '''
 #########################################################
 This file trains a deep learning model to predict
@@ -14,9 +27,8 @@ This work was supported by the DOE CSGF program.
 #########################################################
 '''
 
-from __future__ import print_function
 import os
-import sys 
+import sys
 import time
 import datetime
 import numpy as np
@@ -25,20 +37,14 @@ import random
 from functools import partial
 import socket
 sys.setrecursionlimit(10000)
-import getpass
 
-#import keras sequentially because it otherwise reads from ~/.keras/keras.json with too many threads.
-#from mpi_launch_tensorflow import get_mpi_task_index 
-import mpi4py
-from mpi4py import MPI
+# import keras sequentially because it otherwise reads from ~/.keras/keras.json
+# with too many threads:
+# from mpi_launch_tensorflow import get_mpi_task_index
 comm = MPI.COMM_WORLD
 task_index = comm.Get_rank()
 num_workers = comm.Get_size()
 
-from pprint import pprint
-from plasma.conf import conf
-from plasma.utils.state_reset import reset_states,get_states
-from plasma.models.loader import ProcessGenerator
 
 NUM_GPUS = conf['num_gpus']
 MY_GPU = task_index % NUM_GPUS
@@ -46,511 +52,621 @@ MY_GPU = task_index % NUM_GPUS
 backend = conf['model']['backend']
 
 if backend == 'tf' or backend == 'tensorflow':
-    if NUM_GPUS > 1: os.environ['CUDA_VISIBLE_DEVICES'] = '{}'.format(MY_GPU)#,mode=NanGuardMode'
+    if NUM_GPUS > 1:
+        os.environ['CUDA_VISIBLE_DEVICES'] = '{}'.format(
+            MY_GPU)  # ,mode=NanGuardMode'
     os.environ['KERAS_BACKEND'] = 'tensorflow'
     import tensorflow as tf
     from keras.backend.tensorflow_backend import set_session
-    gpu_options = tf.GPUOptions(per_process_gpu_memory_fraction=0.95, allow_growth=True)
+    gpu_options = tf.GPUOptions(
+        per_process_gpu_memory_fraction=0.95,
+        allow_growth=True)
     config = tf.ConfigProto(gpu_options=gpu_options)
     set_session(tf.Session(config=config))
 else:
     os.environ['KERAS_BACKEND'] = 'theano'
-    base_compile_dir = '{}/tmp/{}-{}'.format(conf['paths']['output_path'],socket.gethostname(),task_index)
-    os.environ['THEANO_FLAGS'] = 'device=gpu{},floatX=float32,base_compiledir={}'.format(MY_GPU,base_compile_dir)#,mode=NanGuardMode'
-    import theano
-#import keras
+    base_compile_dir = '{}/tmp/{}-{}'.format(
+        conf['paths']['output_path'], socket.gethostname(), task_index)
+    os.environ['THEANO_FLAGS'] = (
+        'device=gpu{},floatX=float32,base_compiledir={}'.format(
+            MY_GPU, base_compile_dir))  # ,mode=NanGuardMode'
+    # import theano
+# import keras
 for i in range(num_workers):
-  comm.Barrier()
-  if i == task_index:
-    print('[{}] importing Keras'.format(task_index))
-    from keras import backend as K
-    from keras.optimizers import *
-    from keras.utils.generic_utils import Progbar 
-    import keras.callbacks as cbks
+    comm.Barrier()
+    if i == task_index:
+        print('[{}] importing Keras'.format(task_index))
+        from keras import backend as K
+        # from keras.optimizers import *
+        from keras.utils.generic_utils import Progbar
+        import keras.callbacks as cbks
 
-from plasma.models import builder
-from plasma.utils.evaluation import get_loss_from_list
-from plasma.utils.processing import concatenate_sublists
-from plasma.utils.performance import PerformanceAnalyzer
-from plasma.primitives.ops import mpi_sum_f16
 
 if task_index == 0:
     pprint(conf)
 
 
-
 class MPIOptimizer(object):
-  def __init__(self,lr):
-    self.lr = lr
-    self.iterations = 0
+    def __init__(self, lr):
+        self.lr = lr
+        self.iterations = 0
 
-  def get_deltas(self,raw_deltas):
-    raise NotImplementedError
+    def get_deltas(self, raw_deltas):
+        raise NotImplementedError
 
-  def set_lr(self,lr):
-    self.lr = lr
+    def set_lr(self, lr):
+        self.lr = lr
+
 
 class MPISGD(MPIOptimizer):
-  def __init__(self,lr):
-    super(MPISGD,self).__init__(lr)
+    def __init__(self, lr):
+        super(MPISGD, self).__init__(lr)
 
-  def get_deltas(self,raw_deltas):
-    deltas = []
-    for g in raw_deltas:
-      deltas.append(self.lr*g)
+    def get_deltas(self, raw_deltas):
+        deltas = []
+        for g in raw_deltas:
+            deltas.append(self.lr*g)
 
-    self.iterations += 1
-    return deltas
+        self.iterations += 1
+        return deltas
+
 
 class MPIMomentumSGD(MPIOptimizer):
     def __init__(self, lr):
         super(MPIMomentumSGD, self).__init__(lr)
         self.momentum = 0.9
 
-    def get_deltas(self, raw_deltas): 
+    def get_deltas(self, raw_deltas):
         deltas = []
 
         if self.iterations == 0:
             self.velocity_list = [np.zeros_like(g) for g in raw_deltas]
 
-        for (i,g) in enumerate(raw_deltas):
-            self.velocity_list[i] = self.momentum * self.velocity_list[i] + self.lr * g
+        for (i, g) in enumerate(raw_deltas):
+            self.velocity_list[i] = (
+                self.momentum * self.velocity_list[i] + self.lr * g)
             deltas.append(self.velocity_list[i])
 
         self.iterations += 1
 
         return deltas
 
+
 class MPIAdam(MPIOptimizer):
-  def __init__(self,lr):
-    super(MPIAdam,self).__init__(lr)
-    self.beta_1 = 0.9
-    self.beta_2 = 0.999
-    self.eps = 1e-8
+    def __init__(self, lr):
+        super(MPIAdam, self).__init__(lr)
+        self.beta_1 = 0.9
+        self.beta_2 = 0.999
+        self.eps = 1e-8
 
-  def get_deltas(self,raw_deltas):
+    def get_deltas(self, raw_deltas):
 
-    if self.iterations == 0:
-      self.m_list = [np.zeros_like(g) for g in raw_deltas]
-      self.v_list = [np.zeros_like(g) for g in raw_deltas]
+        if self.iterations == 0:
+            self.m_list = [np.zeros_like(g) for g in raw_deltas]
+            self.v_list = [np.zeros_like(g) for g in raw_deltas]
 
-    t = self.iterations + 1
-    lr_t = self.lr * np.sqrt(1-self.beta_2**t)/(1-self.beta_1**t)
-    deltas = []
-    for (i,g) in enumerate(raw_deltas):
-      m_t = (self.beta_1 * self.m_list[i]) + (1 - self.beta_1) * g
-      v_t = (self.beta_2 * self.v_list[i]) + (1 - self.beta_2) * (g**2)
-      delta_t = lr_t * m_t / (np.sqrt(v_t) + self.eps)
-      deltas.append(delta_t)
-      self.m_list[i] = m_t
-      self.v_list[i] = v_t
+        t = self.iterations + 1
+        lr_t = self.lr * np.sqrt(1-self.beta_2**t)/(1-self.beta_1**t)
+        deltas = []
+        for (i, g) in enumerate(raw_deltas):
+            m_t = (self.beta_1 * self.m_list[i]) + (1 - self.beta_1) * g
+            v_t = (self.beta_2 * self.v_list[i]) + (1 - self.beta_2) * (g**2)
+            delta_t = lr_t * m_t / (np.sqrt(v_t) + self.eps)
+            deltas.append(delta_t)
+            self.m_list[i] = m_t
+            self.v_list[i] = v_t
 
-    self.iterations += 1
+        self.iterations += 1
 
-    return deltas
+        return deltas
 
 
 class Averager(object):
-  def __init__(self):
-    self.steps = 0
-    self.val = 0.0
+    def __init__(self):
+        self.steps = 0
+        self.val = 0.0
 
-  def add_val(self,val):
-    self.val = (self.steps * self.val + 1.0 * val)/(self.steps + 1.0)
-    self.steps += 1
+    def add_val(self, val):
+        self.val = (self.steps * self.val + 1.0 * val)/(self.steps + 1.0)
+        self.steps += 1
 
-  def get_val(self):
-    return self.val
+    def get_val(self):
+        return self.val
 
 
 class MPIModel():
-  def __init__(self,model,optimizer,comm,batch_iterator,batch_size,num_replicas=None,warmup_steps=1000,lr=0.01,num_batches_minimum=100):
-    random.seed(task_index)
-    np.random.seed(task_index)
-    self.start_time = time.time()
-    self.epoch = 0
-    self.num_so_far = 0
-    self.num_so_far_accum = 0
-    self.num_so_far_indiv = 0
-    self.model = model
-    self.optimizer = optimizer
-    self.max_lr = 0.1
-    self.DUMMY_LR = 0.001
-    self.comm = comm
-    self.batch_size = batch_size
-    self.batch_iterator = batch_iterator
-    self.set_batch_iterator_func()
-    self.warmup_steps=warmup_steps
-    self.num_batches_minimum=num_batches_minimum
-    self.num_workers = comm.Get_size()
-    self.task_index = comm.Get_rank()
-    self.history = cbks.History()
-    self.model.stop_training = False
-    if num_replicas is None or num_replicas < 1 or num_replicas > self.num_workers:
-        self.num_replicas = self.num_workers
-    else:
-        self.num_replicas = num_replicas
-    self.lr = lr/(1.0+self.num_replicas/100.0) if (lr < self.max_lr) else self.max_lr/(1.0+self.num_replicas/100.0)
+    def __init__(
+            self,
+            model,
+            optimizer,
+            comm,
+            batch_iterator,
+            batch_size,
+            num_replicas=None,
+            warmup_steps=1000,
+            lr=0.01,
+            num_batches_minimum=100):
+        random.seed(task_index)
+        np.random.seed(task_index)
+        self.start_time = time.time()
+        self.epoch = 0
+        self.num_so_far = 0
+        self.num_so_far_accum = 0
+        self.num_so_far_indiv = 0
+        self.model = model
+        self.optimizer = optimizer
+        self.max_lr = 0.1
+        self.DUMMY_LR = 0.001
+        self.comm = comm
+        self.batch_size = batch_size
+        self.batch_iterator = batch_iterator
+        self.set_batch_iterator_func()
+        self.warmup_steps = warmup_steps
+        self.num_batches_minimum = num_batches_minimum
+        self.num_workers = comm.Get_size()
+        self.task_index = comm.Get_rank()
+        self.history = cbks.History()
+        self.model.stop_training = False
+        if (num_replicas is None or num_replicas < 1
+                or num_replicas > self.num_workers):
+            self.num_replicas = self.num_workers
+        else:
+            self.num_replicas = num_replicas
+        self.lr = (
+            lr/(1.0+self.num_replicas/100.0) if (lr < self.max_lr)
+            else self.max_lr/(1.0+self.num_replicas/100.0)
+            )
+
+    def set_batch_iterator_func(self):
+        self.batch_iterator_func = ProcessGenerator(self.batch_iterator())
+
+    def close(self):
+        self.batch_iterator_func.__exit__()
+
+    def set_lr(self, lr):
+        self.lr = lr
+
+    def save_weights(self, path, overwrite=False):
+        self.model.save_weights(path, overwrite=overwrite)
+
+    def load_weights(self, path):
+        self.model.load_weights(path)
+
+    def compile(self, optimizer, clipnorm, loss='mse'):
+        # TODO(KGF): check the following import taken from runner.py
+        # Was not in this file, originally.
+        from keras.optimizers import SGD, Adam, RMSprop, Nadam, TFOptimizer
+        if optimizer == 'sgd':
+            optimizer_class = SGD(lr=self.DUMMY_LR, clipnorm=clipnorm)
+        elif optimizer == 'momentum_sgd':
+            optimizer_class = SGD(
+                lr=self.DUMMY_LR,
+                clipnorm=clipnorm,
+                decay=1e-6,
+                momentum=0.9)
+        elif optimizer == 'tf_momentum_sgd':
+            optimizer_class = TFOptimizer(
+                tf.train.MomentumOptimizer(
+                    learning_rate=self.DUMMY_LR,
+                    momentum=0.9))
+        elif optimizer == 'adam':
+            optimizer_class = Adam(lr=self.DUMMY_LR, clipnorm=clipnorm)
+        elif optimizer == 'tf_adam':
+            optimizer_class = TFOptimizer(
+                tf.train.AdamOptimizer(
+                    learning_rate=self.DUMMY_LR))
+        elif optimizer == 'rmsprop':
+            optimizer_class = RMSprop(lr=self.DUMMY_LR, clipnorm=clipnorm)
+        elif optimizer == 'nadam':
+            optimizer_class = Nadam(lr=self.DUMMY_LR, clipnorm=clipnorm)
+        else:
+            print("Optimizer not implemented yet")
+            exit(1)
+        self.model.compile(optimizer=optimizer_class, loss=loss)
+        self.ensure_equal_weights()
+
+    def ensure_equal_weights(self):
+        if task_index == 0:
+            new_weights = self.model.get_weights()
+        else:
+            new_weights = None
+        nw = comm.bcast(new_weights, root=0)
+        self.model.set_weights(nw)
+
+    def train_on_batch_and_get_deltas(self, X_batch, Y_batch, verbose=False):
+        '''
+        The purpose of the method is to perform a single gradient update over
+        one mini-batch for one model replica.  Given a mini-batch, it first
+        accesses the current model weights, performs single gradient update
+        over one mini-batch, gets new model weights, calculates weight updates
+        (deltas) by subtracting weight scalars, applies the learning rate.
+
+        It performs calls to: subtract_params, multiply_params
+
+        Argument list:
+          - X_batch: input data for one mini-batch as a Numpy array
+          - Y_batch: labels for one mini-batch as a Numpy array
+          - verbose: set verbosity level (currently unused)
+
+        Returns:
+          - deltas: a list of model weight updates
+          - loss: scalar training loss
+
+        '''
+        weights_before_update = self.model.get_weights()
+
+        loss = self.model.train_on_batch(X_batch, Y_batch)
+
+        weights_after_update = self.model.get_weights()
+        self.model.set_weights(weights_before_update)
+
+        # unscale before subtracting
+        weights_before_update = multiply_params(
+            weights_before_update, 1.0/self.DUMMY_LR)
+        weights_after_update = multiply_params(
+            weights_after_update, 1.0/self.DUMMY_LR)
+
+        deltas = subtract_params(weights_after_update, weights_before_update)
+
+        # unscale loss
+        if conf['model']['loss_scale_factor'] != 1.0:
+            deltas = multiply_params(
+                deltas, 1.0/conf['model']['loss_scale_factor'])
+
+        return deltas, loss
+
+    def get_new_weights(self, deltas):
+        return add_params(self.model.get_weights(), deltas)
+
+    def mpi_average_gradients(self, arr, num_replicas=None):
+        if num_replicas is None:
+            num_replicas = self.num_workers
+        if self.task_index >= num_replicas:
+            arr *= 0.0
+        arr_global = np.empty_like(arr)
+        if K.floatx() == 'float16':
+            self.comm.Allreduce(arr, arr_global, op=mpi_sum_f16)
+        else:
+            self.comm.Allreduce(arr, arr_global, op=MPI.SUM)
+        arr_global /= num_replicas
+        return arr_global
+
+    def mpi_average_scalars(self, val, num_replicas=None):
+        '''
+        The purpose of the method is to calculate a simple scalar arithmetic
+        mean over num_replicas.
+
+        It performs calls to: MPIModel.mpi_sum_scalars
+
+        Argument list:
+          - val: value averaged, scalar
+          - num_replicas: the size of the ensemble an average is perfromed over
+
+        Returns:
+          - val_global: scalar arithmetic mean over num_replicas
+        '''
+        val_global = self.mpi_sum_scalars(val, num_replicas)
+        val_global /= num_replicas
+        return val_global
+
+    def mpi_sum_scalars(self, val, num_replicas=None):
+        '''
+        The purpose of the method is to calculate a simple scalar arithmetic
+        mean over num_replicas using MPI allreduce action with fixed op=MPI.SIM
+
+        Argument list:
+          - val: value averaged, scalar
+          - num_replicas: the size of the ensemble an average is perfromed over
+
+        Returns:
+          - val_global: scalar arithmetic mean over num_replicas
+        '''
+        if num_replicas is None:
+            num_replicas = self.num_workers
+        if self.task_index >= num_replicas:
+            val *= 0.0
+        val_global = 0.0
+        val_global = self.comm.allreduce(val, op=MPI.SUM)
+        return val_global
+
+    def sync_deltas(self, deltas, num_replicas=None):
+        global_deltas = []
+        # default is to reduce the deltas from all workers
+        for delta in deltas:
+            global_deltas.append(
+                self.mpi_average_gradients(
+                    delta, num_replicas))
+        return global_deltas
+
+    def set_new_weights(self, deltas, num_replicas=None):
+        global_deltas = self.sync_deltas(deltas, num_replicas)
+        effective_lr = self.get_effective_lr(num_replicas)
+
+        self.optimizer.set_lr(effective_lr)
+        global_deltas = self.optimizer.get_deltas(global_deltas)
+
+        new_weights = self.get_new_weights(global_deltas)
+        self.model.set_weights(new_weights)
+
+    def build_callbacks(self, conf, callbacks_list):
+        '''
+        The purpose of the method is to set up logging and history. It is based
+        on Keras Callbacks
+        https://github.com/fchollet/keras/blob/fbc9a18f0abc5784607cd4a2a3886558efa3f794/keras/callbacks.py
+
+        Currently used callbacks include: BaseLogger, CSVLogger, EarlyStopping.
+        Other possible callbacks to add in future: RemoteMonitor,
+        LearningRateScheduler
+
+        Argument list:
+        - conf: There is a "callbacks" section in conf.yaml file.
+
+        Relevant parameters are:
+        - list: Parameter specifying additional callbacks, read
+        in the driver script and passed as an argument of type  list (see next
+        arg)
+
+        - metrics: List of quantities monitored during training and validation
+
+        - mode: one of {auto, min, max}. The decision to overwrite the current
+        save file is made based on either the maximization or the minimization
+        of the monitored quantity. For val_acc, this should be max, for
+        val_loss this should be min, etc. In auto mode, the direction is
+        automatically inferred from the name of the monitored quantity.
+
+        -monitor: Quantity used for early stopping, has to
+        be from the list of metrics
+
+        - patience: Number of epochs used to decide on whether to apply early
+          stopping or continue training
+
+        - callbacks_list: uses callbacks.list configuration parameter,
+          specifies the list of additional callbacks Returns: modified list of
+          callbacks
+
+        '''
+
+        mode = conf['callbacks']['mode']
+        monitor = conf['callbacks']['monitor']
+        patience = conf['callbacks']['patience']
+        csvlog_save_path = conf['paths']['csvlog_save_path']
+        # CSV callback is on by default
+        if not os.path.exists(csvlog_save_path):
+            os.makedirs(csvlog_save_path)
+
+        callbacks_list = conf['callbacks']['list']
+
+        callbacks = [cbks.BaseLogger()]
+        callbacks += [self.history]
+        callbacks += [cbks.CSVLogger("{}callbacks-{}.log".format(
+            csvlog_save_path,
+            datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")))]
+
+        if "earlystop" in callbacks_list:
+            callbacks += [
+                cbks.EarlyStopping(
+                    patience=patience,
+                    monitor=monitor,
+                    mode=mode)]
+        if "lr_scheduler" in callbacks_list:
+            pass
+
+        return cbks.CallbackList(callbacks)
+
+    def train_epoch(self):
+        '''
+        The purpose of the method is to perform distributed mini-batch SGD for
+        one epoch.  It takes the batch iterator function and a NN model from
+        MPIModel object, fetches mini-batches in a while-loop until number of
+        samples seen by the ensemble of workers (num_so_far) exceeds the
+        training dataset size (num_total).
+
+        During each iteration, the gradient updates (deltas) and the loss are
+        calculated for each model replica in the ensemble, weights are averaged
+        over ensemble, and the new weights are set.
+
+        It performs calls to: MPIModel.get_deltas, MPIModel.set_new_weights
+        methods
+
+        Argument list: Empty
+
+        Returns:
+          - step: epoch number
+          - ave_loss: training loss averaged over replicas
+          - curr_loss:
+          - num_so_far: the number of samples seen by ensemble of replicas to a
+        current epoch (step)
 
 
-  def set_batch_iterator_func(self):
-    self.batch_iterator_func = ProcessGenerator(self.batch_iterator())
+        Intermediate outputs and logging: debug printout of task_index (MPI),
+        epoch number, number of samples seen to a current epoch, average
+        training loss
 
-  def close(self):
-    self.batch_iterator_func.__exit__()
+        '''
 
-  def set_lr(self,lr):
-    self.lr = lr
-
-  def save_weights(self,path,overwrite=False):
-    self.model.save_weights(path,overwrite=overwrite)
-
-  def load_weights(self,path):
-    self.model.load_weights(path)
-
-  def compile(self,optimizer,clipnorm,loss='mse'):
-    if optimizer == 'sgd':
-        optimizer_class = SGD(lr=self.DUMMY_LR,clipnorm=clipnorm)
-    elif optimizer == 'momentum_sgd':
-        optimizer_class = SGD(lr=self.DUMMY_LR, clipnorm=clipnorm, decay=1e-6, momentum=0.9)
-    elif optimizer == 'tf_momentum_sgd':
-        optimizer_class = TFOptimizer(tf.train.MomentumOptimizer(learning_rate=self.DUMMY_LR,momentum=0.9))
-    elif optimizer == 'adam':
-        optimizer_class = Adam(lr=self.DUMMY_LR,clipnorm=clipnorm)
-    elif optimizer == 'tf_adam':
-        optimizer_class = TFOptimizer(tf.train.AdamOptimizer(learning_rate=self.DUMMY_LR))
-    elif optimizer == 'rmsprop':
-        optimizer_class = RMSprop(lr=self.DUMMY_LR,clipnorm=clipnorm)
-    elif optimizer == 'nadam':
-        optimizer_class = Nadam(lr=self.DUMMY_LR,clipnorm=clipnorm)
-    else:
-        print("Optimizer not implemented yet")
-        exit(1)
-    self.model.compile(optimizer=optimizer_class,loss=loss)
-    self.ensure_equal_weights()
-    
-  def ensure_equal_weights(self):
-    if task_index == 0:
-        new_weights = self.model.get_weights()
-    else:
-        new_weights = None
-    nw = comm.bcast(new_weights,root=0)
-    self.model.set_weights(nw)
-
-
-
-  def train_on_batch_and_get_deltas(self,X_batch,Y_batch,verbose=False):
-    '''
-    The purpose of the method is to perform a single gradient update over one mini-batch for one model replica.
-    Given a mini-batch, it first accesses the current model weights, performs single gradient update over one mini-batch,
-    gets new model weights, calculates weight updates (deltas) by subtracting weight scalars, applies the learning rate.
-
-    It performs calls to: subtract_params, multiply_params 
-
-    Argument list: 
-      - X_batch: input data for one mini-batch as a Numpy array
-      - Y_batch: labels for one mini-batch as a Numpy array
-      - verbose: set verbosity level (currently unused)
-
-    Returns:  
-      - deltas: a list of model weight updates
-      - loss: scalar training loss
-    '''
-    weights_before_update = self.model.get_weights()
-
-    loss = self.model.train_on_batch(X_batch,Y_batch)
-
-    weights_after_update = self.model.get_weights()
-    self.model.set_weights(weights_before_update)
- 
-    #unscale before subtracting
-    weights_before_update = multiply_params(weights_before_update,1.0/self.DUMMY_LR) 
-    weights_after_update = multiply_params(weights_after_update,1.0/self.DUMMY_LR) 
-
-    deltas = subtract_params(weights_after_update,weights_before_update)
-    
-    #unscale loss
-    if conf['model']['loss_scale_factor'] != 1.0:
-        deltas = multiply_params(deltas,1.0/conf['model']['loss_scale_factor'])
- 
-    return deltas,loss
-
-
-  def get_new_weights(self,deltas):
-    return add_params(self.model.get_weights(),deltas)
-
-  def mpi_average_gradients(self,arr,num_replicas=None):
-    if num_replicas == None:
-      num_replicas = self.num_workers 
-    if self.task_index >= num_replicas:
-      arr *= 0.0
-    arr_global = np.empty_like(arr)
-    if K.floatx() == 'float16':
-        self.comm.Allreduce(arr,arr_global,op=mpi_sum_f16)
-    else:
-        self.comm.Allreduce(arr,arr_global,op=MPI.SUM)
-    arr_global /= num_replicas
-    return arr_global
-
-
-
-  def mpi_average_scalars(self,val,num_replicas=None):
-    '''
-    The purpose of the method is to calculate a simple scalar arithmetic mean over num_replicas.
-
-    It performs calls to: MPIModel.mpi_sum_scalars
-
-    Argument list: 
-      - val: value averaged, scalar
-      - num_replicas: the size of the ensemble an average is perfromed over
-
-    Returns:  
-      - val_global: scalar arithmetic mean over num_replicas
-    '''
-    val_global = self.mpi_sum_scalars(val,num_replicas)
-    val_global /= num_replicas
-    return val_global
-
-
-  def mpi_sum_scalars(self,val,num_replicas=None):
-    '''
-    The purpose of the method is to calculate a simple scalar arithmetic mean over num_replicas using MPI allreduce action with fixed op=MPI.SIM
-
-    Argument list: 
-      - val: value averaged, scalar
-      - num_replicas: the size of the ensemble an average is perfromed over
-
-    Returns:  
-      - val_global: scalar arithmetic mean over num_replicas
-    '''
-    if num_replicas == None:
-      num_replicas = self.num_workers 
-    if self.task_index >= num_replicas:
-      val *= 0.0
-    val_global = 0.0 
-    val_global = self.comm.allreduce(val,op=MPI.SUM)
-    return val_global
-
-
-
-  def sync_deltas(self,deltas,num_replicas=None):
-    global_deltas = []
-    #default is to reduce the deltas from all workers
-    for delta in deltas:
-      global_deltas.append(self.mpi_average_gradients(delta,num_replicas))
-    return global_deltas 
-
-  def set_new_weights(self,deltas,num_replicas=None):
-    global_deltas = self.sync_deltas(deltas,num_replicas)
-    effective_lr = self.get_effective_lr(num_replicas)
-
-    self.optimizer.set_lr(effective_lr)
-    global_deltas = self.optimizer.get_deltas(global_deltas)
-
-    new_weights = self.get_new_weights(global_deltas)
-    self.model.set_weights(new_weights)
-
-  def build_callbacks(self,conf,callbacks_list):
-      '''
-      The purpose of the method is to set up logging and history. It is based on Keras Callbacks
-      https://github.com/fchollet/keras/blob/fbc9a18f0abc5784607cd4a2a3886558efa3f794/keras/callbacks.py
-
-      Currently used callbacks include: BaseLogger, CSVLogger, EarlyStopping. 
-      Other possible callbacks to add in future: RemoteMonitor, LearningRateScheduler
-
-      Argument list: 
-        - conf: There is a "callbacks" section in conf.yaml file. Relevant parameters are:
-             list: Parameter specifying additional callbacks, read in the driver script and passed as an argument of type list (see next arg)
-             metrics: List of quantities monitored during training and validation
-             mode: one of {auto, min, max}. The decision to overwrite the current save file is made based on either the maximization or the minimization of the monitored quantity. For val_acc, this should be max, for val_loss this should be min, etc. In auto mode, the direction is automatically inferred from the name of the monitored quantity. 
-             monitor: Quantity used for early stopping, has to be from the list of metrics
-             patience: Number of epochs used to decide on whether to apply early stopping or continue training
-        - callbacks_list: uses callbacks.list configuration parameter, specifies the list of additional callbacks
-      Returns: modified list of callbacks
-      '''
-
-      mode = conf['callbacks']['mode']
-      monitor = conf['callbacks']['monitor']
-      patience = conf['callbacks']['patience']
-      csvlog_save_path = conf['paths']['csvlog_save_path']
-      #CSV callback is on by default
-      if not os.path.exists(csvlog_save_path):
-          os.makedirs(csvlog_save_path)
-
-      callbacks_list = conf['callbacks']['list']
-
-      callbacks = [cbks.BaseLogger()]
-      callbacks += [self.history]
-      callbacks += [cbks.CSVLogger("{}callbacks-{}.log".format(csvlog_save_path,datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")))]
-
-      if "earlystop" in callbacks_list: 
-          callbacks += [cbks.EarlyStopping(patience=patience, monitor=monitor, mode=mode)]
-      if "lr_scheduler" in callbacks_list: 
-          pass
-      
-      return cbks.CallbackList(callbacks)
-
-  def train_epoch(self):
-    '''
-    The purpose of the method is to perform distributed mini-batch SGD for one epoch.
-    It takes the batch iterator function and a NN model from MPIModel object, fetches mini-batches
-    in a while-loop until number of samples seen by the ensemble of workers (num_so_far) exceeds the 
-    training dataset size (num_total). 
-
-    During each iteration, the gradient updates (deltas) and the loss are calculated for each model replica
-    in the ensemble, weights are averaged over ensemble, and the new weights are set.
-
-    It performs calls to: MPIModel.get_deltas, MPIModel.set_new_weights methods 
-
-    Argument list: Empty
-
-    Returns:  
-      - step: epoch number
-      - ave_loss: training loss averaged over replicas
-      - curr_loss:
-      - num_so_far: the number of samples seen by ensemble of replicas to a current epoch (step) 
-
-    Intermediate outputs and logging: debug printout of task_index (MPI), epoch number, number of samples seen to 
-    a current epoch, average training loss
-    '''
-
-    verbose = False
-    first_run = True
-    step = 0
-    loss_averager = Averager()
-    t_start = time.time()
-
-    batch_iterator_func = self.batch_iterator_func
-    num_total = 1
-    ave_loss = -1
-    curr_loss = -1
-    t0 = 0 
-    t1 = 0 
-    t2 = 0
-
-    while (self.num_so_far-self.epoch*num_total) < num_total or step < self.num_batches_minimum:
-
-      try:
-          batch_xs,batch_ys,batches_to_reset,num_so_far_curr,num_total,is_warmup_period = next(batch_iterator_func)
-      except StopIteration:
-          print("Resetting batch iterator.")
-          self.num_so_far_accum = self.num_so_far_indiv
-          self.set_batch_iterator_func()
-          batch_iterator_func = self.batch_iterator_func
-          batch_xs,batch_ys,batches_to_reset,num_so_far_curr,num_total,is_warmup_period = next(batch_iterator_func)
-      self.num_so_far_indiv = self.num_so_far_accum+num_so_far_curr
-
-      # if batches_to_reset:
-        # self.model.reset_states(batches_to_reset)
-
-      warmup_phase = (step < self.warmup_steps and self.epoch == 0)
-      num_replicas = 1 if warmup_phase else self.num_replicas
-
-      self.num_so_far = self.mpi_sum_scalars(self.num_so_far_indiv,num_replicas)
-
-      #run the model once to force compilation. Don't actually use these values.
-      if first_run:
-        first_run = False
-        t0_comp = time.time()
-        _,_ = self.train_on_batch_and_get_deltas(batch_xs,batch_ys,verbose)
-        self.comm.Barrier()
-        sys.stdout.flush()
-        print_unique('Compilation finished in {:.2f}s'.format(time.time()-t0_comp))
+        verbose = False
+        first_run = True
+        step = 0
+        loss_averager = Averager()
         t_start = time.time()
-        sys.stdout.flush()  
-      
-      if np.any(batches_to_reset):
-        reset_states(self.model,batches_to_reset)
 
-      t0 = time.time()
-      deltas,loss = self.train_on_batch_and_get_deltas(batch_xs,batch_ys,verbose)
-      t1 = time.time()
-      if not is_warmup_period:
-        self.set_new_weights(deltas,num_replicas)
-        t2 = time.time()
-        write_str_0 = self.calculate_speed(t0,t1,t2,num_replicas)
+        batch_iterator_func = self.batch_iterator_func
+        num_total = 1
+        ave_loss = -1
+        curr_loss = -1
+        t0 = 0
+        t1 = 0
+        t2 = 0
 
-        curr_loss = self.mpi_average_scalars(1.0*loss,num_replicas)
-        #if self.task_index == 0:
-          #print(self.model.get_weights()[0][0][:4])
-        loss_averager.add_val(curr_loss)
-        ave_loss = loss_averager.get_val()
-        eta = self.estimate_remaining_time(t0 - t_start,self.num_so_far-self.epoch*num_total,num_total)
-        write_str = '\r[{}] step: {} [ETA: {:.2f}s] [{:.2f}/{}], loss: {:.5f} [{:.5f}] | walltime: {:.4f} | '.format(self.task_index,step,eta,1.0*self.num_so_far,num_total,ave_loss,curr_loss,time.time()-self.start_time)
-        print_unique(write_str + write_str_0)
-        step += 1
-      else:
-        print_unique('\r[{}] warmup phase, num so far: {}'.format(self.task_index,self.num_so_far))
-        
+        while (
+            self.num_so_far
+            - self.epoch
+                * num_total) < num_total or step < self.num_batches_minimum:
 
-      
+            try:
+                (batch_xs, batch_ys, batches_to_reset, num_so_far_curr,
+                 num_total, is_warmup_period) = next(batch_iterator_func)
+            except StopIteration:
+                print("Resetting batch iterator.")
+                self.num_so_far_accum = self.num_so_far_indiv
+                self.set_batch_iterator_func()
+                batch_iterator_func = self.batch_iterator_func
+                (batch_xs, batch_ys, batches_to_reset, num_so_far_curr,
+                 num_total, is_warmup_period) = next(batch_iterator_func)
+            self.num_so_far_indiv = self.num_so_far_accum + num_so_far_curr
 
-    effective_epochs = 1.0*self.num_so_far/num_total
-    epoch_previous = self.epoch
-    self.epoch = effective_epochs
-    print_unique('\nEpoch {:.2f} finished ({:.2f} epochs passed) in {:.2f} seconds.\n'.format(1.0*self.epoch,self.epoch-epoch_previous,t2 - t_start))
-    return (step,ave_loss,curr_loss,self.num_so_far,effective_epochs)
+            # if batches_to_reset:
+            # self.model.reset_states(batches_to_reset)
 
+            warmup_phase = (step < self.warmup_steps and self.epoch == 0)
+            num_replicas = 1 if warmup_phase else self.num_replicas
 
-  def estimate_remaining_time(self,time_so_far,work_so_far,work_total):
-    eps = 1e-6
-    total_time = 1.0*time_so_far*work_total/(work_so_far + eps)
-    return total_time - time_so_far
+            self.num_so_far = self.mpi_sum_scalars(
+                self.num_so_far_indiv, num_replicas)
 
-  def get_effective_lr(self,num_replicas):
-    effective_lr = self.lr * num_replicas
-    if effective_lr > self.max_lr:
-      print_unique('Warning: effective learning rate set to {}, larger than maximum {}. Clipping.'.format(effective_lr,self.max_lr))
-      effective_lr = self.max_lr
-    return effective_lr
+            # run the model once to force compilation. Don't actually use these
+            # values.
+            if first_run:
+                first_run = False
+                t0_comp = time.time()
+                _, _ = self.train_on_batch_and_get_deltas(
+                    batch_xs, batch_ys, verbose)
+                self.comm.Barrier()
+                sys.stdout.flush()
+                print_unique(
+                    'Compilation finished in {:.2f}s'.format(
+                        time.time()-t0_comp))
+                t_start = time.time()
+                sys.stdout.flush()
 
-  def get_effective_batch_size(self,num_replicas):
-    return self.batch_size*num_replicas
+            if np.any(batches_to_reset):
+                reset_states(self.model, batches_to_reset)
 
-  def calculate_speed(self,t0,t_after_deltas,t_after_update,num_replicas,verbose=False):
-    effective_batch_size = self.get_effective_batch_size(num_replicas)
-    t_calculate = t_after_deltas - t0
-    t_sync = t_after_update - t_after_deltas
-    t_tot = t_after_update - t0
+            t0 = time.time()
+            deltas, loss = self.train_on_batch_and_get_deltas(
+                batch_xs, batch_ys, verbose)
+            t1 = time.time()
+            if not is_warmup_period:
+                self.set_new_weights(deltas, num_replicas)
+                t2 = time.time()
+                write_str_0 = self.calculate_speed(t0, t1, t2, num_replicas)
 
-    examples_per_sec = effective_batch_size/t_tot
-    frac_calculate = t_calculate/t_tot
-    frac_sync = t_sync/t_tot
+                curr_loss = self.mpi_average_scalars(1.0*loss, num_replicas)
+                # if self.task_index == 0:
+                # print(self.model.get_weights()[0][0][:4])
+                loss_averager.add_val(curr_loss)
+                ave_loss = loss_averager.get_val()
+                eta = self.estimate_remaining_time(
+                    t0 - t_start,
+                    self.num_so_far - self.epoch*num_total, num_total)
+                write_str = (
+                    '\r[{}] step: {} [ETA: {:.2f}s] [{:.2f}/{}], '.format(
+                        self.task_index, step, eta,
+                        1.0*self.num_so_far, num_total)
+                    + 'loss: {:.5f} [{:.5f}] | '.format(ave_loss, curr_loss)
+                    + 'walltime: {:.4f} | '.format(
+                        time.time() - self.start_time))
+                print_unique(write_str + write_str_0)
+                step += 1
+            else:
+                print_unique('\r[{}] warmup phase, num so far: {}'.format(
+                    self.task_index, self.num_so_far))
 
-    print_str = '{:.2E} Examples/sec | {:.2E} sec/batch [{:.1%} calc., {:.1%} synch.]'.format(examples_per_sec,t_tot,frac_calculate,frac_sync)
-    print_str += '[batch = {} = {}*{}] [lr = {:.2E} = {:.2E}*{}]'.format(effective_batch_size,self.batch_size,num_replicas,self.get_effective_lr(num_replicas),self.lr,num_replicas)
-    if verbose:
-      print_unique(print_str)
-    return print_str
+        effective_epochs = 1.0*self.num_so_far/num_total
+        epoch_previous = self.epoch
+        self.epoch = effective_epochs
+        print_unique('\nEpoch {:.2f} finished ({:.2f} epochs passed)'.format(
+            1.0 * self.epoch, self.epoch - epoch_previous)
+                     + ' in {:.2f} seconds.\n'.format(t2 - t_start))
+        return (step, ave_loss, curr_loss, self.num_so_far, effective_epochs)
 
+    def estimate_remaining_time(self, time_so_far, work_so_far, work_total):
+        eps = 1e-6
+        total_time = 1.0*time_so_far*work_total/(work_so_far + eps)
+        return total_time - time_so_far
+
+    def get_effective_lr(self, num_replicas):
+        effective_lr = self.lr * num_replicas
+        if effective_lr > self.max_lr:
+            print_unique('Warning: effective learning rate set to {}, '.format(
+                effective_lr)
+                         + 'larger than maximum {}. Clipping.'.format(
+                             self.max_lr))
+            effective_lr = self.max_lr
+        return effective_lr
+
+    def get_effective_batch_size(self, num_replicas):
+        return self.batch_size*num_replicas
+
+    def calculate_speed(
+            self,
+            t0,
+            t_after_deltas,
+            t_after_update,
+            num_replicas,
+            verbose=False):
+        effective_batch_size = self.get_effective_batch_size(num_replicas)
+        t_calculate = t_after_deltas - t0
+        t_sync = t_after_update - t_after_deltas
+        t_tot = t_after_update - t0
+
+        examples_per_sec = effective_batch_size/t_tot
+        frac_calculate = t_calculate/t_tot
+        frac_sync = t_sync/t_tot
+
+        print_str = (
+            '{:.2E} Examples/sec | {:.2E} sec/batch '.format(examples_per_sec,
+                                                             t_tot)
+            + '[{:.1%} calc., {:.1%} synch.]'.format(frac_calculate,
+                                                     frac_sync))
+        print_str += '[batch = {} = {}*{}] [lr = {:.2E} = {:.2E}*{}]'.format(
+            effective_batch_size,
+            self.batch_size,
+            num_replicas,
+            self.get_effective_lr(num_replicas),
+            self.lr,
+            num_replicas)
+        if verbose:
+            print_unique(print_str)
+        return print_str
 
 
 def print_unique(print_str):
-  if task_index == 0:
-    sys.stdout.write(print_str)
-    sys.stdout.flush()
+    if task_index == 0:
+        sys.stdout.write(print_str)
+        sys.stdout.flush()
+
 
 def print_all(print_str):
-  sys.stdout.write('[{}] '.format(task_index) + print_str)
-  sys.stdout.flush()
+    sys.stdout.write('[{}] '.format(task_index) + print_str)
+    sys.stdout.flush()
 
 
-def multiply_params(params,eps):
-  return [el*eps for el in params]
+def multiply_params(params, eps):
+    return [el*eps for el in params]
 
-def subtract_params(params1,params2):
-  return [p1 - p2 for p1,p2 in zip(params1,params2)]
 
-def add_params(params1,params2):
-  return [p1 + p2 for p1,p2 in zip(params1,params2)]
+def subtract_params(params1, params2):
+    return [p1 - p2 for p1, p2 in zip(params1, params2)]
+
+
+def add_params(params1, params2):
+    return [p1 + p2 for p1, p2 in zip(params1, params2)]
 
 
 def get_shot_list_path(conf):
-    return conf['paths']['base_path'] + '/normalization/shot_lists.npz' #kyle: not compatible with flexible conf.py hierarchy 
+    # KGF: not compatible with flexible conf.py hierarchy
+    return conf['paths']['base_path'] + '/normalization/shot_lists.npz'
 
-def save_shotlists(conf,shot_list_train,shot_list_validate,shot_list_test):
+
+def save_shotlists(conf, shot_list_train, shot_list_validate, shot_list_test):
     path = get_shot_list_path(conf)
-    np.savez(path,shot_list_train=shot_list_train,shot_list_validate=shot_list_validate,shot_list_test=shot_list_test)
+    np.savez(
+        path,
+        shot_list_train=shot_list_train,
+        shot_list_validate=shot_list_validate,
+        shot_list_test=shot_list_test)
+
 
 def load_shotlists(conf):
     path = get_shot_list_path(conf)
@@ -558,36 +674,40 @@ def load_shotlists(conf):
     shot_list_train = data['shot_list_train'][()]
     shot_list_validate = data['shot_list_validate'][()]
     shot_list_test = data['shot_list_test'][()]
-    return shot_list_train,shot_list_validate,shot_list_test
+    return shot_list_train, shot_list_validate, shot_list_test
 
-#shot_list_train,shot_list_validate,shot_list_test = load_shotlists(conf)
+# shot_list_train, shot_list_validate, shot_list_test = load_shotlists(conf)
 
-def mpi_make_predictions(conf,shot_list,loader,custom_path=None):
+
+def mpi_make_predictions(conf, shot_list, loader, custom_path=None):
     loader.set_inference_mode(True)
     np.random.seed(task_index)
-    shot_list.sort()#make sure all replicas have the same list
-    specific_builder = builder.ModelBuilder(conf) 
+    shot_list.sort()  # make sure all replicas have the same list
+    specific_builder = builder.ModelBuilder(conf)
 
     y_prime = []
     y_gold = []
     disruptive = []
 
     model = specific_builder.build_model(True)
-    specific_builder.load_model_weights(model,custom_path)
+    specific_builder.load_model_weights(model, custom_path)
 
-    #broadcast model weights then set it explicitely: fix for Py3.6
+    # broadcast model weights then set it explicitely: fix for Py3.6
     if sys.version_info[0] > 2:
         if task_index == 0:
             new_weights = model.get_weights()
         else:
             new_weights = None
-        nw = comm.bcast(new_weights,root=0)
+        nw = comm.bcast(new_weights, root=0)
         model.set_weights(nw)
 
     model.reset_states()
     if task_index == 0:
-        pbar =  Progbar(len(shot_list))
-    shot_sublists = shot_list.sublists(conf['model']['pred_batch_size'],do_shuffle=False,equal_size=True)
+        pbar = Progbar(len(shot_list))
+    shot_sublists = shot_list.sublists(
+        conf['model']['pred_batch_size'],
+        do_shuffle=False,
+        equal_size=True)
 
     y_prime_global = []
     y_gold_global = []
@@ -595,39 +715,36 @@ def mpi_make_predictions(conf,shot_list,loader,custom_path=None):
     if task_index != 0:
         loader.verbose = False
 
-    for (i,shot_sublist) in enumerate(shot_sublists):
+    for (i, shot_sublist) in enumerate(shot_sublists):
 
         if i % num_workers == task_index:
-            X,y,shot_lengths,disr = loader.load_as_X_y_pred(shot_sublist)
+            X, y, shot_lengths, disr = loader.load_as_X_y_pred(shot_sublist)
 
-
-        
-            #load data and fit on data
-            y_p = model.predict(X,batch_size=conf['model']['pred_batch_size'])
+            # load data and fit on data
+            y_p = model.predict(X, batch_size=conf['model']['pred_batch_size'])
             model.reset_states()
             y_p = loader.batch_output_to_array(y_p)
             y = loader.batch_output_to_array(y)
 
-            #cut arrays back
-            y_p = [arr[:shot_lengths[j]] for (j,arr) in enumerate(y_p)]
-            y = [arr[:shot_lengths[j]] for (j,arr) in enumerate(y)]
+            # cut arrays back
+            y_p = [arr[:shot_lengths[j]] for (j, arr) in enumerate(y_p)]
+            y = [arr[:shot_lengths[j]] for (j, arr) in enumerate(y)]
 
-            # print('Shots {}/{}'.format(i*num_at_once + j*1.0*len(shot_sublist)/len(X_list),len(shot_list_train)))
             y_prime += y_p
             y_gold += y
             disruptive += disr
             # print_all('\nFinished with i = {}'.format(i))
 
-        if i % num_workers == num_workers -1 or i == len(shot_sublists) - 1:
+        if i % num_workers == num_workers - 1 or i == len(shot_sublists) - 1:
             comm.Barrier()
             y_prime_global += concatenate_sublists(comm.allgather(y_prime))
             y_gold_global += concatenate_sublists(comm.allgather(y_gold))
-            disruptive_global += concatenate_sublists(comm.allgather(disruptive))
+            disruptive_global += concatenate_sublists(
+                comm.allgather(disruptive))
             comm.Barrier()
             y_prime = []
             y_gold = []
             disruptive = []
-            # print_all('\nFinished subepoch with lists len(y_prime_global), gold, disruptive = {},{},{}'.format(len(y_prime_global),len(y_gold_global),len(disruptive_global)))
 
         if task_index == 0:
             pbar.add(1.0*len(shot_sublist))
@@ -637,19 +754,28 @@ def mpi_make_predictions(conf,shot_list,loader,custom_path=None):
     disruptive_global = disruptive_global[:len(shot_list)]
     loader.set_inference_mode(False)
 
-    return y_prime_global,y_gold_global,disruptive_global
+    return y_prime_global, y_gold_global, disruptive_global
 
 
-def mpi_make_predictions_and_evaluate(conf,shot_list,loader,custom_path=None):
-    y_prime,y_gold,disruptive = mpi_make_predictions(conf,shot_list,loader,custom_path)
+def mpi_make_predictions_and_evaluate(
+        conf, shot_list, loader, custom_path=None):
+    y_prime, y_gold, disruptive = mpi_make_predictions(
+        conf, shot_list, loader, custom_path)
     analyzer = PerformanceAnalyzer(conf=conf)
-    roc_area = analyzer.get_roc_area(y_prime,y_gold,disruptive)
-    shot_list.set_weights(analyzer.get_shot_difficulty(y_prime,y_gold,disruptive))
-    loss = get_loss_from_list(y_prime,y_gold,conf['data']['target'])
-    return y_prime,y_gold,disruptive,roc_area,loss
+    roc_area = analyzer.get_roc_area(y_prime, y_gold, disruptive)
+    shot_list.set_weights(
+        analyzer.get_shot_difficulty(
+            y_prime, y_gold, disruptive))
+    loss = get_loss_from_list(y_prime, y_gold, conf['data']['target'])
+    return y_prime, y_gold, disruptive, roc_area, loss
 
 
-def mpi_train(conf,shot_list_train,shot_list_validate,loader, callbacks_list=None):   
+def mpi_train(
+        conf,
+        shot_list_train,
+        shot_list_validate,
+        loader,
+        callbacks_list=None):
 
     loader.set_inference_mode(False)
     conf['num_workers'] = comm.Get_size()
@@ -657,7 +783,7 @@ def mpi_train(conf,shot_list_train,shot_list_validate,loader, callbacks_list=Non
     specific_builder = builder.ModelBuilder(conf)
     train_model = specific_builder.build_model(False)
 
-    #load the latest epoch we did. Returns -1 if none exist yet
+    # load the latest epoch we did. Returns -1 if none exist yet
     e = specific_builder.load_model_weights(train_model)
     e_old = e
 
@@ -671,7 +797,8 @@ def mpi_train(conf,shot_list_train,shot_list_validate,loader, callbacks_list=Non
 
     if 'adam' in conf['model']['optimizer']:
         optimizer = MPIAdam(lr=lr)
-    elif conf['model']['optimizer'] == 'sgd' or conf['model']['optimizer'] == 'tf_sgd':
+    elif (conf['model']['optimizer'] == 'sgd'
+          or conf['model']['optimizer'] == 'tf_sgd'):
         optimizer = MPISGD(lr=lr)
     elif 'momentum_sgd' in conf['model']['optimizer']:
         optimizer = MPIMomentumSGD(lr=lr)
@@ -681,30 +808,45 @@ def mpi_train(conf,shot_list_train,shot_list_validate,loader, callbacks_list=Non
 
     print('{} epochs left to go'.format(num_epochs - 1 - e))
 
-    # batch_generator = partial(loader.training_batch_generator,shot_list=shot_list_train)
-    batch_generator = partial(loader.training_batch_generator_partial_reset,shot_list=shot_list_train)
-    #{}batch_generator = partial(loader.training_batch_generator_process,shot_list=shot_list_train)
+    batch_generator = partial(
+        loader.training_batch_generator_partial_reset,
+        shot_list=shot_list_train)
 
     print("warmup {}".format(warmup_steps))
-    mpi_model = MPIModel(train_model,optimizer,comm,batch_generator,batch_size,lr=lr,warmup_steps = warmup_steps,num_batches_minimum=num_batches_minimum)
-    mpi_model.compile(conf['model']['optimizer'],clipnorm,conf['data']['target'].loss)
+    mpi_model = MPIModel(
+        train_model,
+        optimizer,
+        comm,
+        batch_generator,
+        batch_size,
+        lr=lr,
+        warmup_steps=warmup_steps,
+        num_batches_minimum=num_batches_minimum)
+    mpi_model.compile(
+        conf['model']['optimizer'],
+        clipnorm,
+        conf['data']['target'].loss)
 
     tensorboard = None
     if backend != "theano" and task_index == 0:
         tensorboard_save_path = conf['paths']['tensorboard_save_path']
         write_grads = conf['callbacks']['write_grads']
-        tensorboard = TensorBoard(log_dir=tensorboard_save_path,histogram_freq=1,write_graph=True,write_grads=write_grads)
+        tensorboard = TensorBoard(
+            log_dir=tensorboard_save_path,
+            histogram_freq=1,
+            write_graph=True,
+            write_grads=write_grads)
         tensorboard.set_model(mpi_model.model)
         mpi_model.model.summary()
 
     if task_index == 0:
-        callbacks = mpi_model.build_callbacks(conf,callbacks_list)
+        callbacks = mpi_model.build_callbacks(conf, callbacks_list)
         callbacks.set_model(mpi_model.model)
         callback_metrics = conf['callbacks']['metrics']
         callbacks.set_params({
-        'epochs': num_epochs,
-        'metrics': callback_metrics,
-        'batch_size': batch_size,
+            'epochs': num_epochs,
+            'metrics': callback_metrics,
+            'batch_size': batch_size,
         })
         callbacks.on_train_begin()
     if conf['callbacks']['mode'] == 'max':
@@ -718,29 +860,36 @@ def mpi_train(conf,shot_list_train,shot_list_validate,loader, callbacks_list=Non
         if task_index == 0:
             callbacks.on_epoch_begin(int(round(e)))
         mpi_model.set_lr(lr*lr_decay**e)
-        print_unique('\nEpoch {}/{}'.format(e,num_epochs))
+        print_unique('\nEpoch {}/{}'.format(e, num_epochs))
 
-        (step,ave_loss,curr_loss,num_so_far,effective_epochs) = mpi_model.train_epoch()
+        (step, ave_loss, curr_loss, num_so_far,
+         effective_epochs) = mpi_model.train_epoch()
         e = e_old + effective_epochs
 
-        loader.verbose=False #True during the first iteration
-        if task_index == 0: 
-            specific_builder.save_model_weights(train_model,int(round(e)))
+        loader.verbose = False  # True during the first iteration
+        if task_index == 0:
+            specific_builder.save_model_weights(train_model, int(round(e)))
 
         epoch_logs = {}
-        
-        _,_,_,roc_area,loss = mpi_make_predictions_and_evaluate(conf,shot_list_validate,loader)
+
+        _, _, _, roc_area, loss = mpi_make_predictions_and_evaluate(
+            conf, shot_list_validate, loader)
         if conf['training']['ranking_difficulty_fac'] != 1.0:
-            _,_,_,roc_area_train,loss_train = mpi_make_predictions_and_evaluate(conf,shot_list_train,loader)
-            batch_generator = partial(loader.training_batch_generator_partial_reset,shot_list=shot_list_train)
+            (_, _, _, roc_area_train,
+             loss_train) = mpi_make_predictions_and_evaluate(
+                 conf, shot_list_train, loader)
+            batch_generator = partial(
+                loader.training_batch_generator_partial_reset,
+                shot_list=shot_list_train)
             mpi_model.batch_iterator = batch_generator
             mpi_model.batch_iterator_func.__exit__()
             mpi_model.num_so_far_accum = mpi_model.num_so_far_indiv
             mpi_model.set_batch_iterator_func()
-        epoch_logs['val_roc'] = roc_area 
+        epoch_logs['val_roc'] = roc_area
         epoch_logs['val_loss'] = loss
         epoch_logs['train_loss'] = ave_loss
-        best_so_far = cmp_fn(epoch_logs[conf['callbacks']['monitor']],best_so_far)
+        best_so_far = cmp_fn(
+            epoch_logs[conf['callbacks']['monitor']], best_so_far)
 
         if task_index == 0:
             print('=========Summary======== for epoch{}'.format(step))
@@ -752,17 +901,23 @@ def mpi_train(conf,shot_list_train,shot_list_validate,loader, callbacks_list=Non
                 print('Training ROC: {:.4f}'.format(roc_area_train))
 
             callbacks.on_epoch_end(int(round(e)), epoch_logs)
-            if best_so_far != epoch_logs[conf['callbacks']['monitor']]: #only save model weights if quantity we are tracking is improving
+            # only save model weights if quantity we are tracking is improving
+            if best_so_far != epoch_logs[conf['callbacks']['monitor']]:
                 print("Not saving model weights")
-                specific_builder.delete_model_weights(train_model,int(round(e)))
+                specific_builder.delete_model_weights(
+                    train_model, int(round(e)))
 
-            #tensorboard
+            # tensorboard
             if backend != 'theano':
-                val_generator = partial(loader.training_batch_generator,shot_list=shot_list_validate)()
+                val_generator = partial(
+                    loader.training_batch_generator,
+                    shot_list=shot_list_validate)()
                 val_steps = 1
-                tensorboard.on_epoch_end(val_generator,val_steps,int(round(e)),epoch_logs)
+                tensorboard.on_epoch_end(
+                    val_generator, val_steps, int(
+                        round(e)), epoch_logs)
 
-        stop_training = comm.bcast(mpi_model.model.stop_training,root=0)
+        stop_training = comm.bcast(mpi_model.model.stop_training, root=0)
         if stop_training:
             print("Stopping training due to early stopping")
             break
@@ -776,11 +931,12 @@ def mpi_train(conf,shot_list_train,shot_list_validate,loader, callbacks_list=Non
 
 def get_stop_training(callbacks):
     for cb in callbacks.callbacks:
-        if isinstance(cb,cbks.EarlyStopping):
+        if isinstance(cb, cbks.EarlyStopping):
             print("Checking for early stopping")
             return cb.model.stop_training
     print("No early stopping callback found.")
     return False
+
 
 class TensorBoard(object):
     def __init__(self, log_dir='./logs',
@@ -812,27 +968,28 @@ class TensorBoard(object):
                     mapped_weight_name = weight.name.replace(':', '_')
                     tf.summary.histogram(mapped_weight_name, weight)
                     if self.write_grads:
-                        grads = self.model.optimizer.get_gradients(self.model.total_loss,
-                                                            weight)
+                        grads = self.model.optimizer.get_gradients(
+                            self.model.total_loss, weight)
+
                         def is_indexed_slices(grad):
                             return type(grad).__name__ == 'IndexedSlices'
                         grads = [
                             grad.values if is_indexed_slices(grad) else grad
                             for grad in grads]
-                        for grad in grads: 
-                            tf.summary.histogram('{}_grad'.format(mapped_weight_name), grad)
+                        for grad in grads:
+                            tf.summary.histogram(
+                                '{}_grad'.format(mapped_weight_name), grad)
 
                 if hasattr(layer, 'output'):
                     tf.summary.histogram('{}_out'.format(layer.name),
-                                       layer.output)
+                                         layer.output)
         self.merged = tf.summary.merge_all()
 
         if self.write_graph:
             self.writer = tf.summary.FileWriter(self.log_dir,
-                                              self.sess.graph)
+                                                self.sess.graph)
         else:
             self.writer = tf.summary.FileWriter(self.log_dir)
-
 
     def on_epoch_end(self, val_generator, val_steps, epoch, logs=None):
         logs = logs or {}
@@ -847,9 +1004,9 @@ class TensorBoard(object):
             self.writer.add_summary(summary, epoch)
             self.writer.flush()
 
-        tensors = (self.model.inputs +
-                   self.model.targets +
-                   self.model.sample_weights)
+        tensors = (self.model.inputs
+                   + self.model.targets
+                   + self.model.sample_weights)
 
         if self.model.uses_learning_phase:
             tensors += [K.learning_phase()]
@@ -870,8 +1027,8 @@ class TensorBoard(object):
             summary_str = result[0]
             self.writer.add_summary(summary_str, int(round(epoch)))
             val_steps -= 1
-            if val_steps <= 0: break
-
+            if val_steps <= 0:
+                break
 
     def on_train_end(self):
         self.writer.close()

--- a/plasma/models/runner.py
+++ b/plasma/models/runner.py
@@ -1,71 +1,78 @@
-from __future__ import print_function
+from plasma.utils.state_reset import reset_states
+from plasma.utils.evaluation import lr, tf, get_loss_from_list
+from plasma.utils.performance import PerformanceAnalyzer
+from plasma.models.loader import Loader, ProcessGenerator
+from plasma.conf import conf
+import pathos.multiprocessing as mp
+from functools import partial
+import os
+import time
+from hyperopt import hp, STATUS_OK
+import numpy as np
+import sys
+import matplotlib.pyplot as plt
 import matplotlib
 matplotlib.use('Agg')
-import matplotlib.pyplot as plt
 
-import numpy as np
+# if sys.version_info[0] < 3:
+#     from itertools import imap
 
-from hyperopt import hp, STATUS_OK
-
-import time
-import sys
-import os
-from functools import partial
-import pathos.multiprocessing as mp
-
-if sys.version_info[0] < 3:
-    from itertools import imap
-
-from plasma.conf import conf
-from plasma.models.loader import Loader, ProcessGenerator
-from plasma.utils.performance import PerformanceAnalyzer
-from plasma.utils.evaluation import *
-from plasma.utils.state_reset import reset_states
 
 backend = conf['model']['backend']
 
-def train(conf,shot_list_train,shot_list_validate,loader):
+
+def train(conf, shot_list_train, shot_list_validate, loader):
     loader.set_inference_mode(False)
     np.random.seed(1)
 
     validation_losses = []
     validation_roc = []
     training_losses = []
-    print('validate: {} shots, {} disruptive'.format(len(shot_list_validate),shot_list_validate.num_disruptive()))
-    print('training: {} shots, {} disruptive'.format(len(shot_list_train),shot_list_train.num_disruptive()))
+    print(
+        'validate: {} shots, {} disruptive'.format(
+            len(shot_list_validate),
+            shot_list_validate.num_disruptive()))
+    print(
+        'training: {} shots, {} disruptive'.format(
+            len(shot_list_train),
+            shot_list_train.num_disruptive()))
 
     if backend == 'tf' or backend == 'tensorflow':
         first_time = "tensorflow" not in sys.modules
         if first_time:
-                import tensorflow as tf
-                os.environ['KERAS_BACKEND'] = 'tensorflow'
-                from keras.backend.tensorflow_backend import set_session
-                config = tf.ConfigProto(device_count={"GPU":1})
-                set_session(tf.Session(config=config))
+            import tensorflow as tf
+            os.environ['KERAS_BACKEND'] = 'tensorflow'
+            from keras.backend.tensorflow_backend import set_session
+            config = tf.ConfigProto(device_count={"GPU": 1})
+            set_session(tf.Session(config=config))
     else:
         os.environ['KERAS_BACKEND'] = 'theano'
         os.environ['THEANO_FLAGS'] = 'device=gpu,floatX=float32'
-        import theano
+        # import theano
 
-    from keras.utils.generic_utils import Progbar 
+    from keras.utils.generic_utils import Progbar
     from keras import backend as K
     from plasma.models import builder
 
-    print('Build model...',end='')
+    print('Build model...', end='')
     specific_builder = builder.ModelBuilder(conf)
-    train_model = specific_builder.build_model(False) 
-    print('Compile model',end='')
-    train_model.compile(optimizer=optimizer_class(),loss=conf['data']['target'].loss)
+    train_model = specific_builder.build_model(False)
+    print('Compile model', end='')
+    train_model.compile(
+        optimizer=optimizer_class(),
+        loss=conf['data']['target'].loss)
     print('...done')
 
-    #load the latest epoch we did. Returns -1 if none exist yet
+    # load the latest epoch we did. Returns -1 if none exist yet
     e = specific_builder.load_model_weights(train_model)
     e_start = e
-    batch_generator = partial(loader.training_batch_generator_partial_reset,shot_list=shot_list_train)
+    batch_generator = partial(
+        loader.training_batch_generator_partial_reset,
+        shot_list=shot_list_train)
     batch_iterator = ProcessGenerator(batch_generator())
 
     num_epochs = conf['training']['num_epochs']
-    num_at_once = conf['training']['num_shots_at_once']
+    # num_at_once = conf['training']['num_shots_at_once']
     lr_decay = conf['model']['lr_decay']
     print('{} epochs left to go'.format(num_epochs - 1 - e))
     num_so_far_accum = 0
@@ -81,67 +88,77 @@ def train(conf,shot_list_train,shot_list_validate,loader):
 
     while e < num_epochs-1:
         e += 1
-        print('\nEpoch {}/{}'.format(e+1,num_epochs))
-        pbar =  Progbar(len(shot_list_train))
+        print('\nEpoch {}/{}'.format(e+1, num_epochs))
+        pbar = Progbar(len(shot_list_train))
 
-        #decay learning rate each epoch:
+        # decay learning rate each epoch:
         K.set_value(train_model.optimizer.lr, lr*lr_decay**(e))
-        
-        #print('Learning rate: {}'.format(train_model.optimizer.lr.get_value()))
+
         num_batches_minimum = 100
         num_batches_current = 0
         training_losses_tmp = []
 
-        while num_so_far < (e - e_start)*num_total or num_batches_current < num_batches_minimum:
+        while (num_so_far < (e - e_start)*num_total
+               or num_batches_current < num_batches_minimum):
             num_so_far_old = num_so_far
             try:
-                batch_xs,batch_ys,batches_to_reset,num_so_far_curr,num_total,is_warmup_period = next(batch_iterator)
+                (batch_xs, batch_ys, batches_to_reset, num_so_far_curr,
+                 num_total, is_warmup_period) = next(batch_iterator)
             except StopIteration:
                 print("Resetting batch iterator.")
                 num_so_far_accum = num_so_far
                 batch_iterator = ProcessGenerator(batch_generator())
-                batch_xs,batch_ys,batches_to_reset,num_so_far_curr,num_total,is_warmup_period = next(batch_iterator)
+                (batch_xs, batch_ys, batches_to_reset, num_so_far_curr,
+                 num_total, is_warmup_period) = next(batch_iterator)
             if np.any(batches_to_reset):
-                reset_states(train_model,batches_to_reset)
+                reset_states(train_model, batches_to_reset)
             if not is_warmup_period:
                 num_so_far = num_so_far_accum+num_so_far_curr
 
-                num_batches_current +=1 
+                num_batches_current += 1
 
-
-                loss = train_model.train_on_batch(batch_xs,batch_ys)
+                loss = train_model.train_on_batch(batch_xs, batch_ys)
                 training_losses_tmp.append(loss)
-                pbar.add(num_so_far - num_so_far_old, values=[("train loss", loss)])
-                loader.verbose=False#True during the first iteration
+                pbar.add(num_so_far - num_so_far_old,
+                         values=[("train loss", loss)])
+                loader.verbose = False  # True during the first iteration
             else:
-                _ = train_model.predict(batch_xs,batch_size=conf['training']['batch_size'])
-
+                _ = train_model.predict(
+                    batch_xs, batch_size=conf['training']['batch_size'])
 
         e = e_start+1.0*num_so_far/num_total
         sys.stdout.flush()
         ave_loss = np.mean(training_losses_tmp)
         training_losses.append(ave_loss)
-        specific_builder.save_model_weights(train_model,int(round(e)))
+        specific_builder.save_model_weights(train_model, int(round(e)))
 
         if conf['training']['validation_frac'] > 0.0:
             print("prediction on GPU...")
-            _,_,_,roc_area,loss = make_predictions_and_evaluate_gpu(conf,shot_list_validate,loader)
+            _, _, _, roc_area, loss = make_predictions_and_evaluate_gpu(
+                conf, shot_list_validate, loader)
             validation_losses.append(loss)
             validation_roc.append(roc_area)
 
             epoch_logs = {}
-            epoch_logs['val_roc'] = roc_area 
+            epoch_logs['val_roc'] = roc_area
             epoch_logs['val_loss'] = loss
             epoch_logs['train_loss'] = ave_loss
-            best_so_far = cmp_fn(epoch_logs[conf['callbacks']['monitor']],best_so_far)
-            if best_so_far != epoch_logs[conf['callbacks']['monitor']]: #only save model weights if quantity we are tracking is improving
+            best_so_far = cmp_fn(
+                epoch_logs[conf['callbacks']['monitor']], best_so_far)
+            # only save model weights if quantity we are tracking is improving
+            if best_so_far != epoch_logs[conf['callbacks']['monitor']]:
                 print("Not saving model weights")
-                specific_builder.delete_model_weights(train_model,int(round(e)))
+                specific_builder.delete_model_weights(
+                    train_model, int(round(e)))
 
             if conf['training']['ranking_difficulty_fac'] != 1.0:
-                _,_,_,roc_area_train,loss_train = make_predictions_and_evaluate_gpu(conf,shot_list_train,loader)
+                (_, _, _, roc_area_train,
+                 loss_train) = make_predictions_and_evaluate_gpu(
+                     conf, shot_list_train, loader)
                 batch_iterator.__exit__()
-                batch_generator = partial(loader.training_batch_generator_partial_reset,shot_list=shot_list_train)
+                batch_generator = partial(
+                    loader.training_batch_generator_partial_reset,
+                    shot_list=shot_list_train)
                 batch_iterator = ProcessGenerator(batch_generator())
                 num_so_far_accum = num_so_far
 
@@ -153,58 +170,78 @@ def train(conf,shot_list_train,shot_list_validate,loader):
             if conf['training']['ranking_difficulty_fac'] != 1.0:
                 print('Train Loss: {:.3e}'.format(loss_train))
                 print('Train ROC: {:.4f}'.format(roc_area_train))
-        
-
 
     # plot_losses(conf,[training_losses],specific_builder,name='training')
     if conf['training']['validation_frac'] > 0.0:
-        plot_losses(conf,[training_losses,validation_losses,validation_roc],specific_builder,name='training_validation_roc')
+        plot_losses(conf,
+                    [training_losses,
+                     validation_losses,
+                     validation_roc],
+                    specific_builder,
+                    name='training_validation_roc')
     batch_iterator.__exit__()
     print('...done')
 
+
 def optimizer_class():
-    from keras.optimizers import SGD,Adam,RMSprop,Nadam,TFOptimizer
+    from keras.optimizers import SGD, Adam, RMSprop, Nadam, TFOptimizer
 
     if conf['model']['optimizer'] == 'sgd':
-        return SGD(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm'])
+        return SGD(lr=conf['model']['lr'], clipnorm=conf['model']['clipnorm'])
     elif conf['model']['optimizer'] == 'momentum_sgd':
-        return SGD(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm'], decay=1e-6, momentum=0.9)
+        return SGD(
+            lr=conf['model']['lr'],
+            clipnorm=conf['model']['clipnorm'],
+            decay=1e-6,
+            momentum=0.9)
     elif conf['model']['optimizer'] == 'tf_momentum_sgd':
-        return TFOptimizer(tf.train.MomentumOptimizer(learning_rate=conf['model']['lr'],momentum=0.9))
+        return TFOptimizer(
+            tf.train.MomentumOptimizer(
+                learning_rate=conf['model']['lr'],
+                momentum=0.9))
     elif conf['model']['optimizer'] == 'adam':
-        return Adam(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm'])
+        return Adam(lr=conf['model']['lr'], clipnorm=conf['model']['clipnorm'])
     elif conf['model']['optimizer'] == 'tf_adam':
-        return TFOptimizer(tf.train.AdamOptimizer(learning_rate=conf['model']['lr']))
+        return TFOptimizer(
+            tf.train.AdamOptimizer(
+                learning_rate=conf['model']['lr']))
     elif conf['model']['optimizer'] == 'rmsprop':
-        return RMSprop(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm'])
+        return RMSprop(
+            lr=conf['model']['lr'],
+            clipnorm=conf['model']['clipnorm'])
     elif conf['model']['optimizer'] == 'nadam':
-        return Nadam(lr=conf['model']['lr'],clipnorm=conf['model']['clipnorm'])
+        return Nadam(
+            lr=conf['model']['lr'],
+            clipnorm=conf['model']['clipnorm'])
     else:
         print("Optimizer not implemented yet")
         exit(1)
 
 
 class HyperRunner(object):
-    def __init__(self,conf,loader,shot_list):
+    def __init__(self, conf, loader, shot_list):
         self.loader = loader
         self.shot_list = shot_list
         self.conf = conf
 
-    #FIXME setup for hyperas search
-    def keras_fmin_fnct(self,space):
+    # FIXME setup for hyperas search
+    def keras_fmin_fnct(self, space):
         from plasma.models import builder
 
         specific_builder = builder.ModelBuilder(self.conf)
 
-        train_model = specific_builder.hyper_build_model(space,False)
-        train_model.compile(optimizer=optimizer_class(),loss=conf['data']['target'].loss)
+        train_model = specific_builder.hyper_build_model(space, False)
+        train_model.compile(
+            optimizer=optimizer_class(),
+            loss=conf['data']['target'].loss)
 
         np.random.seed(1)
         validation_losses = []
         validation_roc = []
         training_losses = []
-        shot_list_train,shot_list_validate = self.shot_list.split_direct(1.0-conf['training']['validation_frac'],do_shuffle=True)
-        
+        shot_list_train, shot_list_validate = self.shot_list.split_direct(
+            1.0-conf['training']['validation_frac'], do_shuffle=True)
+
         from keras.utils.generic_utils import Progbar
         from keras import backend as K
 
@@ -212,46 +249,59 @@ class HyperRunner(object):
         num_at_once = self.conf['training']['num_shots_at_once']
         lr_decay = self.conf['model']['lr_decay']
 
-        resulting_dict = {'loss':None,'status':STATUS_OK,'model':None}
+        resulting_dict = {'loss': None, 'status': STATUS_OK, 'model': None}
 
         e = -1
-        #print("Current num_epochs {}".format(e))
+        # print("Current num_epochs {}".format(e))
         while e < num_epochs-1:
             e += 1
-            pbar =  Progbar(len(shot_list_train))
+            pbar = Progbar(len(shot_list_train))
 
             shot_list_train.shuffle()
             shot_sublists = shot_list_train.sublists(num_at_once)[:1]
             training_losses_tmp = []
 
             K.set_value(train_model.optimizer.lr, lr*lr_decay**(e))
-            for (i,shot_sublist) in enumerate(shot_sublists):
-                X_list,y_list = self.loader.load_as_X_y_list(shot_sublist)
-                for j,(X,y) in enumerate(zip(X_list,y_list)):
+            for (i, shot_sublist) in enumerate(shot_sublists):
+                X_list, y_list = self.loader.load_as_X_y_list(shot_sublist)
+                for j, (X, y) in enumerate(zip(X_list, y_list)):
                     history = builder.LossHistory()
-                    train_model.fit(X,y,
-                        batch_size=Loader.get_batch_size(self.conf['training']['batch_size'],prediction_mode=False),
-                        epochs=1,shuffle=False,verbose=0,
-                        validation_split=0.0,callbacks=[history])
+                    train_model.fit(
+                        X,
+                        y,
+                        batch_size=Loader.get_batch_size(
+                            self.conf['training']['batch_size'],
+                            prediction_mode=False),
+                        epochs=1,
+                        shuffle=False,
+                        verbose=0,
+                        validation_split=0.0,
+                        callbacks=[history])
                     train_model.reset_states()
                     train_loss = np.mean(history.losses)
                     training_losses_tmp.append(train_loss)
 
-                    pbar.add(1.0*len(shot_sublist)/len(X_list), values=[("train loss", train_loss)])
-                    self.loader.verbose=False
+                    pbar.add(1.0*len(shot_sublist)/len(X_list),
+                             values=[("train loss", train_loss)])
+                    self.loader.verbose = False
             sys.stdout.flush()
             training_losses.append(np.mean(training_losses_tmp))
-            specific_builder.save_model_weights(train_model,e)
+            specific_builder.save_model_weights(train_model, e)
 
-            _,_,_,roc_area,loss = make_predictions_and_evaluate_gpu(self.conf,shot_list_validate,self.loader)
-            print("Epoch: {}, loss: {}, validation_losses_size: {}".format(e,loss,len(validation_losses)))
+            _, _, _, roc_area, loss = make_predictions_and_evaluate_gpu(
+                self.conf, shot_list_validate, self.loader)
+            print(
+                "Epoch: {}, loss: {}, validation_losses_size: {}".format(
+                    e, loss, len(validation_losses)))
             validation_losses.append(loss)
             validation_roc.append(roc_area)
             resulting_dict['loss'] = loss
             resulting_dict['model'] = train_model
-            #print("Results {}, before {}".format(resulting_dict,id(resulting_dict)))
+            # print("Results {}, before
+            # {}".format(resulting_dict,id(resulting_dict)))
 
-        #print("Results {}, after {}".format(resulting_dict,id(resulting_dict)))
+        # print("Results {}, after
+        # {}".format(resulting_dict,id(resulting_dict)))
         return resulting_dict
 
     def get_space(self):
@@ -263,29 +313,31 @@ class HyperRunner(object):
         from hyperopt import fmin
 
         best_run = fmin(self.keras_fmin_fnct,
-                    space=self.get_space(),
-                    algo=algo,
-                    max_evals=max_evals,
-                    trials=trials,
-                    rstate=np.random.RandomState(rseed))
+                        space=self.get_space(),
+                        algo=algo,
+                        max_evals=max_evals,
+                        trials=trials,
+                        rstate=np.random.RandomState(rseed))
 
         best_model = None
         for trial in trials:
             vals = trial.get('misc').get('vals')
             for key in vals.keys():
                 vals[key] = vals[key][0]
-            if trial.get('misc').get('vals') == best_run and 'model' in trial.get('result').keys():
+            if (trial.get('misc').get('vals') == best_run
+                    and 'model' in trial.get('result').keys()):
                 best_model = trial.get('result').get('model')
 
         return best_run, best_model
 
-def plot_losses(conf,losses_list,specific_builder,name=''):
+
+def plot_losses(conf, losses_list, specific_builder, name=''):
     unique_id = specific_builder.get_unique_id()
     savedir = 'losses'
     if not os.path.exists(savedir):
         os.makedirs(savedir)
 
-    save_path = os.path.join(savedir,'{}_loss_{}.png'.format(name,unique_id))
+    save_path = os.path.join(savedir, '{}_loss_{}.png'.format(name, unique_id))
     plt.figure()
     for losses in losses_list:
         plt.semilogy(losses)
@@ -295,43 +347,49 @@ def plot_losses(conf,losses_list,specific_builder,name=''):
     plt.savefig(save_path)
 
 
-def make_predictions(conf,shot_list,loader):
+def make_predictions(conf, shot_list, loader):
     loader.set_inference_mode(True)
 
-    use_cores = max(1,mp.cpu_count()-2)
+    use_cores = max(1, mp.cpu_count()-2)
 
     if backend == 'tf' or backend == 'tensorflow':
         first_time = "tensorflow" not in sys.modules
         if first_time:
-                import tensorflow as tf
-                os.environ['KERAS_BACKEND'] = 'tensorflow'
-                from keras.backend.tensorflow_backend import set_session
-                config = tf.ConfigProto(device_count={"CPU":use_cores})
-                set_session(tf.Session(config=config))
+            import tensorflow as tf
+            os.environ['KERAS_BACKEND'] = 'tensorflow'
+            from keras.backend.tensorflow_backend import set_session
+            config = tf.ConfigProto(device_count={"CPU": use_cores})
+            set_session(tf.Session(config=config))
     else:
         os.environ['THEANO_FLAGS'] = 'device=cpu'
-        import theano
+        # import theano
 
     from plasma.models.builder import ModelBuilder
-    specific_builder = ModelBuilder(conf) 
+    specific_builder = ModelBuilder(conf)
 
     y_prime = []
     y_gold = []
     disruptive = []
 
     model = specific_builder.build_model(True)
-    model.compile(optimizer=optimizer_class(),loss=conf['data']['target'].loss)
+    model.compile(
+        optimizer=optimizer_class(),
+        loss=conf['data']['target'].loss)
 
     specific_builder.load_model_weights(model)
     model_save_path = specific_builder.get_latest_save_path()
 
     start_time = time.time()
     pool = mp.Pool(use_cores)
-    fn = partial(make_single_prediction,builder=specific_builder,loader=loader,model_save_path=model_save_path)
+    fn = partial(
+        make_single_prediction,
+        builder=specific_builder,
+        loader=loader,
+        model_save_path=model_save_path)
 
     print('running in parallel on {} processes'.format(pool._processes))
-    for (i,(y_p,y,is_disruptive)) in enumerate(pool.imap(fn,shot_list)):
-        print('Shot {}/{}'.format(i,len(shot_list)))
+    for (i, (y_p, y, is_disruptive)) in enumerate(pool.imap(fn, shot_list)):
+        print('Shot {}/{}'.format(i, len(shot_list)))
         sys.stdout.flush()
         y_prime.append(y_p)
         y_gold.append(y)
@@ -340,77 +398,87 @@ def make_predictions(conf,shot_list,loader):
     pool.join()
     print('Finished Predictions in {} seconds'.format(time.time()-start_time))
     loader.set_inference_mode(False)
-    return y_prime,y_gold,disruptive
+    return y_prime, y_gold, disruptive
 
 
-def make_single_prediction(shot,specific_builder,loader,model_save_path):
+def make_single_prediction(shot, specific_builder, loader, model_save_path):
     loader.set_inference_mode(True)
     model = specific_builder.build_model(True)
-    model.compile(optimizer=optimizer_class(),loss=conf['data']['target'].loss)
+    model.compile(
+        optimizer=optimizer_class(),
+        loss=conf['data']['target'].loss)
 
     model.load_weights(model_save_path)
     model.reset_states()
-    X,y = loader.load_as_X_y(shot,prediction_mode=True)
+    X, y = loader.load_as_X_y(shot, prediction_mode=True)
     assert(X.shape[0] == y.shape[0])
-    y_p = model.predict(X,batch_size=Loader.get_batch_size(conf['training']['batch_size'],prediction_mode=True),verbose=0)
+    y_p = model.predict(
+        X,
+        batch_size=Loader.get_batch_size(conf['training']['batch_size'],
+                                         prediction_mode=True),
+        verbose=0)
     answer_dims = y_p.shape[-1]
     if conf['model']['return_sequences']:
         shot_length = y_p.shape[0]*y_p.shape[1]
     else:
         shot_length = y_p.shape[0]
-    y_p = np.reshape(y_p,(shot_length,answer_dims))
-    y = np.reshape(y,(shot_length,answer_dims))
+    y_p = np.reshape(y_p, (shot_length, answer_dims))
+    y = np.reshape(y, (shot_length, answer_dims))
     is_disruptive = shot.is_disruptive_shot()
     model.reset_states()
     loader.set_inference_mode(False)
-    return y_p,y,is_disruptive
+    return y_p, y, is_disruptive
 
 
-def make_predictions_gpu(conf,shot_list,loader,custom_path=None):
+def make_predictions_gpu(conf, shot_list, loader, custom_path=None):
     loader.set_inference_mode(True)
 
     if backend == 'tf' or backend == 'tensorflow':
         first_time = "tensorflow" not in sys.modules
         if first_time:
-                import tensorflow as tf
-                os.environ['KERAS_BACKEND'] = 'tensorflow'
-                from keras.backend.tensorflow_backend import set_session
-                config = tf.ConfigProto(device_count={"GPU":1})
-                set_session(tf.Session(config=config))
+            import tensorflow as tf
+            os.environ['KERAS_BACKEND'] = 'tensorflow'
+            from keras.backend.tensorflow_backend import set_session
+            config = tf.ConfigProto(device_count={"GPU": 1})
+            set_session(tf.Session(config=config))
     else:
         os.environ['THEANO_FLAGS'] = 'device=gpu,floatX=float32'
-        import theano
+        # import theano
 
-    from keras.utils.generic_utils import Progbar 
+    from keras.utils.generic_utils import Progbar
     from plasma.models.builder import ModelBuilder
-    specific_builder = ModelBuilder(conf) 
+    specific_builder = ModelBuilder(conf)
 
     y_prime = []
     y_gold = []
     disruptive = []
 
     model = specific_builder.build_model(True)
-    model.compile(optimizer=optimizer_class(),loss=conf['data']['target'].loss)
+    model.compile(optimizer=optimizer_class(),
+                  loss=conf['data']['target'].loss)
 
-    specific_builder.load_model_weights(model,custom_path)
+    specific_builder.load_model_weights(model, custom_path)
     model.reset_states()
 
-    pbar =  Progbar(len(shot_list))
-    shot_sublists = shot_list.sublists(conf['model']['pred_batch_size'],do_shuffle=False,equal_size=True)
-    for (i,shot_sublist) in enumerate(shot_sublists):
-        X,y,shot_lengths,disr = loader.load_as_X_y_pred(shot_sublist)
-        #load data and fit on data
+    pbar = Progbar(len(shot_list))
+    shot_sublists = shot_list.sublists(
+        conf['model']['pred_batch_size'],
+        do_shuffle=False,
+        equal_size=True)
+    for (i, shot_sublist) in enumerate(shot_sublists):
+        X, y, shot_lengths, disr = loader.load_as_X_y_pred(shot_sublist)
+        # load data and fit on data
         y_p = model.predict(X,
-            batch_size=conf['model']['pred_batch_size'])
+                            batch_size=conf['model']['pred_batch_size'])
         model.reset_states()
         y_p = loader.batch_output_to_array(y_p)
         y = loader.batch_output_to_array(y)
-        #cut arrays back
-        y_p = [arr[:shot_lengths[j]] for (j,arr) in enumerate(y_p)]
-        y = [arr[:shot_lengths[j]] for (j,arr) in enumerate(y)]
+        # cut arrays back
+        y_p = [arr[:shot_lengths[j]] for (j, arr) in enumerate(y_p)]
+        y = [arr[:shot_lengths[j]] for (j, arr) in enumerate(y)]
 
         pbar.add(1.0*len(shot_sublist))
-        loader.verbose=False#True during the first iteration
+        loader.verbose = False  # True during the first iteration
         y_prime += y_p
         y_gold += y
         disruptive += disr
@@ -418,67 +486,83 @@ def make_predictions_gpu(conf,shot_list,loader,custom_path=None):
     y_gold = y_gold[:len(shot_list)]
     disruptive = disruptive[:len(shot_list)]
     loader.set_inference_mode(False)
-    return y_prime,y_gold,disruptive
+    return y_prime, y_gold, disruptive
 
 
-
-def make_predictions_and_evaluate_gpu(conf,shot_list,loader,custom_path=None):
-    y_prime,y_gold,disruptive = make_predictions_gpu(conf,shot_list,loader,custom_path)
+def make_predictions_and_evaluate_gpu(
+        conf, shot_list, loader, custom_path=None):
+    y_prime, y_gold, disruptive = make_predictions_gpu(
+        conf, shot_list, loader, custom_path)
     analyzer = PerformanceAnalyzer(conf=conf)
-    roc_area = analyzer.get_roc_area(y_prime,y_gold,disruptive)
-    shot_list.set_weights(analyzer.get_shot_difficulty(y_prime,y_gold,disruptive))
-    loss = get_loss_from_list(y_prime,y_gold,conf['data']['target'])
-    return y_prime,y_gold,disruptive,roc_area,loss
+    roc_area = analyzer.get_roc_area(y_prime, y_gold, disruptive)
+    shot_list.set_weights(
+        analyzer.get_shot_difficulty(
+            y_prime, y_gold, disruptive))
+    loss = get_loss_from_list(y_prime, y_gold, conf['data']['target'])
+    return y_prime, y_gold, disruptive, roc_area, loss
 
-def make_evaluations_gpu(conf,shot_list,loader):
+
+def make_evaluations_gpu(conf, shot_list, loader):
     loader.set_inference_mode(True)
 
     if backend == 'tf' or backend == 'tensorflow':
         first_time = "tensorflow" not in sys.modules
         if first_time:
-                import tensorflow as tf
-                os.environ['KERAS_BACKEND'] = 'tensorflow'
-                from keras.backend.tensorflow_backend import set_session
-                config = tf.ConfigProto(device_count={"GPU":1})
-                set_session(tf.Session(config=config))
+            import tensorflow as tf
+            os.environ['KERAS_BACKEND'] = 'tensorflow'
+            from keras.backend.tensorflow_backend import set_session
+            config = tf.ConfigProto(device_count={"GPU": 1})
+            set_session(tf.Session(config=config))
     else:
         os.environ['THEANO_FLAGS'] = 'device=gpu,floatX=float32'
-        import theano
-    
-    from keras.utils.generic_utils import Progbar 
+        # import theano
+
+    from keras.utils.generic_utils import Progbar
     from plasma.models.builder import ModelBuilder
-    specific_builder = ModelBuilder(conf) 
+    specific_builder = ModelBuilder(conf)
 
-    y_prime = []
-    y_gold = []
-    disruptive = []
-    batch_size = min(len(shot_list),conf['model']['pred_batch_size'])
+    # y_prime = []
+    # y_gold = []
+    # disruptive = []
+    batch_size = min(len(shot_list), conf['model']['pred_batch_size'])
 
-    pbar =  Progbar(len(shot_list))
-    print('evaluating {} shots using batchsize {}'.format(len(shot_list),batch_size))
+    pbar = Progbar(len(shot_list))
+    print(
+        'evaluating {} shots using batchsize {}'.format(
+            len(shot_list),
+            batch_size))
 
-    shot_sublists = shot_list.sublists(batch_size,equal_size=False)
+    shot_sublists = shot_list.sublists(batch_size, equal_size=False)
     all_metrics = []
     all_weights = []
-    for (i,shot_sublist) in enumerate(shot_sublists):
+    for (i, shot_sublist) in enumerate(shot_sublists):
         batch_size = len(shot_sublist)
-        model = specific_builder.build_model(True,custom_batch_size=batch_size)
-        model.compile(optimizer=optimizer_class(),loss=conf['data']['target'].loss)
+        model = specific_builder.build_model(
+            True, custom_batch_size=batch_size)
+        model.compile(
+            optimizer=optimizer_class(),
+            loss=conf['data']['target'].loss)
 
         specific_builder.load_model_weights(model)
         model.reset_states()
-        X,y,shot_lengths,disr = loader.load_as_X_y_pred(shot_sublist,custom_batch_size=batch_size)
-        #load data and fit on data
-        all_metrics.append(model.evaluate(X,y,batch_size=batch_size,verbose=False))
+        X, y, shot_lengths, disr = loader.load_as_X_y_pred(
+            shot_sublist, custom_batch_size=batch_size)
+        # load data and fit on data
+        all_metrics.append(
+            model.evaluate(
+                X,
+                y,
+                batch_size=batch_size,
+                verbose=False))
         all_weights.append(batch_size)
         model.reset_states()
 
         pbar.add(1.0*len(shot_sublist))
-        loader.verbose=False#True during the first iteration
+        loader.verbose = False  # True during the first iteration
 
     if len(all_metrics) > 1:
         print('evaluations all: {}'.format(all_metrics))
-    loss = np.average(all_metrics,weights = all_weights)
+    loss = np.average(all_metrics, weights=all_weights)
     print('Evaluation Loss: {}'.format(loss))
     loader.set_inference_mode(False)
-    return loss 
+    return loss

--- a/plasma/models/shallow_runner.py
+++ b/plasma/models/shallow_runner.py
@@ -1,43 +1,46 @@
-from __future__ import print_function
+from sklearn import svm
+from keras.utils.generic_utils import Progbar
+import keras.callbacks as cbks
+from sklearn.metrics import classification_report
+#  accuracy_score, auc, confusion_matrix
+from sklearn.externals import joblib
+from sklearn.ensemble import RandomForestClassifier
+import hashlib
+from plasma.utils.downloading import makedirs_process_safe
+# from plasma.utils.state_reset import reset_states
+from plasma.utils.evaluation import ttd, get_loss_from_list
+from plasma.utils.performance import PerformanceAnalyzer
+# from plasma.models.loader import Loader, ProcessGenerator
+# from plasma.conf import conf
+from sklearn.neural_network import MLPClassifier
+from xgboost import XGBClassifier
+import pathos.multiprocessing as mp
+from functools import partial
+import os
+import datetime
+import time
+import numpy as np
+# import matplotlib.pyplot as plt
 import matplotlib
 matplotlib.use('Agg')
-import matplotlib.pyplot as plt
 
-import numpy as np
-import sys
-if sys.version_info[0] < 3:
-    from itertools import imap
+# import sys
+# if sys.version_info[0] < 3:
+#     from itertools import imap
 
-#leading to import errors:
-#from hyperopt import hp, STATUS_OK
-#from hyperas.distributions import conditional
+# leading to import errors:
+# from hyperopt import hp, STATUS_OK
+# from hyperas.distributions import conditional
 
-import time
-import datetime
-import os
-from functools import partial
-import pathos.multiprocessing as mp
-from xgboost import XGBClassifier
-from sklearn.neural_network import MLPClassifier
-
-from plasma.conf import conf
-from plasma.models.loader import Loader, ProcessGenerator
-from plasma.utils.performance import PerformanceAnalyzer
-from plasma.utils.evaluation import *
-from plasma.utils.state_reset import reset_states
-from plasma.utils.downloading import makedirs_process_safe
-
-from keras.utils.generic_utils import Progbar 
-
-import hashlib
 
 debug_use_shots = 100000
 model_filename = "saved_model.pkl"
 dataset_path = "dataset.npz"
 dataset_test_path = "dataset_test.npz"
 
+
 class FeatureExtractor(object):
-    def __init__(self,loader,timesteps = 32):
+    def __init__(self, loader, timesteps=32):
         self.loader = loader
         self.timesteps = timesteps
         self.positional_fit_order = 4
@@ -45,53 +48,72 @@ class FeatureExtractor(object):
         self.temporal_fit_order = 3
         self.num_temporal_features = self.temporal_fit_order + 1 + 3
 
-    def get_sample_probs(self,shot_list,num_samples):
+    def get_sample_probs(self, shot_list, num_samples):
         print("Calculating number of timesteps")
-        timesteps_total,timesteps_d,timesteps_nd = shot_list.num_timesteps(self.loader.conf['paths']['processed_prepath'])
-        print("Total data: {} time samples, {} disruptive".format(timesteps_total,1.0*timesteps_d/timesteps_total))
+        timesteps_total, timesteps_d, timesteps_nd = shot_list.num_timesteps(
+            self.loader.conf['paths']['processed_prepath'])
+        print("Total data: {} time samples, {} disruptive".format(
+            timesteps_total, 1.0*timesteps_d/timesteps_total))
         if self.loader.conf['data']['equalize_classes']:
-            sample_prob_d = np.minimum(1.0,1.0*timesteps_nd/timesteps_d)
-            sample_prob_nd = np.minimum(1.0,1.0*timesteps_d/timesteps_nd)
-            timesteps_total = 1.0*sample_prob_d*timesteps_d+sample_prob_nd*timesteps_nd 
-            sample_prob = np.minimum(1.0,1.0*num_samples/timesteps_total)
+            sample_prob_d = np.minimum(1.0, 1.0*timesteps_nd/timesteps_d)
+            sample_prob_nd = np.minimum(1.0, 1.0*timesteps_d/timesteps_nd)
+            timesteps_total = (1.0*sample_prob_d*timesteps_d
+                               + sample_prob_nd*timesteps_nd)
+            sample_prob = np.minimum(1.0, 1.0*num_samples/timesteps_total)
             sample_prob_d *= sample_prob
             sample_prob_nd *= sample_prob
         else:
-            sample_prob_d = np.minimum(1.0,1.0*num_samples/timesteps_total)
+            sample_prob_d = np.minimum(1.0, 1.0*num_samples/timesteps_total)
             sample_prob_nd = sample_prob_d
         if sample_prob_nd <= 0.0 or sample_prob_d <= 0.0:
-            val = np.minimum(1.0,num_samples/timesteps_total)
-            return val,val
-        return sample_prob_d,sample_prob_nd
+            val = np.minimum(1.0, num_samples/timesteps_total)
+            return val, val
+        return sample_prob_d, sample_prob_nd
 
-    def load_shots(self,shot_list,is_inference=False,as_list=False,num_samples=np.Inf):
+    def load_shots(
+            self,
+            shot_list,
+            is_inference=False,
+            as_list=False,
+            num_samples=np.Inf):
         X = []
         Y = []
         Disr = []
         print("loading...")
-        pbar =  Progbar(len(shot_list))
-        
-        sample_prob_d,sample_prob_nd = self.get_sample_probs(shot_list,num_samples)
-        fn = partial(self.load_shot,is_inference=is_inference,sample_prob_d=sample_prob_d,sample_prob_nd=sample_prob_nd)
+        pbar = Progbar(len(shot_list))
+
+        sample_prob_d, sample_prob_nd = self.get_sample_probs(
+            shot_list, num_samples)
+        fn = partial(
+            self.load_shot,
+            is_inference=is_inference,
+            sample_prob_d=sample_prob_d,
+            sample_prob_nd=sample_prob_nd)
         pool = mp.Pool()
-        print('loading data in parallel on {} processes'.format(pool._processes))
-        for x,y,disr in pool.imap(fn,shot_list):
+        print('loading data in parallel on {} processes'.format(
+            pool._processes))
+        for x, y, disr in pool.imap(fn, shot_list):
             X.append(x)
             Y.append(y)
             Disr.append(disr)
             pbar.add(1.0)
         pool.close()
         pool.join()
-        return X,Y,np.array(Disr)
+        return X, Y, np.array(Disr)
 
     def get_save_prepath(self):
         prepath = self.loader.conf['paths']['processed_prepath']
         use_signals = self.loader.conf['paths']['use_signals']
-        identifying_tuple = ''.join(tuple(map(lambda x: x.description, sorted(use_signals)))).encode('utf-8')
-        save_prepath = prepath + "shallow/use_signals_{}/".format(int(hashlib.md5(identifying_tuple).hexdigest(),16))
+        identifying_tuple = ''.join(
+            tuple(map(lambda x: x.description,
+                      sorted(use_signals)))).encode('utf-8')
+        save_prepath = (
+            prepath + "shallow/use_signals_{}/".format(
+                int(hashlib.md5(identifying_tuple).hexdigest(), 16))
+            )
         return save_prepath
 
-    def process(self,shot): 
+    def process(self, shot):
         save_prepath = self.get_save_prepath()
         save_path = shot.get_save_path(save_prepath)
         if not os.path.exists(save_prepath):
@@ -99,45 +121,45 @@ class FeatureExtractor(object):
         prepath = self.loader.conf['paths']['processed_prepath']
         assert(shot.valid)
         shot.restore(prepath)
-        self.loader.set_inference_mode(True)#make sure shots aren't cut
+        self.loader.set_inference_mode(True)  # make sure shots aren't cut
         if self.loader.normalizer is not None:
             self.loader.normalizer.apply(shot)
         else:
-            print('Warning, no normalization. Training data may be poorly conditioned')
+            print('Warning, no normalization. ',
+                  'Training data may be poorly conditioned')
         self.loader.set_inference_mode(False)
-        # sig,res = self.get_signal_result_from_shot(shot)
+        # sig, res = self.get_signal_result_from_shot(shot)
         disr = 1 if shot.is_disruptive else 0
-
 
         if not os.path.isfile(save_path):
             X = self.get_X(shot)
-            np.savez(save_path,X=X)#,Y=Y,disr=disr
-            #print(X.shape,Y.shape)
+            np.savez(save_path, X=X)  # , Y=Y, disr=disr
+            # print(X.shape, Y.shape)
         else:
             try:
                 dat = np.load(save_path)
-                # X,Y,disr = dat["X"],dat["Y"],dat["disr"][()]
+                # X, Y, disr = dat["X"], dat["Y"], dat["disr"][()]
                 X = dat["X"]
-            except: #data was there but corrupted, save it again
+            except BaseException:
+                # data was there but corrupted, save it again
                 X = self.get_X(shot)
-                np.savez(save_path,X=X)
-
+                np.savez(save_path, X=X)
 
         Y = self.get_Y(shot)
 
         shot.make_light()
 
-        return X,Y,disr
+        return X, Y, disr
 
-    def get_X(self,shot):
+    def get_X(self, shot):
 
         use_signals = self.loader.conf['paths']['use_signals']
-        sig_sample = shot.signals_dict[use_signals[0]] 
+        sig_sample = shot.signals_dict[use_signals[0]]
         if len(shot.ttd.shape) == 1:
-            shot.ttd = np.expand_dims(shot.ttd,axis=1)
+            shot.ttd = np.expand_dims(shot.ttd, axis=1)
         length = sig_sample.shape[0]
         if length < self.timesteps:
-            print(ttd,shot,shot.number)
+            print(ttd, shot, shot.number)
             print("Shot must be at least as long as the RNN length.")
             exit(1)
         assert(len(sig_sample.shape) == len(shot.ttd.shape) == 2)
@@ -146,24 +168,29 @@ class FeatureExtractor(object):
         X = []
         while(len(X) == 0):
             for i in range(length-self.timesteps+1):
-                #if np.random.rand() < sample_prob:
-                x = self.get_x(i,shot)
+                # if np.random.rand() < sample_prob:
+                x = self.get_x(i, shot)
                 X.append(x)
         X = np.stack(X)
         return X
 
-    def get_Y(self,shot):
+    def get_Y(self, shot):
         if len(shot.ttd.shape) == 1:
-            shot.ttd = np.expand_dims(shot.ttd,axis=1)
+            shot.ttd = np.expand_dims(shot.ttd, axis=1)
         offset = self.timesteps - 1
-        return np.round(shot.ttd[offset:,0]).astype(np.int)
+        return np.round(shot.ttd[offset:, 0]).astype(np.int)
 
-    def load_shot(self,shot,is_inference=False,sample_prob_d=1.0,sample_prob_nd=1.0):
+    def load_shot(
+            self,
+            shot,
+            is_inference=False,
+            sample_prob_d=1.0,
+            sample_prob_nd=1.0):
 
-        X,Y,disr = self.process(shot)
+        X, Y, disr = self.process(shot)
 
-        #cut shot ends if we are supposed to
-        if self.loader.conf['data']['cut_shot_ends'] and not is_inference: 
+        # cut shot ends if we are supposed to
+        if self.loader.conf['data']['cut_shot_ends'] and not is_inference:
             T_min_warn = self.loader.conf['data']['T_min_warn']
             X = X[:-T_min_warn]
             Y = Y[:-T_min_warn]
@@ -171,22 +198,23 @@ class FeatureExtractor(object):
         sample_prob = sample_prob_nd
         if disr:
             sample_prob = sample_prob_d
-        if sample_prob < 1.0: 
-            indices = np.sort(np.random.choice(np.array(range(len(Y))),int(round(sample_prob*len(Y))),replace=False))
+        if sample_prob < 1.0:
+            indices = np.sort(
+                np.random.choice(np.array(range(len(Y))),
+                                 int(round(sample_prob*len(Y))),
+                                 replace=False))
             X = X[indices]
             Y = Y[indices]
-        return X,Y,disr
+        return X, Y, disr
 
-
-    def get_x(self,timestep,shot):
+    def get_x(self, timestep, shot):
         x = []
         use_signals = self.loader.conf['paths']['use_signals']
         for sig in use_signals:
-            x += [self.extract_features(timestep,shot,sig)]
-            # x = sig[timestep:timestep+timesteps,:]
-        x = np.concatenate(x,axis=0)
+            x += [self.extract_features(timestep, shot, sig)]
+            # x = sig[timestep:timestep + timesteps,:]
+        x = np.concatenate(x, axis=0)
         return x
-
 
     # def get_x_y(self,timestep,shot):
     #     x = []
@@ -198,24 +226,28 @@ class FeatureExtractor(object):
     #     y = np.round(shot.ttd[timestep+self.timesteps-1,0]).astype(np.int)
     #     return x,y
 
-
-    def extract_features(self,timestep,shot,signal):
-        raw_sig = shot.signals_dict[signal][timestep:timestep+self.timesteps]
-        num_positional_features = self.num_positional_features if signal.num_channels > 1 else 1
-        output_arr = np.empty((self.timesteps,num_positional_features))
-        final_output_arr = np.empty((num_positional_features*self.num_temporal_features))
+    def extract_features(self, timestep, shot, signal):
+        raw_sig = shot.signals_dict[signal][timestep:timestep + self.timesteps]
+        num_positional_features = (
+            self.num_positional_features if signal.num_channels > 1 else 1)
+        output_arr = np.empty((self.timesteps, num_positional_features))
+        final_output_arr = np.empty(
+            (num_positional_features*self.num_temporal_features))
         for t in range(self.timesteps):
-            output_arr[t,:] = self.extract_positional_features(raw_sig[t,:])
+            output_arr[t, :] = self.extract_positional_features(raw_sig[t, :])
         for i in range(num_positional_features):
             idx = i*self.num_temporal_features
-            final_output_arr[idx:idx+self.num_temporal_features] = self.extract_temporal_features(output_arr[:,i])
+            final_output_arr[idx:idx + self.num_temporal_features] = (
+                self.extract_temporal_features(output_arr[:, i]))
         return final_output_arr
 
-    def extract_positional_features(self,arr):
+    def extract_positional_features(self, arr):
         num_channels = len(arr)
         if num_channels > 1:
             ret_arr = np.empty(self.num_positional_features)
-            coefficients = np.polynomial.polynomial.polyfit(np.linspace(0,1,num_channels),arr,self.positional_fit_order)
+            coefficients = np.polynomial.polynomial.polyfit(
+                np.linspace(0, 1, num_channels), arr,
+                self.positional_fit_order)
             mu = np.mean(arr)
             std = np.std(arr)
             max_val = np.max(arr)
@@ -227,9 +259,10 @@ class FeatureExtractor(object):
         else:
             return arr
 
-    def extract_temporal_features(self,arr):
+    def extract_temporal_features(self, arr):
         ret_arr = np.empty(self.num_temporal_features)
-        coefficients = np.polynomial.polynomial.polyfit(np.linspace(0,1,self.timesteps),arr,self.temporal_fit_order)
+        coefficients = np.polynomial.polynomial.polyfit(
+            np.linspace(0, 1, self.timesteps), arr, self.temporal_fit_order)
         mu = np.mean(arr)
         std = np.std(arr)
         max_val = np.max(arr)
@@ -239,75 +272,95 @@ class FeatureExtractor(object):
         ret_arr[self.temporal_fit_order+3] = max_val
         return ret_arr
 
-    def prepend_timesteps(self,arr):
+    def prepend_timesteps(self, arr):
         prepend = arr[0]*np.ones(self.timesteps-1)
-        return np.concatenate((prepend,arr))
+        return np.concatenate((prepend, arr))
 
-from sklearn import svm
-from sklearn.ensemble import RandomForestClassifier
-from sklearn.externals import joblib
-from sklearn.metrics import accuracy_score,auc,classification_report,confusion_matrix
-import keras.callbacks as cbks
 
 def build_callbacks(conf):
     '''
-    The purpose of the method is to set up logging and history. It is based on Keras Callbacks
+    The purpose of the method is to set up logging and history. It is based on
+    Keras Callbacks
     https://github.com/fchollet/keras/blob/fbc9a18f0abc5784607cd4a2a3886558efa3f794/keras/callbacks.py
 
-    Currently used callbacks include: BaseLogger, CSVLogger, EarlyStopping. 
-    Other possible callbacks to add in future: RemoteMonitor, LearningRateScheduler
+    Currently used callbacks include: BaseLogger, CSVLogger, EarlyStopping.
+    Other possible callbacks to add in future:
+    RemoteMonitor, LearningRateScheduler
 
-    Argument list: 
-        - conf: There is a "callbacks" section in conf.yaml file. Relevant parameters are:
-                 list: Parameter specifying additional callbacks, read in the driver script and passed as an argument of type list (see next arg)
-                 metrics: List of quantities monitored during training and validation
-                 mode: one of {auto, min, max}. The decision to overwrite the current save file is made based on either the maximization or the minimization of the monitored quantity. For val_acc, this should be max, for val_loss this should be min, etc. In auto mode, the direction is automatically inferred from the name of the monitored quantity. 
-                 monitor: Quantity used for early stopping, has to be from the list of metrics
-                 patience: Number of epochs used to decide on whether to apply early stopping or continue training
-        - callbacks_list: uses callbacks.list configuration parameter, specifies the list of additional callbacks
-    Returns: modified list of callbacks
+    Argument list:
+        - conf: There is a "callbacks" section in conf.yaml file.
+
+    Relevant parameters are:
+        list: Parameter specifying additional callbacks, read in the driver
+    script and passed as an argument of type list (see next arg)
+        metrics: List of quantities monitored during training and
+    validation
+        mode: one of {auto, min, max}. The decision to overwrite the
+    current save file is made based on either the maximization or the
+    minimization of the monitored quantity. For val_acc, this should be max,
+    for val_loss this should be min, etc. In auto mode, the direction is
+    automatically inferred from the name of the monitored quantity.
+        monitor: Quantity used for early stopping, has to be from the list
+    of metrics
+        patience: Number of epochs used to decide on whether to apply early
+    stopping or continue training
+
+        - callbacks_list: uses callbacks.list configuration parameter,
+          specifies the list of additional callbacks
+
+    Returns:
+        modified list of callbacks
     '''
 
-    mode = conf['callbacks']['mode']
-    monitor = conf['callbacks']['monitor']
-    patience = conf['callbacks']['patience']
+    # mode = conf['callbacks']['mode']
+    # monitor = conf['callbacks']['monitor']
+    # patience = conf['callbacks']['patience']
     csvlog_save_path = conf['paths']['csvlog_save_path']
-    #CSV callback is on by default
+    # CSV callback is on by default
     if not os.path.exists(csvlog_save_path):
-            os.makedirs(csvlog_save_path)
+        os.makedirs(csvlog_save_path)
 
-    callbacks_list = conf['callbacks']['list']
+    # callbacks_list = conf['callbacks']['list']
 
     callbacks = [cbks.BaseLogger()]
-    callbacks += [cbks.CSVLogger("{}callbacks-{}.log".format(csvlog_save_path,datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")))]
-
+    callbacks += [cbks.CSVLogger("{}callbacks-{}.log".format(
+        csvlog_save_path,
+        datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")))
+    ]
     return cbks.CallbackList(callbacks)
 
 
-def train(conf,shot_list_train,shot_list_validate,loader):
+def train(conf, shot_list_train, shot_list_validate, loader):
 
     np.random.seed(1)
 
-    print('validate: {} shots, {} disruptive'.format(len(shot_list_validate),shot_list_validate.num_disruptive()))
-    print('training: {} shots, {} disruptive'.format(len(shot_list_train),shot_list_train.num_disruptive()))
+    print('validate: {} shots, {} disruptive'.format(
+        len(shot_list_validate),
+        shot_list_validate.num_disruptive()))
+    print('training: {} shots, {} disruptive'.format(
+        len(shot_list_train),
+        shot_list_train.num_disruptive()))
 
     num_samples = conf['model']['shallow_model']['num_samples']
     feature_extractor = FeatureExtractor(loader)
     shot_list_train = shot_list_train.random_sublist(debug_use_shots)
-    X,Y,_ = feature_extractor.load_shots(shot_list_train,num_samples = num_samples)
-    Xv,Yv,_ = feature_extractor.load_shots(shot_list_validate,num_samples = num_samples)
-    X = np.concatenate(X,axis=0)
-    Y = np.concatenate(Y,axis=0)
-    Xv = np.concatenate(Xv,axis=0)
-    Yv = np.concatenate(Yv,axis=0)
+    X, Y, _ = feature_extractor.load_shots(
+        shot_list_train, num_samples=num_samples)
+    Xv, Yv, _ = feature_extractor.load_shots(
+        shot_list_validate, num_samples=num_samples)
+    X = np.concatenate(X, axis=0)
+    Y = np.concatenate(Y, axis=0)
+    Xv = np.concatenate(Xv, axis=0)
+    Yv = np.concatenate(Yv, axis=0)
 
-    #max_samples = 100000
-    #num_samples = min(max_samples,len(Y))
-    #indices = np.random.choice(np.array(range(len(Y))),num_samples,replace=False)
-    #X = X[indices]
-    #Y = Y[indices]
+    # max_samples = 100000
+    # num_samples = min(max_samples, len(Y))
+    # indices = np.random.choice(np.array(range(len(Y))), num_samples,
+    #          replace=False)
+    # X = X[indices]
+    # Y = Y[indices]
 
-    print("fitting on {} samples, {} positive".format(len(X),np.sum(Y > 0)))
+    print("fitting on {} samples, {} positive".format(len(X), np.sum(Y > 0)))
     callbacks = build_callbacks(conf)
     callback_metrics = conf['callbacks']['metrics']
     callbacks.set_params({
@@ -316,119 +369,131 @@ def train(conf,shot_list_train,shot_list_validate,loader):
     callbacks.on_train_begin()
     callbacks.on_epoch_begin(0)
 
-    save_prepath = feature_extractor.get_save_prepath()
-    model_path = conf['paths']['model_save_path'] + model_filename #save_prepath + model_filename
+    # save_prepath = feature_extractor.get_save_prepath()
+    model_path = (conf['paths']['model_save_path']
+                  + model_filename)  # save_prepath + model_filename
     makedirs_process_safe(conf['paths']['model_save_path'])
     model_conf = conf['model']['shallow_model']
     if not model_conf['skip_train'] or not os.path.isfile(model_path):
-        
+
         start_time = time.time()
         if model_conf["scale_pos_weight"] != 1:
-            scale_pos_weight_dict = {np.min(Y) : 1, np.max(Y):model_conf["scale_pos_weight"]}
+            scale_pos_weight_dict = {
+                np.min(Y): 1, np.max(Y): model_conf["scale_pos_weight"]}
         else:
             scale_pos_weight_dict = None
         if model_conf['type'] == "svm":
             model = svm.SVC(probability=True,
-                C=model_conf["C"],
-                kernel=model_conf["kernel"],
-                class_weight=scale_pos_weight_dict)
+                            C=model_conf["C"],
+                            kernel=model_conf["kernel"],
+                            class_weight=scale_pos_weight_dict)
         elif model_conf['type'] == "random_forest":
-            model = RandomForestClassifier(n_estimators=model_conf["n_estimators"],
+            model = RandomForestClassifier(
+                n_estimators=model_conf["n_estimators"],
                 max_depth=model_conf["max_depth"],
                 class_weight=scale_pos_weight_dict,
                 n_jobs=-1)
         elif model_conf['type'] == "xgboost":
             max_depth = model_conf["max_depth"]
-            if max_depth == None:
+            if max_depth is None:
                 max_depth = 0
-            model = XGBClassifier(max_depth=max_depth,
+            model = XGBClassifier(
+                max_depth=max_depth,
                 learning_rate=model_conf['learning_rate'],
                 n_estimators=model_conf["n_estimators"],
                 scale_pos_weight=model_conf["scale_pos_weight"])
         elif model_conf['type'] == 'mlp':
-            hidden_layer_sizes = tuple(reversed([model_conf['final_hidden_layer_size']*2**x for x in range(model_conf['num_hidden_layers'])]))
-            model = MLPClassifier(hidden_layer_sizes = hidden_layer_sizes,
-                learning_rate_init = model_conf['learning_rate_mlp'],
-                alpha = model_conf['mlp_regularization'])
+            hidden_layer_sizes = tuple(reversed(
+                [model_conf['final_hidden_layer_size']*2**x
+                 for x in range(model_conf['num_hidden_layers'])]))
+            model = MLPClassifier(
+                hidden_layer_sizes=hidden_layer_sizes,
+                learning_rate_init=model_conf['learning_rate_mlp'],
+                alpha=model_conf['mlp_regularization'])
         else:
             print("Unkown model type, exiting.")
             exit(1)
-        model.fit(X,Y)
-        joblib.dump(model,model_path)
+        model.fit(X, Y)
+        joblib.dump(model, model_path)
         print("Fit model in {} seconds".format(time.time()-start_time))
     else:
         model = joblib.load(model_path)
         print("model exists.")
-    
 
     Y_pred = model.predict(X)
     print("Train")
-    print(classification_report(Y,Y_pred))
+    print(classification_report(Y, Y_pred))
     Y_predv = model.predict(Xv)
     print("Validate")
-    print(classification_report(Yv,Y_predv))
-    #print(confusion_matrix(Y,Y_pred))
-    _,_,_,roc_area,loss = make_predictions_and_evaluate_gpu(conf,shot_list_validate,loader)
-    # _,_,_,roc_area_train,loss_train = make_predictions_and_evaluate_gpu(conf,shot_list_train,loader)   
+    print(classification_report(Yv, Y_predv))
+    # print(confusion_matrix(Y,Y_pred))
+    _, _, _, roc_area, loss = make_predictions_and_evaluate_gpu(
+        conf, shot_list_validate, loader)
+    # _, _, _, roc_area_train, loss_train = make_predictions_and_evaluate_gpu(
+    #          conf, shot_list_train, loader)
 
     print('Validation Loss: {:.3e}'.format(loss))
     print('Validation ROC: {:.4f}'.format(roc_area))
     epoch_logs = {}
-    epoch_logs['val_roc'] = roc_area 
+    epoch_logs['val_roc'] = roc_area
     epoch_logs['val_loss'] = loss
     # epoch_logs['train_roc'] = roc_area_train
-    # epoch_logs['train_loss'] = loss_train 
+    # epoch_logs['train_loss'] = loss_train
     callbacks.on_epoch_end(0, epoch_logs)
-
 
     print('...done')
 
 
-def make_predictions(conf,shot_list,loader,custom_path=None):
+def make_predictions(conf, shot_list, loader, custom_path=None):
     feature_extractor = FeatureExtractor(loader)
-    save_prepath = feature_extractor.get_save_prepath()
-    if custom_path == None:
-        model_path = conf['paths']['model_save_path'] + model_filename#save_prepath + model_filename
+    # save_prepath = feature_extractor.get_save_prepath()
+    if custom_path is None:
+        model_path = conf['paths']['model_save_path'] + \
+            model_filename  # save_prepath + model_filename
     else:
         model_path = custom_path
     model = joblib.load(model_path)
-    #shot_list = shot_list.random_sublist(10)
+    # shot_list = shot_list.random_sublist(10)
 
     y_prime = []
     y_gold = []
     disruptive = []
 
-    pbar =  Progbar(len(shot_list))
-    fn = partial(predict_single_shot,model=model,feature_extractor=feature_extractor)
+    pbar = Progbar(len(shot_list))
+    fn = partial(
+        predict_single_shot,
+        model=model,
+        feature_extractor=feature_extractor)
     pool = mp.Pool()
     print('predicting in parallel on {} processes'.format(pool._processes))
-    #for (y_p,y,disr) in map(fn,shot_list):
-    for (y_p,y,disr) in pool.imap(fn,shot_list):
-        #y_p,y,disr = predict_single_shot(model,feature_extractor,shot)
-        y_prime += [np.expand_dims(y_p,axis=1)]
-        y_gold += [np.expand_dims(y,axis=1)]
+    # for (y_p, y, disr) in map(fn, shot_list):
+    for (y_p, y, disr) in pool.imap(fn, shot_list):
+        # y_p, y, disr = predict_single_shot(model, feature_extractor,shot)
+        y_prime += [np.expand_dims(y_p, axis=1)]
+        y_gold += [np.expand_dims(y, axis=1)]
         disruptive += [disr]
         pbar.add(1.0)
 
     pool.close()
     pool.join()
-    return y_prime,y_gold,disruptive
+    return y_prime, y_gold, disruptive
 
-def predict_single_shot(shot,model,feature_extractor):
-    X,y,disr = feature_extractor.load_shot(shot,is_inference=True)
-    y_p = model.predict_proba(X)[:,1]
-    #print(y)
-    #print(y_p)
+
+def predict_single_shot(shot, model, feature_extractor):
+    X, y, disr = feature_extractor.load_shot(shot, is_inference=True)
+    y_p = model.predict_proba(X)[:, 1]
+    # print(y)
+    # print(y_p)
     y = feature_extractor.prepend_timesteps(y)
     y_p = feature_extractor.prepend_timesteps(y_p)
-    return y_p,y,disr
+    return y_p, y, disr
 
 
-
-def make_predictions_and_evaluate_gpu(conf,shot_list,loader,custom_path = None):
-    y_prime,y_gold,disruptive = make_predictions(conf,shot_list,loader,custom_path)
+def make_predictions_and_evaluate_gpu(
+        conf, shot_list, loader, custom_path=None):
+    y_prime, y_gold, disruptive = make_predictions(
+        conf, shot_list, loader, custom_path)
     analyzer = PerformanceAnalyzer(conf=conf)
-    roc_area = analyzer.get_roc_area(y_prime,y_gold,disruptive)
-    loss = get_loss_from_list(y_prime,y_gold,conf['data']['target'])
-    return y_prime,y_gold,disruptive,roc_area,loss
-
+    roc_area = analyzer.get_roc_area(y_prime, y_gold, disruptive)
+    loss = get_loss_from_list(y_prime, y_gold, conf['data']['target'])
+    return y_prime, y_gold, disruptive, roc_area, loss

--- a/plasma/models/targets.py
+++ b/plasma/models/targets.py
@@ -1,27 +1,32 @@
 import numpy as np
 import abc
 
-from keras.losses import hinge, squared_hinge, mean_absolute_percentage_error
-from plasma.utils.evaluation import mae_np,mse_np,binary_crossentropy_np,hinge_np,squared_hinge_np
+from keras.losses import hinge  # squared_hinge, mean_absolute_percentage_error
+from plasma.utils.evaluation import (
+    mse_np, binary_crossentropy_np, hinge_np,
+    # mae_np, squared_hinge_np,
+    )
 import keras.backend as K
 
-#Requirement: larger value must mean disruption more likely.
+# Requirement: larger value must mean disruption more likely.
+
+
 class Target(object):
     activation = 'linear'
     loss = 'mse'
 
     @abc.abstractmethod
-    def loss_np(y_true,y_pred):
+    def loss_np(y_true, y_pred):
         from plasma.conf import conf
-        return conf['model']['loss_scale_factor']*mse_np(y_true,y_pred)
+        return conf['model']['loss_scale_factor']*mse_np(y_true, y_pred)
 
     @abc.abstractmethod
-    def remapper(ttd,T_warning):
+    def remapper(ttd, T_warning):
         return -ttd
 
     @abc.abstractmethod
     def threshold_range(T_warning):
-        return np.logspace(-1,4,100)
+        return np.logspace(-1, 4, 100)
 
 
 class BinaryTarget(Target):
@@ -29,12 +34,13 @@ class BinaryTarget(Target):
     loss = 'binary_crossentropy'
 
     @staticmethod
-    def loss_np(y_true,y_pred):
-        from plasma.conf import conf 
-        return conf['model']['loss_scale_factor']*binary_crossentropy_np(y_true,y_pred)
+    def loss_np(y_true, y_pred):
+        from plasma.conf import conf
+        return (conf['model']['loss_scale_factor']
+                * binary_crossentropy_np(y_true, y_pred))
 
     @staticmethod
-    def remapper(ttd,T_warning,as_array_of_shots=True):
+    def remapper(ttd, T_warning, as_array_of_shots=True):
         binary_ttd = 0*ttd
         mask = ttd < np.log10(T_warning)
         binary_ttd[mask] = 1.0
@@ -43,28 +49,27 @@ class BinaryTarget(Target):
 
     @staticmethod
     def threshold_range(T_warning):
-        return np.logspace(-6,0,100)
+        return np.logspace(-6, 0, 100)
 
 
 class TTDTarget(Target):
     activation = 'linear'
     loss = 'mse'
 
+    @staticmethod
+    def loss_np(y_true, y_pred):
+        from plasma.conf import conf
+        return conf['model']['loss_scale_factor']*mse_np(y_true, y_pred)
 
     @staticmethod
-    def loss_np(y_true,y_pred):
-        from plasma.conf import conf 
-        return conf['model']['loss_scale_factor']*mse_np(y_true,y_pred)
-
-    @staticmethod
-    def remapper(ttd,T_warning):
+    def remapper(ttd, T_warning):
         mask = ttd < np.log10(T_warning)
         ttd[~mask] = np.log10(T_warning)
         return -ttd
 
     @staticmethod
     def threshold_range(T_warning):
-        return np.linspace(-np.log10(T_warning),6,100)
+        return np.linspace(-np.log10(T_warning), 6, 100)
 
 
 class TTDInvTarget(Target):
@@ -72,21 +77,21 @@ class TTDInvTarget(Target):
     loss = 'mse'
 
     @staticmethod
-    def loss_np(y_true,y_pred):
-        return mse_np(y_true,y_pred)
+    def loss_np(y_true, y_pred):
+        return mse_np(y_true, y_pred)
 
     @staticmethod
-    def remapper(ttd,T_warning):
+    def remapper(ttd, T_warning):
         eps = 1e-4
         ttd = 10**(ttd)
         mask = ttd < T_warning
         ttd[~mask] = T_warning
-        ttd = (1.0)/(ttd+eps)#T_warning
+        ttd = (1.0)/(ttd+eps)  # T_warning
         return ttd
 
     @staticmethod
     def threshold_range(T_warning):
-        return np.logspace(-6,np.log10(T_warning),100)
+        return np.logspace(-6, np.log10(T_warning), 100)
 
 
 class TTDLinearTarget(Target):
@@ -94,26 +99,25 @@ class TTDLinearTarget(Target):
     loss = 'mse'
 
     @staticmethod
-    def loss_np(y_true,y_pred):
+    def loss_np(y_true, y_pred):
         from plasma.conf import conf
-        return conf['model']['loss_scale_factor']*mse_np(y_true,y_pred)
-    
+        return conf['model']['loss_scale_factor']*mse_np(y_true, y_pred)
 
     @staticmethod
-    def remapper(ttd,T_warning):
+    def remapper(ttd, T_warning):
         ttd = 10**(ttd)
         mask = ttd < T_warning
-        ttd[~mask] = 0#T_warning
-        ttd[mask] = T_warning - ttd[mask]#T_warning
+        ttd[~mask] = 0  # T_warning
+        ttd[mask] = T_warning - ttd[mask]  # T_warning
         return ttd
 
     @staticmethod
     def threshold_range(T_warning):
-        return np.logspace(-6,np.log10(T_warning),100)
+        return np.logspace(-6, np.log10(T_warning), 100)
 
 
-#implements a "maximum" driven loss function. Only the maximal value in the time sequence is punished.
-#Also implements class weighting
+# implements a "maximum" driven loss function. Only the maximal value in the
+# time sequence is punished. Also implements class weighting
 class MaxHingeTarget(Target):
     activation = 'linear'
     fac = 1.0
@@ -122,35 +126,46 @@ class MaxHingeTarget(Target):
     def loss(y_true, y_pred):
         from plasma.conf import conf
         fac = MaxHingeTarget.fac
-        #overall_fac = np.prod(np.array(K.shape(y_pred)[1:]).astype(np.float32))
-        overall_fac = K.prod(K.cast(K.shape(y_pred)[1:],K.floatx()))
-        max_val = K.max(y_pred,axis=-2) #temporal axis!
-        max_val1 = K.repeat(max_val,K.shape(y_pred)[-2])
-        mask = K.cast(K.equal(max_val1,y_pred),K.floatx())
+        # overall_fac =
+        # np.prod(np.array(K.shape(y_pred)[1:]).astype(np.float32))
+        overall_fac = K.prod(K.cast(K.shape(y_pred)[1:], K.floatx()))
+        max_val = K.max(y_pred, axis=-2)  # temporal axis!
+        max_val1 = K.repeat(max_val, K.shape(y_pred)[-2])
+        mask = K.cast(K.equal(max_val1, y_pred), K.floatx())
         y_pred1 = mask * y_pred + (1-mask) * y_true
-        weight_mask = K.mean(y_true,axis=-1)
-        weight_mask = K.cast(K.greater(weight_mask,0.0),K.floatx()) #positive label!
+        weight_mask = K.mean(y_true, axis=-1)
+        weight_mask = K.cast(K.greater(weight_mask, 0.0),
+                             K.floatx())  # positive label!
         weight_mask = fac*weight_mask + (1 - weight_mask)
-        #return weight_mask*squared_hinge(y_true,y_pred1)
-        return conf['model']['loss_scale_factor']*overall_fac*weight_mask*hinge(y_true,y_pred1)
+        # return weight_mask*squared_hinge(y_true, y_pred1)
+        return conf['model']['loss_scale_factor'] * \
+            overall_fac*weight_mask*hinge(y_true, y_pred1)
 
     @staticmethod
     def loss_np(y_true, y_pred):
         from plasma.conf import conf
         fac = MaxHingeTarget.fac
-        #print(y_pred.shape)
+        # print(y_pred.shape)
         overall_fac = np.prod(np.array(y_pred.shape).astype(np.float32))
-        max_val = np.max(y_pred,axis=-2) #temporal axis!
-        max_val = np.reshape(max_val,max_val.shape[:-1] + (1,) + (max_val.shape[-1],))
-        max_val = np.tile(max_val,(1,y_pred.shape[-2],1))
-        mask = np.equal(max_val,y_pred)
+        max_val = np.max(y_pred, axis=-2)  # temporal axis!
+        max_val = np.reshape(
+            max_val, max_val.shape[:-1] + (1,) + (max_val.shape[-1],))
+        max_val = np.tile(max_val, (1, y_pred.shape[-2], 1))
+        mask = np.equal(max_val, y_pred)
         mask = mask.astype(np.float32)
         y_pred = mask * y_pred + (1-mask) * y_true
-        weight_mask = np.greater(y_true,0.0).astype(np.float32) #positive label!
+        weight_mask = np.greater(
+            y_true, 0.0).astype(
+            np.float32)  # positive label!
         weight_mask = fac*weight_mask + (1 - weight_mask)
-        #return np.mean(weight_mask*np.square(np.maximum(1. - y_true * y_pred, 0.)))#, axis=-1) only during training, here we want to completely sum up over all instances
-        return conf['model']['loss_scale_factor']*np.mean(overall_fac*weight_mask*np.maximum(1. - y_true * y_pred, 0.))#, axis=-1) only during training, here we want to completely sum up over all instances
-
+        # return np.mean(
+        #  weight_mask*np.square(np.maximum(1. - y_true * y_pred, 0.)))
+        # , axis=-1)
+        # only during training, here we want to completely sum up over all
+        # instances
+        return (conf['model']['loss_scale_factor']
+                * np.mean(overall_fac * weight_mask
+                          * np.maximum(1. - y_true * y_pred, 0.)))
 
     # def _loss_tensor_old(y_true, y_pred):
     #     max_val = K.max(y_pred) #temporal axis!
@@ -158,9 +173,8 @@ class MaxHingeTarget(Target):
     #     y_pred = mask * y_pred + (1-mask) * y_true
     #     return squared_hinge(y_true,y_pred)
 
-
     @staticmethod
-    def remapper(ttd,T_warning,as_array_of_shots=True):
+    def remapper(ttd, T_warning, as_array_of_shots=True):
         binary_ttd = 0*ttd
         mask = ttd < np.log10(T_warning)
         binary_ttd[mask] = 1.0
@@ -169,22 +183,24 @@ class MaxHingeTarget(Target):
 
     @staticmethod
     def threshold_range(T_warning):
-        return np.concatenate((np.linspace(-2,-1.06,100),np.linspace(-1.06,-0.96,100),np.linspace(-0.96,2,50)))
+        return np.concatenate(
+            (np.linspace(-2, -1.06, 100), np.linspace(-1.06, -0.96, 100),
+             np.linspace(-0.96, 2, 50)))
 
 
 class HingeTarget(Target):
     activation = 'linear'
 
-    loss = 'hinge' #hinge
-    
+    loss = 'hinge'  # hinge
+
     @staticmethod
     def loss_np(y_true, y_pred):
         from plasma.conf import conf
-        return conf['model']['loss_scale_factor']*hinge_np(y_true,y_pred)
-        #return squared_hinge_np(y_true,y_pred)
-        
+        return conf['model']['loss_scale_factor']*hinge_np(y_true, y_pred)
+        # return squared_hinge_np(y_true, y_pred)
+
     @staticmethod
-    def remapper(ttd,T_warning,as_array_of_shots=True):
+    def remapper(ttd, T_warning, as_array_of_shots=True):
         binary_ttd = 0*ttd
         mask = ttd < np.log10(T_warning)
         binary_ttd[mask] = 1.0
@@ -193,4 +209,6 @@ class HingeTarget(Target):
 
     @staticmethod
     def threshold_range(T_warning):
-        return np.concatenate((np.linspace(-2,-1.06,100),np.linspace(-1.06,-0.96,100),np.linspace(-0.96,2,50)))
+        return np.concatenate(
+            (np.linspace(-2, -1.06, 100), np.linspace(-1.06, -0.96, 100),
+             np.linspace(-0.96, 2, 50)))

--- a/plasma/preprocessor/augment.py
+++ b/plasma/preprocessor/augment.py
@@ -1,13 +1,11 @@
 from __future__ import print_function
-import os
-import time,sys
 import abc
 import numpy as np
 import random
 
 
 class ByShotAugmentator(object):
-    def __init__(self,normalizer):
+    def __init__(self, normalizer):
         self.normalizer = normalizer
 
     def __str__(self):
@@ -15,35 +13,39 @@ class ByShotAugmentator(object):
         s += "\n including by shot augmentation"
         return s
 
-    def apply(self,shot):
+    def apply(self, shot):
         '''
-        The purpose of the method is to apply normalization to a shot and then optionally apply augmentation with a function that is individual to every shot.
+        The purpose of the method is to apply normalization to a shot and then
+        optionally apply augmentation with a function that is individual to
+        every shot.
 
-        Argument list: 
+        Argument list:
           - shot: plasma shot. Should contain an augment function
 
         Config parameters list:
-          - conf['data']['augment_during_training']: boolean flag, yes or no to augment during training
+          - conf['data']['augment_during_training']: boolean flag, yes or no to
+        augment during training
+
         '''
-        #first just apply normalization as usual.
+        # first just apply normalization as usual.
         self.normalizer.apply(shot)
         if shot.augmentation_fn is not None:
             shot.augmentation_fn(shot)
 
-    def set_inference_mode(self,is_inference):
+    def set_inference_mode(self, is_inference):
         self.normalizer.set_inference_mode(is_inference)
 
 
 class AbstractAugmentator(object):
 
-    def __init__(self,normalizer,is_inference,conf):
+    def __init__(self, normalizer, is_inference, conf):
         self.conf = conf
         self.to_augment_str = self.conf['data']['signal_to_augment']
         self.normalizer = normalizer
         self.is_inference = is_inference
 
-    #set whether we are training or testing
-    def set_inference(self,is_inference):
+    # set whether we are training or testing
+    def set_inference(self, is_inference):
         self.is_inference = is_inference
 
     def __str__(self):
@@ -52,78 +54,89 @@ class AbstractAugmentator(object):
         s += "Signal to augmented: {}\n".format(self.to_augment_str)
         s += "Is inference: {}\n".format(self.is_inference)
         return s
-    
-    #for compatibility with code that changes the mode of the normalizer
-    def set_inference_mode(self,is_inference):
+
+    # for compatibility with code that changes the mode of the normalizer
+    def set_inference_mode(self, is_inference):
         self.normalizer.set_inference_mode(is_inference)
 
     @abc.abstractmethod
-    def apply(self,shot):
+    def apply(self, shot):
         pass
 
     @abc.abstractmethod
-    def augment(self,sig):
+    def augment(self, sig):
         pass
-    
+
 
 class Augmentator(AbstractAugmentator):
 
-    def apply(self,shot):
+    def apply(self, shot):
         '''
-        The purpose of the method is to apply normalization to a shot and then optionally apply augmentation.
-        During inference, a specific signal (one at a time) is augmented based on the string supplied in the config file.
-        During training, augment a random signal (again, one at a time) or do not augment at all.
+        The purpose of the method is to apply normalization to a shot and then
+        optionally apply augmentation.  During inference, a specific signal
+        (one at a time) is augmented based on the string supplied in the config
+        file.  During training, augment a random signal (again, one at a time)
+        or do not augment at all.
 
         It performs calls to: Augmentator.augment(), random.random.choice
 
-        Argument list: 
+        Argument list:
           - shot: plasma shot
 
         Config parameters list:
-          - conf['data']['augment_during_training']: boolean flag, yes or no to augment during training
+          - conf['data']['augment_during_training']: boolean flag, yes or no to
+        augment during training
+
         '''
-        #first just apply normalization as usual.
+        # first just apply normalization as usual.
         self.normalizer.apply(shot)
         if self.is_inference:
-            #during inference, augment a specific signal (one at a time)
+            # during inference, augment a specific signal (one at a time)
             to_augment_str = self.to_augment_str
-        else: 
-            #during training augment a random signal, one at a time
+        else:
+            # during training augment a random signal, one at a time
             if self.conf['data']['augment_during_training']:
-                to_augment_str = random.choice([x.description for x in shot.signals])
+                to_augment_str = random.choice(
+                    [x.description for x in shot.signals])
             else:
-                to_augment_str = None 
+                to_augment_str = None
         if to_augment_str is not None:
-            #FIXME might be better to use search. are we always going to augment 1 signal at a time? 
-            for (i,sig) in enumerate(shot.signals):
+            # FIXME might be better to use search. are we always going to
+            # augment 1 signal at a time?
+            for (i, sig) in enumerate(shot.signals):
                 if sig.description == to_augment_str:
-                    print ('Augmenting {} signal'.format(sig.description))
-                    shot.signals_dict[sig] = self.augment(shot.signals_dict[sig])
+                    print('Augmenting {} signal'.format(sig.description))
+                    shot.signals_dict[sig] = self.augment(
+                        shot.signals_dict[sig])
 
-    def augment(self,signal,strength=10):
+    def augment(self, signal, strength=10):
         '''
-        The purpose of the method is to modify a signal specified by a configuration parameter or at random according to 
-        a specific mode. Modes include: noise, zeroing and no augmentation.
+        The purpose of the method is to modify a signal specified by a
+        configuration parameter or at random according to a specific
+        mode. Modes include: noise, zeroing and no augmentation.
 
         It performs calls to: numpy random number generator
 
-        Argument list: 
+        Argument list:
           - signal: signal
-          - strength: strength of the noise, measured in standard deviations. Integer, default value: 10
+          - strength: strength of the noise, measured in standard
+        deviations. Integer, default value: 10
 
         Config parameters list:
-          - conf['data']['augmentation_mode']: categorical config parameter specifying how to augment. Possible values
-                                               include "noise", "zero" and "none" (strings)
+          - conf['data']['augmentation_mode']: categorical config parameter
+        specifying how to augment. Possible values include "noise", "zero" and
+        "none" (strings)
 
-        Returns:  
+        Returns:
           - signal: augmented signal ... numpy array of numeric types?
         '''
         if self.conf['data']['augmentation_mode'] == "noise":
-            return np.random.normal(0,strength,signal.shape) 
+            return np.random.normal(0, strength, signal.shape)
         elif self.conf['data']['augmentation_mode'] == "zero":
-            return signal*0.0 #if "set to zero" augmentation. Can control in conf.
+            # if "set to zero" augmentation. Can control in conf.
+            return signal*0.0
         elif self.conf['data']['augmentation_mode'] == "none":
-            return signal #if no augmentation. Should be the default in conf.
+            return signal  # if no augmentation. Should be the default in conf.
         else:
             print("Unknown augmentation mode. Exiting")
             exit(-1)

--- a/plasma/preprocessor/normalize.py
+++ b/plasma/preprocessor/normalize.py
@@ -10,32 +10,34 @@ This work was supported by the DOE CSGF program.
 
 from __future__ import print_function
 import os
-import time,sys
+import time
+import sys
 import abc
 
 import numpy as np
-from scipy.signal import exponential,correlate
+from scipy.signal import exponential, correlate
 import pathos.multiprocessing as mp
 
 from plasma.primitives.shots import ShotList, Shot
-from plasma.utils.processing import get_signal_slices
 
 '''TODO
 - incorporate stats, pass machine (perhaps save machine in stats object!)
 - incorporate stats, have a dictionary of aggregate stats for every machine.
-- check "is_previously_saved" by making sure there is a normalizer for every machine
+- check "is_previously_saved" by making sure there is a normalizer for every
+machine
+
 '''
 
 
-
-
-#######NORMALIZATION##########
+#################
+# NORMALIZATION #
+#################
 class Stats(object):
     pass
 
 
 class Normalizer(object):
-    def __init__(self,conf):
+    def __init__(self, conf):
         self.num_processed = dict()
         self.num_disruptive = dict()
         self.conf = conf
@@ -50,15 +52,15 @@ class Normalizer(object):
         pass
 
     @abc.abstractmethod
-    def extract_stats(self,shot):
+    def extract_stats(self, shot):
         pass
 
     @abc.abstractmethod
-    def incorporate_stats(self,stats):
+    def incorporate_stats(self, stats):
         pass
 
     @abc.abstractmethod
-    def apply(self,shot):
+    def apply(self, shot):
         pass
 
     @abc.abstractmethod
@@ -69,19 +71,20 @@ class Normalizer(object):
     def load_stats(self):
         pass
 
-    def set_inference_mode(self,val):
+    def set_inference_mode(self, val):
         self.inference_mode = val
 
-    def ensure_machine(self,machine):
+    def ensure_machine(self, machine):
         if machine not in self.means:
-                self.num_processed[machine] = 0
-                self.num_disruptive[machine] = 0
-    ######Modify the above to change the specifics of the normalization scheme#######
+            self.num_processed[machine] = 0
+            self.num_disruptive[machine] = 0
+    # Modify the above to change the specifics of the normalization scheme
 
     def train(self):
         conf = self.conf
-        #only use training shots here!! "Don't touch testing shots"
-        shot_files = conf['paths']['shot_files']# + conf['paths']['shot_files_test']
+        # only use training shots here!! "Don't touch testing shots"
+        # + conf['paths']['shot_files_test']
+        shot_files = conf['paths']['shot_files']
         shot_files_all = conf['paths']['shot_files_all']
         all_machines = set([file.machine for file in shot_files_all])
         train_machines = set([file.machine for file in shot_files])
@@ -89,22 +92,22 @@ class Normalizer(object):
         if train_machines >= all_machines:
             shot_files_use = shot_files
         else:
-            print('Testing set contains new machine, using testing set to train normalizer for that machine.')
+            print('Testing set contains new machine, using testing set ',
+                  'to train normalizer for that machine.')
             shot_files_use = shot_files_all
 
         # shot_list_dir = conf['paths']['shot_list_dir']
-        use_shots = max(400,conf['data']['use_shots'])
-        return self.train_on_files(shot_files_use,use_shots,all_machines)
+        use_shots = max(400, conf['data']['use_shots'])
+        return self.train_on_files(shot_files_use, use_shots, all_machines)
 
-
-    def train_on_files(self,shot_files,use_shots,all_machines):
+    def train_on_files(self, shot_files, use_shots, all_machines):
         conf = self.conf
-        all_signals = conf['paths']['all_signals'] 
+        all_signals = conf['paths']['all_signals']
         shot_list = ShotList()
-        shot_list.load_from_shot_list_files_objects(shot_files,all_signals)
-        shot_list_picked = shot_list.random_sublist(use_shots) 
+        shot_list.load_from_shot_list_files_objects(shot_files, all_signals)
+        shot_list_picked = shot_list.random_sublist(use_shots)
 
-        previously_saved,machines_saved = self.previously_saved_stats()
+        previously_saved, machines_saved = self.previously_saved_stats()
         machines_to_compute = all_machines - machines_saved
         recompute = conf['data']['recompute_normalization']
         if recompute:
@@ -114,34 +117,43 @@ class Normalizer(object):
         if not previously_saved or len(machines_to_compute) > 0:
             if previously_saved:
                 self.load_stats()
-            print('computing normalization for machines {}'.format(machines_to_compute))
-            use_cores = max(1,mp.cpu_count()-2)
+            print('computing normalization for machines {}'.format(
+                machines_to_compute))
+            use_cores = max(1, mp.cpu_count()-2)
             pool = mp.Pool(use_cores)
-            print('running in parallel on {} processes'.format(pool._processes))
+            print('running in parallel on {} processes'.format(
+                pool._processes))
             start_time = time.time()
 
-            for (i,stats) in enumerate(pool.imap_unordered(self.train_on_single_shot,shot_list_picked)):
-            #for (i,stats) in enumerate(map(self.train_on_single_shot,shot_list_picked)):
+            for (i, stats) in enumerate(pool.imap_unordered(
+                    self.train_on_single_shot,
+                    shot_list_picked)):
+                # for (i,stats) in
+                # enumerate(map(self.train_on_single_shot,shot_list_picked)):
                 if stats.machine in machines_to_compute:
                     self.incorporate_stats(stats)
                     self.machines.add(stats.machine)
-                sys.stdout.write('\r' + '{}/{}'.format(i,len(shot_list_picked)))
+                sys.stdout.write('\r'
+                                 + '{}/{}'.format(i, len(shot_list_picked)))
 
             pool.close()
             pool.join()
-            print('Finished Training Normalizer on {} files in {} seconds'.format(len(shot_list_picked),time.time()-start_time))
+            print('Finished Training Normalizer on ',
+                  '{} files in {} seconds'.format(len(shot_list_picked),
+                                                  time.time()-start_time))
             self.save_stats()
         else:
             self.load_stats()
         print(self)
 
-
-    def cut_end_of_shot(self,shot):
+    def cut_end_of_shot(self, shot):
         cut_shot_ends = self.conf['data']['cut_shot_ends']
-        if not self.inference_mode and cut_shot_ends: #only cut shots during training
+        # only cut shots during training
+        if not self.inference_mode and cut_shot_ends:
             T_min_warn = self.conf['data']['T_min_warn']
             for key in shot.signals_dict:
-                shot.signals_dict[key] = shot.signals_dict[key][:-T_min_warn,:]
+                shot.signals_dict[key] = shot.signals_dict[key][:-T_min_warn,
+                                                                :]
             shot.ttd = shot.ttd[:-T_min_warn]
 
     # def apply_mask(self,shot):
@@ -151,18 +163,19 @@ class Normalizer(object):
     # def apply_positivity_mask(self,shot):
     #     mask = self.conf['paths']['positivity_mask']
     #     mask = [np.array(subl) for subl in mask]
-    #     indices = np.concatenate([indices_sublist[mask[i]] for i,indices_sublist in enumerate(self.get_indices_list())])
+    #     indices = np.concatenate([indices_sublist[mask[i]] for
+    #     i,indices_sublist in enumerate(self.get_indices_list())])
     #     shot.signals[:,indices] = np.clip(shot.signals[:,indices],0,np.Inf)
 
-    def train_on_single_shot(self,shot):
-        assert isinstance(shot,Shot), 'should be instance of shot'
+    def train_on_single_shot(self, shot):
+        assert isinstance(shot, Shot), 'should be instance of shot'
         processed_prepath = self.conf['paths']['processed_prepath']
         shot.restore(processed_prepath)
-        #print(shot)
-        stats = self.extract_stats(shot) 
+        # print(shot)
+        stats = self.extract_stats(shot)
         shot.make_light()
         return stats
-    
+
     def ensure_save_directory(self):
         prepath = os.path.dirname(self.path)
         if not os.path.exists(prepath):
@@ -170,27 +183,25 @@ class Normalizer(object):
 
     def previously_saved_stats(self):
         if not os.path.isfile(self.path):
-            return False,set([])
+            return False, set([])
         else:
-            dat = np.load(self.path,encoding="latin1")
+            dat = np.load(self.path, encoding="latin1")
             machines = dat['machines'][()]
-            ret =  all([m in machines for m in self.conf['paths']['all_machines']])
+            ret = all(
+                [m in machines for m in self.conf['paths']['all_machines']])
             if not ret:
                 print(machines)
                 print(self.conf['paths']['all_machines'])
                 print('Not all machines present. Recomputing normalizer.')
-            return True,set(machines)
+            return True, set(machines)
 
     # def get_indices_list(self):
     #     return get_signal_slices(self.conf['paths']['signals_dirs'])
 
 
-
-
-
 class MeanVarNormalizer(Normalizer):
-    def __init__(self,conf):
-        Normalizer.__init__(self,conf)
+    def __init__(self, conf):
+        Normalizer.__init__(self, conf)
         self.means = dict()
         self.stds = dict()
         self.bound = self.conf['data']['norm_stat_range']
@@ -198,19 +209,23 @@ class MeanVarNormalizer(Normalizer):
     def __str__(self):
         s = ''
         for machine in self.means:
-                means = np.median(self.means[machine],axis=0)
-                stds = np.median(self.stds[machine],axis=0)
-                s += 'Machine: {}:\nMean Var Normalizer.\nmeans: {}\nstds: {}'.format(machine,means,stds)
-        return s 
+            means = np.median(self.means[machine], axis=0)
+            stds = np.median(self.stds[machine], axis=0)
+            s += 'Machine: {}:\nMean Var Normalizer.\n'.format(machine)
+            s += 'means: {}\nstds: {}'.format(means, stds)
+        return s
 
-    def extract_stats(self,shot):
+    def extract_stats(self, shot):
         stats = Stats()
         if shot.valid:
             list_of_signals = shot.get_individual_signal_arrays()
             num_signals = len(list_of_signals)
-            stats.means = np.reshape(np.array([np.mean(sig) for sig in list_of_signals]),(1,num_signals))
-            stats.stds = np.reshape(np.array([np.std(sig,dtype=np.float64) for sig in list_of_signals]),(1,num_signals))
-                
+            stats.means = np.reshape(np.array([np.mean(sig) for
+                                               sig in list_of_signals]),
+                                     (1, num_signals))
+            stats.stds = np.reshape(np.array([np.std(sig, dtype=np.float64) for
+                                              sig in list_of_signals]),
+                                    (1, num_signals))
             stats.is_disruptive = shot.is_disruptive
         else:
             print('Warning: shot {} not valid, omitting'.format(shot.number))
@@ -218,9 +233,7 @@ class MeanVarNormalizer(Normalizer):
         stats.machine = shot.machine
         return stats
 
-
-
-    def incorporate_stats(self,stats):
+    def incorporate_stats(self, stats):
         machine = stats.machine
         self.ensure_machine(stats.machine)
         if stats.valid:
@@ -228,95 +241,113 @@ class MeanVarNormalizer(Normalizer):
             stds = stats.stds
             if self.num_processed[machine] == 0:
                 self.means[machine] = means
-                self.stds[machine] = stds 
+                self.stds[machine] = stds
             else:
-                self.means[machine] = np.concatenate((self.means[machine],means),axis=0)
-                self.stds[machine] = np.concatenate((self.stds[machine],stds),axis=0)
+                self.means[machine] = np.concatenate(
+                    (self.means[machine], means), axis=0)
+                self.stds[machine] = np.concatenate(
+                    (self.stds[machine], stds), axis=0)
             self.num_processed[machine] = self.num_processed[machine] + 1
-            self.num_disruptive[machine] = self.num_disruptive[machine] + (1 if stats.is_disruptive else 0)
+            self.num_disruptive[machine] = self.num_disruptive[machine] + \
+                (1 if stats.is_disruptive else 0)
 
-
-    def apply(self,shot):
+    def apply(self, shot):
         apply_positivity(shot)
         m = shot.machine
-        assert self.means[m] is not None and self.stds[m] is not None, "self.means or self.stds not initialized"
-        means = np.median(self.means[m],axis=0)
-        stds = np.median(self.stds[m],axis=0)
-        for (i,sig) in enumerate(shot.signals):
+        assert self.means[m] is not None and self.stds[m] is not None, (
+            "self.means or self.stds not initialized")
+        means = np.median(self.means[m], axis=0)
+        stds = np.median(self.stds[m], axis=0)
+        for (i, sig) in enumerate(shot.signals):
             if sig.normalize:
                 stds_curr = stds[i]
                 if stds_curr == 0.0:
                     stds_curr = 1.0
-                shot.signals_dict[sig] = (shot.signals_dict[sig] - means[i])/stds_curr
-                shot.signals_dict[sig] = np.clip(shot.signals_dict[sig],-self.bound,self.bound)
+                shot.signals_dict[sig] = (
+                    shot.signals_dict[sig] - means[i])/stds_curr
+                shot.signals_dict[sig] = np.clip(
+                    shot.signals_dict[sig], -self.bound, self.bound)
 
-        shot.ttd = self.remapper(shot.ttd,self.conf['data']['T_warning'])
+        shot.ttd = self.remapper(shot.ttd, self.conf['data']['T_warning'])
         self.cut_end_of_shot(shot)
         # self.apply_positivity_mask(shot)
         # self.apply_mask(shot)
-
 
     def save_stats(self):
         # standard_deviations = dat['standard_deviations']
         # num_processed = dat['num_processed']
         # num_disruptive = dat['num_disruptive']
         self.ensure_save_directory()
-        np.savez(self.path,means = self.means,stds = self.stds,
-         num_processed=self.num_processed,num_disruptive=self.num_disruptive,machines=self.machines)
-        print('saved normalization data from {} shots ( {} disruptive )'.format(self.num_processed,self.num_disruptive))
+        np.savez(
+            self.path,
+            means=self.means,
+            stds=self.stds,
+            num_processed=self.num_processed,
+            num_disruptive=self.num_disruptive,
+            machines=self.machines)
+        print(
+            'saved normalization data from {} shots ( {} disruptive )'.format(
+                self.num_processed,
+                self.num_disruptive))
 
     def load_stats(self):
         assert self.previously_saved_stats()[0], "stats not saved before"
-        dat = np.load(self.path,encoding="latin1")
+        dat = np.load(self.path, encoding="latin1")
         self.means = dat['means'][()]
         self.stds = dat['stds'][()]
         self.num_processed = dat['num_processed'][()]
         self.num_disruptive = dat['num_disruptive'][()]
         self.machines = dat['machines'][()]
         for machine in self.means:
-                print('Machine {}:'.format(machine))
-                print('loaded normalization data from {} shots ( {} disruptive )'.format(self.num_processed,self.num_disruptive))
-        #print('loading normalization data from {} shots, {} disruptive'.format(num_processed,num_disruptive))
+            print('Machine {}:'.format(machine))
+            print('loaded normalization data from ',
+                  '{} shots ( {} disruptive )'.format(self.num_processed,
+                                                      self.num_disruptive))
 
 
 class VarNormalizer(MeanVarNormalizer):
-    def apply(self,shot):
+    def apply(self, shot):
         apply_positivity(shot)
-        assert self.means is not None and self.stds is not None, "self.means or self.stds not initialized"
+        assert self.means is not None and self.stds is not None, (
+            "self.means or self.stds not initialized")
         m = shot.machine
-        stds = np.median(self.stds[m],axis=0)
-        for (i,sig) in enumerate(shot.signals):
+        stds = np.median(self.stds[m], axis=0)
+        for (i, sig) in enumerate(shot.signals):
             if sig.normalize:
                 stds_curr = stds[i]
                 if stds_curr == 0.0:
                     stds_curr = 1.0
                 shot.signals_dict[sig] = (shot.signals_dict[sig])/stds_curr
-                shot.signals_dict[sig] = np.clip(shot.signals_dict[sig],-self.bound,self.bound)
-        shot.ttd = self.remapper(shot.ttd,self.conf['data']['T_warning'])
+                shot.signals_dict[sig] = np.clip(
+                    shot.signals_dict[sig], -self.bound, self.bound)
+        shot.ttd = self.remapper(shot.ttd, self.conf['data']['T_warning'])
         self.cut_end_of_shot(shot)
 
     def __str__(self):
         s = ''
         for m in self.stds:
-                stds = np.median(self.stds[m],axis=0)
-                s += 'Machine: {}:\n'.format(m)
-                s += 'Var Normalizer.\nstds: {}\n'.format(stds)
+            stds = np.median(self.stds[m], axis=0)
+            s += 'Machine: {}:\n'.format(m)
+            s += 'Var Normalizer.\nstds: {}\n'.format(stds)
         return s
 
 
 class AveragingVarNormalizer(VarNormalizer):
 
-    def apply(self,shot):
+    def apply(self, shot):
         apply_positivity(shot)
-        super(AveragingVarNormalizer,self).apply(shot)
+        super(AveragingVarNormalizer, self).apply(shot)
         window_decay = self.conf['data']['window_decay']
         window_size = self.conf['data']['window_size']
-        window = exponential(window_size,0,window_decay,False)
+        window = exponential(window_size, 0, window_decay, False)
         window /= np.sum(window)
-        for (i,sig) in enumerate(shot.signals):
+        for (i, sig) in enumerate(shot.signals):
             if sig.normalize:
-                shot.signals_dict[sig] = apply_along_axis(lambda m : correlate(m,window,'valid'),axis=0,arr=shot.signals_dict[sig])
-                shot.signals_dict[sig] = np.clip(shot.signals_dict[sig],-self.bound,self.bound)
+                shot.signals_dict[sig] = np.apply_along_axis(
+                    lambda m: correlate(m, window, 'valid'),
+                    axis=0, arr=shot.signals_dict[sig])
+                shot.signals_dict[sig] = np.clip(
+                    shot.signals_dict[sig], -self.bound, self.bound)
         shot.ttd = shot.ttd[-shot.signals.shape[0]:]
 
     def __str__(self):
@@ -324,27 +355,30 @@ class AveragingVarNormalizer(VarNormalizer):
         window_size = self.conf['data']['window_size']
         s = ''
         for m in self.stds:
-                stds = np.median(self.stds[m],axis=0)
-                s += 'Machine: {}:\n'.format(m)
-                s += 'Averaging Var Normalizer.\nstds: {}\nWindow size: {}, Window decay: {}'.format(stds,window_size,window_decay)
+            stds = np.median(self.stds[m], axis=0)
+            s += 'Machine: {}:\n'.format(m)
+            s += 'Averaging Var Normalizer.\nstds: '
+            s += ' {}\nWindow size: {}, Window decay: {}'.format(
+                stds, window_size, window_decay)
         return s
 
 
 class MinMaxNormalizer(Normalizer):
-    def __init__(self,conf):
-        Normalizer.__init__(self,conf)
+    def __init__(self, conf):
+        Normalizer.__init__(self, conf)
         self.minimums = None
         self.maximums = None
         self.bound = self.conf['data']['norm_stat_range']
 
-
     def __str__(self):
         s = ''
         for m in self.minimums:
-                s += 'Machine {}:\n.Min Max Normalizer.\nminimums: {}\nmaximums: {}'.format(m,self.minimums[m],self.maximums[m])
-        return s 
+            s += 'Machine {}:\n.Min Max Normalizer.\n'.format(m,
+                                                              self.minimums[m])
+            s += 'minimums: {}\nmaximums: {}'.format(self.maximums[m])
+        return s
 
-    def extract_stats(self,shot):
+    def extract_stats(self, shot):
         stats = Stats()
         if shot.valid:
             list_of_signals = shot.get_individual_signal_arrays()
@@ -357,8 +391,7 @@ class MinMaxNormalizer(Normalizer):
         stats.machine = shot.machine
         return stats
 
-
-    def incorporate_stats(self,stats):
+    def incorporate_stats(self, stats):
         self.ensure_machine(stats.machine)
         if stats.valid:
             m = stats.machine
@@ -368,25 +401,30 @@ class MinMaxNormalizer(Normalizer):
                 self.minimums[m] = minimums
                 self.maximums[m] = maximums
             else:
-                self.minimums[m] = (self.num_processed[m]*self.minimums + minimums)/(self.num_processed[m] + 1.0)#snp.min(vstack((self.minimums,minimums)),0)
-                self.maximums[m] = (self.num_processed[m]*self.maximums + maximums)/(self.num_processed[m] + 1.0)#snp.max(vstack((self.maximums,maximums)),0)
+                self.minimums[m] = (self.num_processed[m]*self.minimums
+                                    + minimums)/(self.num_processed[m] + 1.0)
+                self.maximums[m] = (self.num_processed[m]*self.maximums
+                                    + maximums)/(self.num_processed[m] + 1.0)
             self.num_processed[m] = self.num_processed[m] + 1
-            self.num_disruptive[m] = self.num_disruptive[m] + (1 if stats.is_disruptive else 0)
+            self.num_disruptive[m] = self.num_disruptive[m] + \
+                (1 if stats.is_disruptive else 0)
 
-
-    def apply(self,shot):
+    def apply(self, shot):
         apply_positivity(shot)
-        assert(self.minimums is not None and self.maximums is not None) 
+        assert(self.minimums is not None and self.maximums is not None)
         m = shot.machine
         curr_range = (self.maximums[m] - self.minimums[m])
         if curr_range == 0.0:
-                curr_range = 1.0
+            curr_range = 1.0
         shot.signals = (shot.signals - self.minimums[m])/curr_range
-        for (i,sig) in enumerate(shot.signals):
+        for (i, sig) in enumerate(shot.signals):
             if sig.normalize:
-                shot.signals_dict[sig] = (shot.signals_dict[sig] - self.minimums[m])/(self.maximums[m] - self.minimums[m])
-                shot.signals_dict[sig] = np.clip(shot.signals_dict[sig],-self.bound,self.bound)
-        shot.ttd = self.remapper(shot.ttd,self.conf['data']['T_warning'])
+                shot.signals_dict[sig] = (
+                    shot.signals_dict[sig] - self.minimums[m])/(
+                        self.maximums[m] - self.minimums[m])
+                shot.signals_dict[sig] = np.clip(
+                    shot.signals_dict[sig], -self.bound, self.bound)
+        shot.ttd = self.remapper(shot.ttd, self.conf['data']['T_warning'])
         self.cut_end_of_shot(shot)
         # self.apply_positivity_mask(shot)
         # self.apply_mask(shot)
@@ -396,29 +434,42 @@ class MinMaxNormalizer(Normalizer):
         # num_processed = dat['num_processed']
         # num_disruptive = dat['num_disruptive']
         self.ensure_save_directory()
-        np.savez(self.path,minimums = self.minimums,maximums = self.maximums,
-         num_processed=self.num_processed,num_disruptive=self.num_disruptive,machines=self.machines)
-        print('saved normalization data from {} shots ( {} disruptive )'.format(self.num_processed,self.num_disruptive))
+        np.savez(
+            self.path,
+            minimums=self.minimums,
+            maximums=self.maximums,
+            num_processed=self.num_processed,
+            num_disruptive=self.num_disruptive,
+            machines=self.machines)
+        print(
+            'saved normalization data from {} shots ( {} disruptive )'.format(
+                self.num_processed,
+                self.num_disruptive))
 
     def load_stats(self):
         assert(self.previously_saved_stats()[0])
-        dat = np.load(self.path,encoding="latin1")
+        dat = np.load(self.path, encoding="latin1")
         self.minimums = dat['minimums'][()]
         self.maximums = dat['maximums'][()]
         self.num_processed = dat['num_processed'][()]
         self.num_disruptive = dat['num_disruptive'][()]
         self.machines = dat['machines'][()]
-        print('loaded normalization data from {} shots ( {} disruptive )'.format(self.num_processed,self.num_disruptive))
-        #print('loading normalization data from {} shots, {} disruptive'.format(num_processed,num_disruptive))
+        print(
+            'loaded normalization data from {} shots ( {} disruptive )'.format(
+                self.num_processed,
+                self.num_disruptive))
 
 
-def get_individual_shot_file(prepath,shot_num,ext='.txt'):
-    return prepath + str(shot_num) + ext 
+def get_individual_shot_file(prepath, shot_num, ext='.txt'):
+    return prepath + str(shot_num) + ext
 
 
 def apply_positivity(shot):
-    for (i,sig) in enumerate(shot.signals):
-        if hasattr(sig,"is_strictly_positive"): #backwards compatibility when this attribute didn't exist
+    for (i, sig) in enumerate(shot.signals):
+        if hasattr(sig, "is_strictly_positive"):
+            # backwards compatibility when this attribute didn't exist
             if sig.is_strictly_positive:
-                #print ('Applying positivity constraint to {} signal'.format(sig.description))
-                shot.signals_dict[sig]=np.clip(shot.signals_dict[sig],0,np.inf)
+                # print ('Applying positivity constraint to {}
+                # signal'.format(sig.description))
+                shot.signals_dict[sig] = np.clip(
+                    shot.signals_dict[sig], 0, np.inf)

--- a/plasma/preprocessor/preprocess.py
+++ b/plasma/preprocessor/preprocess.py
@@ -21,6 +21,7 @@ from plasma.utils.processing import append_to_filename
 from plasma.primitives.shots import ShotList
 from plasma.utils.downloading import mkdirdepth
 
+
 class Preprocessor(object):
 
     def __init__(self, conf):

--- a/plasma/preprocessor/preprocess.py
+++ b/plasma/preprocessor/preprocess.py
@@ -21,7 +21,6 @@ from plasma.utils.processing import append_to_filename
 from plasma.primitives.shots import ShotList
 from plasma.utils.downloading import mkdirdepth
 
-
 class Preprocessor(object):
 
     def __init__(self, conf):

--- a/plasma/preprocessor/preprocess.py
+++ b/plasma/preprocessor/preprocess.py
@@ -9,7 +9,7 @@ This work was supported by the DOE CSGF program.
 '''
 
 from __future__ import print_function
-from os import listdir,remove
+from os import listdir  # , remove
 import time
 import sys
 import os
@@ -17,41 +17,43 @@ import os
 import numpy as np
 import pathos.multiprocessing as mp
 
-from plasma.utils.processing import *
+from plasma.utils.processing import append_to_filename
 from plasma.primitives.shots import ShotList
 from plasma.utils.downloading import mkdirdepth
 
+
 class Preprocessor(object):
 
-    def __init__(self,conf):
+    def __init__(self, conf):
         self.conf = conf
-
 
     def clean_shot_lists(self):
         shot_list_dir = self.conf['paths']['shot_list_dir']
-        paths = [os.path.join(shot_list_dir, f) for f in listdir(shot_list_dir) if os.path.isfile(os.path.join(shot_list_dir, f))]
+        paths = [
+            os.path.join(
+                shot_list_dir,
+                f) for f in listdir(shot_list_dir) if os.path.isfile(
+                os.path.join(
+                    shot_list_dir,
+                    f))]
         for path in paths:
             self.clean_shot_list(path)
 
-
-    def clean_shot_list(self,path):
+    def clean_shot_list(self, path):
         data = np.loadtxt(path)
-        ending_idx = path.rfind('.')
-        new_path = append_to_filename(path,'_clear')
+        # ending_idx = path.rfind('.')
+        new_path = append_to_filename(path, '_clear')
         if len(np.shape(data)) < 2:
-            #nondisruptive
+            # nondisruptive
             nd_times = -1.0*np.ones_like(data)
-            data_two_column = np.vstack((data,nd_times)).transpose()
-            np.savetxt(new_path,data_two_column,fmt = '%d %f')
+            data_two_column = np.vstack((data, nd_times)).transpose()
+            np.savetxt(new_path, data_two_column, fmt='%d %f')
             print('created new file: {}'.format(new_path))
             print('deleting old file: {}'.format(path))
             os.remove(path)
 
-
     def all_are_preprocessed(self):
         return os.path.isfile(self.get_shot_list_path())
-
-    
 
     def preprocess_all(self):
         conf = self.conf
@@ -60,47 +62,65 @@ class Preprocessor(object):
         # shot_files_test = conf['paths']['shot_files_test']
         # shot_list_dir = conf['paths']['shot_list_dir']
         use_shots = conf['data']['use_shots']
-        train_frac = conf['training']['train_frac']
-        use_shots_train = int(round(train_frac*use_shots))
-        use_shots_test = int(round((1-train_frac)*use_shots))
-#        print(use_shots_train)
-#        print(use_shots_test) #each print out 100,000
+        # train_frac = conf['training']['train_frac']
+        # use_shots_train = int(round(train_frac*use_shots))
+        # use_shots_test = int(round((1-train_frac)*use_shots))
+        #        print(use_shots_train)
+        #        print(use_shots_test) #each print out 100,000
+
         # if len(shot_files_test) > 0:
-        #     return self.preprocess_from_files(shot_list_dir,shot_files_train,machines_train,use_shots_train) + \
-        #        self.preprocess_from_files(shot_list_dir,shot_files_test,machines_train,use_shots_test)
+        #     return
+        #     self.preprocess_from_files(shot_list_dir,shot_files_train,
+        #      machines_train,use_shots_train)
+        #     + self.preprocess_from_files(shot_list_dir,
+        #      shot_files_test,machines_train,use_shots_test)
         # else:
-        return self.preprocess_from_files(shot_files_all,use_shots)
+        return self.preprocess_from_files(shot_files_all, use_shots)
 
-
-    def preprocess_from_files(self,shot_files,use_shots):
-        #all shots, including invalid ones
-        all_signals = self.conf['paths']['all_signals'] 
+    def preprocess_from_files(self, shot_files, use_shots):
+        # all shots, including invalid ones
+        all_signals = self.conf['paths']['all_signals']
         shot_list = ShotList()
-        shot_list.load_from_shot_list_files_objects(shot_files,all_signals)
+        shot_list.load_from_shot_list_files_objects(shot_files, all_signals)
         shot_list_picked = shot_list.random_sublist(use_shots)
 
-        #empty
+        # empty
         used_shots = ShotList()
 
-        use_cores = max(1,mp.cpu_count()-2)
+        use_cores = max(1, mp.cpu_count()-2)
         pool = mp.Pool(use_cores)
         print('running in parallel on {} processes'.format(pool._processes))
         start_time = time.time()
-        for (i,shot) in enumerate(pool.imap_unordered(self.preprocess_single_file,shot_list_picked)):
-        #for (i,shot) in enumerate(map(self.preprocess_single_file,shot_list_picked)):
-            sys.stdout.write('\r{}/{}'.format(i,len(shot_list_picked)))
+        for (
+            i,
+            shot) in enumerate(
+            pool.imap_unordered(
+                self.preprocess_single_file,
+                shot_list_picked)):
+            # for (i,shot) in
+            # enumerate(map(self.preprocess_single_file,shot_list_picked)):
+            sys.stdout.write('\r{}/{}'.format(i, len(shot_list_picked)))
             used_shots.append_if_valid(shot)
 
         pool.close()
         pool.join()
-        print('Finished Preprocessing {} files in {} seconds'.format(len(shot_list_picked),time.time()-start_time))
-        print('Omitted {} shots of {} total.'.format(len(shot_list_picked) - len(used_shots),len(shot_list_picked)))
-        print('{}/{} disruptive shots'.format(used_shots.num_disruptive(),len(used_shots)))
+        print('Finished Preprocessing {} files in {} seconds'.format(
+            len(shot_list_picked), time.time()-start_time))
+        print(
+            'Omitted {} shots of {} total.'.format(
+                len(shot_list_picked)
+                - len(used_shots),
+                len(shot_list_picked)))
+        print('{}/{} disruptive shots'.format(used_shots.num_disruptive(),
+                                              len(used_shots)))
         if len(used_shots) == 0:
-            print("WARNING: All shots were omitted, please ensure raw data is complete and available at {}.".format(self.conf['paths']['signal_prepath']))
-        return used_shots 
+            print(
+                "WARNING: All shots were omitted, please ensure raw data "
+                " is complete and available at {}.".format(
+                    self.conf['paths']['signal_prepath']))
+        return used_shots
 
-    def preprocess_single_file(self,shot):
+    def preprocess_single_file(self, shot):
         processed_prepath = self.conf['paths']['processed_prepath']
         recompute = self.conf['data']['recompute']
         # print('({}/{}): '.format(num_processed,use_shots))
@@ -110,52 +130,62 @@ class Preprocessor(object):
 
         else:
             try:
-                shot.restore(processed_prepath,light=True)
+                shot.restore(processed_prepath, light=True)
                 sys.stdout.write('\r{} exists.'.format(shot.number))
-            except:
+            except BaseException:
                 shot.preprocess(self.conf)
                 shot.save(processed_prepath)
-                sys.stdout.write('\r{} exists but corrupted, resaved.'.format(shot.number))
+                sys.stdout.write(
+                    '\r{} exists but corrupted, resaved.'.format(
+                        shot.number))
         shot.make_light()
-        return shot 
-
+        return shot
 
     def get_individual_channel_dirs(self):
-        signals_dirs = self.conf['paths']['signals_dirs']
+        return self.conf['paths']['signals_dirs']
 
     def get_shot_list_path(self):
         return self.conf['paths']['saved_shotlist_path']
 
     def load_shotlists(self):
         path = self.get_shot_list_path()
-        data = np.load(path,encoding="latin1")
+        data = np.load(path, encoding="latin1")
         shot_list_train = data['shot_list_train'][()]
         shot_list_validate = data['shot_list_validate'][()]
         shot_list_test = data['shot_list_test'][()]
-        if isinstance(shot_list_train,ShotList):
-            return shot_list_train,shot_list_validate,shot_list_test
+        if isinstance(shot_list_train, ShotList):
+            return shot_list_train, shot_list_validate, shot_list_test
         else:
-            return ShotList(shot_list_train),ShotList(shot_list_validate),ShotList(shot_list_test)
+            return ShotList(shot_list_train), ShotList(
+                shot_list_validate), ShotList(shot_list_test)
 
-
-    def save_shotlists(self,shot_list_train,shot_list_validate,shot_list_test):
+    def save_shotlists(
+            self,
+            shot_list_train,
+            shot_list_validate,
+            shot_list_test):
         path = self.get_shot_list_path()
         mkdirdepth(path)
-        np.savez(path,shot_list_train=shot_list_train,shot_list_validate=shot_list_validate,shot_list_test=shot_list_test)
+        np.savez(
+            path,
+            shot_list_train=shot_list_train,
+            shot_list_validate=shot_list_validate,
+            shot_list_test=shot_list_test)
 
 
-
-def apply_bleed_in(conf,shot_list_train,shot_list_validate,shot_list_test):
+def apply_bleed_in(conf, shot_list_train, shot_list_validate, shot_list_test):
     np.random.seed(2)
     num = conf['data']['bleed_in']
-    new_shots = []
+    # new_shots = []
     if num > 0:
         shot_list_bleed = ShotList()
         print('applying bleed in with {} disruptive shots\n'.format(num))
-        num_total = len(shot_list_test)
+        # num_total = len(shot_list_test)
         num_d = shot_list_test.num_disruptive()
-        num_nd = num_total - num_d
-        assert(num_d >= num), "Not enough disruptive shots {} to cover bleed in {}".format(num_d,num)
+        # num_nd = num_total - num_d
+        assert num_d >= num, (
+            "Not enough disruptive shots {} to cover bleed in {}".format(
+                num_d, num))
         num_sampled_d = 0
         num_sampled_nd = 0
         while num_sampled_d < num:
@@ -167,12 +197,15 @@ def apply_bleed_in(conf,shot_list_train,shot_list_validate,shot_list_test):
                 num_sampled_d += 1
             else:
                 num_sampled_nd += 1
-        print("Sampled {} shots, {} disruptive, {} nondisruptive".format(num_sampled_nd+num_sampled_d,num_sampled_d,num_sampled_nd))
-        print("Before adding: training shots: {} validation shots: {}".format(len(shot_list_train),len(shot_list_validate)))
+        print("Sampled {} shots, {} disruptive, {} nondisruptive".format(
+            num_sampled_nd+num_sampled_d, num_sampled_d, num_sampled_nd))
+        print("Before adding: training shots: {} validation shots: {}".format(
+            len(shot_list_train), len(shot_list_validate)))
         assert(num_sampled_d == num)
-        if conf['data']['bleed_in_equalize_sets']:#add bleed-in shots to training and validation set repeatedly
+        # add bleed-in shots to training and validation set repeatedly
+        if conf['data']['bleed_in_equalize_sets']:
             print("Applying equalized bleed in")
-            for shot_list_curr in [shot_list_train,shot_list_validate]:
+            for shot_list_curr in [shot_list_train, shot_list_validate]:
                 for i in range(len(shot_list_curr)):
                     s = shot_list_bleed.sample_shot()
                     shot_list_curr.append(s)
@@ -184,12 +217,13 @@ def apply_bleed_in(conf,shot_list_train,shot_list_validate,shot_list_test):
                 s = shot_list_bleed.sample_shot()
                 shot_list_train.append(s)
                 shot_list_validate.append(s)
-        else: #add each shot only once
+        else:  # add each shot only once
             print("Applying bleed in without repetition")
             for s in shot_list_bleed:
                 shot_list_train.append(s)
                 shot_list_validate.append(s)
-        print("After adding: training shots: {} validation shots: {}".format(len(shot_list_train),len(shot_list_validate)))
+        print("After adding: training shots: {} validation shots: {}".format(
+            len(shot_list_train), len(shot_list_validate)))
         print("Added bleed in shots to training and validation sets")
         # if num_d > 0:
         #     for i in range(num):
@@ -209,34 +243,39 @@ def apply_bleed_in(conf,shot_list_train,shot_list_validate,shot_list_test):
         #             shot_list_test.remove(s)
         # else:
         #     print('No nondisruptive shots in test set, omitting bleed in')
-    return shot_list_train,shot_list_validate,shot_list_test
-
-
-
+    return shot_list_train, shot_list_validate, shot_list_test
 
 
 def guarantee_preprocessed(conf):
     pp = Preprocessor(conf)
     if pp.all_are_preprocessed():
         print("shots already processed.")
-        shot_list_train,shot_list_validate,shot_list_test = pp.load_shotlists()
+        (shot_list_train, shot_list_validate,
+         shot_list_test) = pp.load_shotlists()
     else:
-        print("preprocessing all shots",end='')
+        print("preprocessing all shots", end='')
         pp.clean_shot_lists()
-        shot_list = pp.preprocess_all()
-        shot_list.sort()
-        shot_list_train,shot_list_test = shot_list.split_train_test(conf)
-        num_shots = len(shot_list_train) + len(shot_list_test)
+        shot_list = sorted(pp.preprocess_all())
+        shot_list_train, shot_list_test = shot_list.split_train_test(conf)
+        # num_shots = len(shot_list_train) + len(shot_list_test)
         validation_frac = conf['training']['validation_frac']
         if validation_frac <= 0.05:
             print('Setting validation to a minimum of 0.05')
             validation_frac = 0.05
-        shot_list_train,shot_list_validate = shot_list_train.split_direct(1.0-validation_frac,do_shuffle=True)
-        pp.save_shotlists(shot_list_train,shot_list_validate,shot_list_test)
-    shot_list_train,shot_list_validate,shot_list_test = apply_bleed_in(conf,shot_list_train,shot_list_validate,shot_list_test)
-    print('validate: {} shots, {} disruptive'.format(len(shot_list_validate),shot_list_validate.num_disruptive()))
-    print('training: {} shots, {} disruptive'.format(len(shot_list_train),shot_list_train.num_disruptive()))
-    print('testing: {} shots, {} disruptive'.format(len(shot_list_test),shot_list_test.num_disruptive()))
+        shot_list_train, shot_list_validate = shot_list_train.split_direct(
+            1.0-validation_frac, do_shuffle=True)
+        pp.save_shotlists(shot_list_train, shot_list_validate, shot_list_test)
+    shot_list_train, shot_list_validate, shot_list_test = apply_bleed_in(
+        conf, shot_list_train, shot_list_validate, shot_list_test)
+    print(
+        'validate: {} shots, {} disruptive'.format(
+            len(shot_list_validate),
+            shot_list_validate.num_disruptive()))
+    print(
+        'training: {} shots, {} disruptive'.format(
+            len(shot_list_train),
+            shot_list_train.num_disruptive()))
+    print('testing: {} shots, {} disruptive'.format(
+        len(shot_list_test), shot_list_test.num_disruptive()))
     print("...done")
-    return shot_list_train,shot_list_validate,shot_list_test
-
+    return shot_list_train, shot_list_validate, shot_list_test

--- a/plasma/primitives/data.py
+++ b/plasma/primitives/data.py
@@ -1,13 +1,13 @@
 from __future__ import division
 import numpy as np
-import time
-import sys,os
+import sys
+import os
 import re
 
 from scipy.interpolate import UnivariateSpline
 
 from plasma.utils.processing import get_individual_shot_file
-from plasma.utils.downloading import format_save_path,get_missing_value_array
+from plasma.utils.downloading import get_missing_value_array
 
 # class SignalCollection:
 #   """GA Data Obj"""
@@ -16,25 +16,31 @@ from plasma.utils.downloading import format_save_path,get_missing_value_array
 #       for i in range(len(signal_paths))
 #           self.signals.append(Signal(signal_descriptions[i],signal_paths[i]))
 
+try:
+    from MDSplus import Connection
+except ImportError:
+    pass
+
+
 class Signal(object):
-    def __init__(self,description,paths,machines,tex_label=None,
-        causal_shifts=None,is_ip=False,normalize=True,
-        data_avail_tolerances=None,is_strictly_positive=False,
-        mapping_paths=None):
+    def __init__(self, description, paths, machines, tex_label=None,
+                 causal_shifts=None, is_ip=False, normalize=True,
+                 data_avail_tolerances=None, is_strictly_positive=False,
+                 mapping_paths=None):
         assert(len(paths) == len(machines))
         self.description = description
         self.paths = paths
-        self.machines = machines #on which machines is the signal defined
-        if causal_shifts == None:
+        self.machines = machines  # on which machines is the signal defined
+        if causal_shifts is None:
             causal_shifts = [0 for m in machines]
-        self.causal_shifts = causal_shifts #causal shift in ms
+        self.causal_shifts = causal_shifts  # causal shift in ms
         self.is_ip = is_ip
         self.num_channels = 1
         self.normalize = normalize
-        if data_avail_tolerances == None:
+        if data_avail_tolerances is None:
             data_avail_tolerances = [0 for m in machines]
         self.data_avail_tolerances = data_avail_tolerances
-        self.is_strictly_positive=is_strictly_positive
+        self.is_strictly_positive = is_strictly_positive
         self.mapping_paths = mapping_paths
 
     def is_strictly_positive_fn(self):
@@ -43,231 +49,317 @@ class Signal(object):
     def is_ip(self):
         return self.is_ip
 
-    def get_file_path(self,prepath,machine,shot_number):
+    def get_file_path(self, prepath, machine, shot_number):
         dirname = self.get_path(machine)
-        return get_individual_shot_file(prepath + '/' + machine.name + '/' +dirname + '/',shot_number)
+        return get_individual_shot_file(prepath + '/' + machine.name + '/'
+                                        + dirname + '/', shot_number)
 
-    def is_valid(self,prepath,shot,dtype='float32'):
-        t,data,exists = self.load_data(prepath,shot,dtype)
-        return exists 
+    def is_valid(self, prepath, shot, dtype='float32'):
+        t, data, exists = self.load_data(prepath, shot, dtype)
+        return exists
 
-    def is_saved(self,prepath,shot):
-        file_path = self.get_file_path(prepath,shot.machine,shot.number)
+    def is_saved(self, prepath, shot):
+        file_path = self.get_file_path(prepath, shot.machine, shot.number)
         return os.path.isfile(file_path)
 
-    def load_data_from_txt_safe(self,prepath,shot,dtype='float32'):
-        file_path = self.get_file_path(prepath,shot.machine,shot.number)
-        if not self.is_saved(prepath,shot):
-            print('Signal {}, shot {} was never downloaded'.format(self.description,shot.number))
-            return None,False
+    def load_data_from_txt_safe(self, prepath, shot, dtype='float32'):
+        file_path = self.get_file_path(prepath, shot.machine, shot.number)
+        if not self.is_saved(prepath, shot):
+            print(
+                'Signal {}, shot {} was never downloaded'.format(
+                    self.description,
+                    shot.number))
+            return None, False
 
         if os.path.getsize(file_path) == 0:
-            print('Signal {}, shot {} was downloaded incorrectly (empty file). Removing.'.format(self.description,shot.number))
+            print('Signal {}, shot {} '.format(self.description, shot.number),
+                  'was downloaded incorrectly (empty file). Removing.')
             os.remove(file_path)
-            return None,False
+            return None, False
         try:
-            data = np.loadtxt(file_path,dtype=dtype)
+            data = np.loadtxt(file_path, dtype=dtype)
             if np.all(data == get_missing_value_array()):
-                print('Signal {}, shot {} contains no data'.format(self.description,shot.number))
-                return None,False
+                print(
+                    'Signal {}, shot {} contains no data'.format(
+                        self.description, shot.number))
+                return None, False
         except Exception as e:
             print(e)
-            print('Couldnt load signal {} shot {}. Removing.'.format(file_path,shot.number))
+            print(
+                'Couldnt load signal {} shot {}. Removing.'.format(
+                    file_path, shot.number))
             os.remove(file_path)
             return None, False
 
-        return data,True
+        return data, True
 
-    def load_data(self,prepath,shot,dtype='float32'):
-        data,succ = self.load_data_from_txt_safe(prepath,shot)
+    def load_data(self, prepath, shot, dtype='float32'):
+        data, succ = self.load_data_from_txt_safe(prepath, shot)
         if not succ:
-            return None,None,False
-            
+            return None, None, False
+
         if np.ndim(data) == 1:
-            data = np.expand_dims(data,axis=0)
+            data = np.expand_dims(data, axis=0)
 
-        t = data[:,0]
-        sig = data[:,1:]
+        t = data[:, 0]
+        sig = data[:, 1:]
 
-        if self.is_ip: #restrict shot to current threshold
+        if self.is_ip:  # restrict shot to current threshold
             region = np.where(np.abs(sig) >= shot.machine.current_threshold)[0]
             if len(region) == 0:
                 print('shot {} has no current'.format(shot.number))
-                return None,None,False
+                return None, None, False
             first_idx = region[0]
             last_idx = region[-1]
-            last_time = t[last_idx]+5e-2 #add 50 ms to cover possible disruption event
+            # add 50 ms to cover possible disruption event
+            last_time = t[last_idx]+5e-2
             last_indices = np.where(t > last_time)[0]
             if len(last_indices) == 0:
                 last_idx = -1
             else:
                 last_idx = last_indices[0]
             t = t[first_idx:last_idx]
-            sig = sig[first_idx:last_idx,:]
+            sig = sig[first_idx:last_idx, :]
 
-        #make sure shot is not garbage data
+        # make sure shot is not garbage data
         if len(t) <= 1 or (np.max(sig) == 0.0 and np.min(sig) == 0.0):
             if self.is_ip:
                 print('shot {} has no current'.format(shot.number))
             else:
-                print('Signal {}, shot {} contains no data'.format(self.description,shot.number))
-            return None,None,False
-        
-        #make sure data doesn't contain nan
+                print(
+                    'Signal {}, shot {} contains no data'.format(
+                        self.description, shot.number))
+            return None, None, False
+
+        # make sure data doesn't contain nan
         if np.any(np.isnan(t)) or np.any(np.isnan(sig)):
-            print('Signal {}, shot {} contains NAN'.format(self.description,shot.number))
-            return None,None,False
+            print(
+                'Signal {}, shot {} contains NAN'.format(
+                    self.description,
+                    shot.number))
+            return None, None, False
 
-        return t,sig,True
+        return t, sig, True
 
-
-    def fetch_data_basic(self,machine,shot_num,c,path=None):
+    def fetch_data_basic(self, machine, shot_num, c, path=None):
         if path is None:
             path = self.get_path(machine)
         success = False
         mapping = None
         try:
-            time,data,mapping,success = machine.fetch_data_fn(path,shot_num,c)
+            time, data, mapping, success = machine.fetch_data_fn(
+                path, shot_num, c)
         except Exception as e:
             print(e)
             sys.stdout.flush()
 
         if not success:
-            return None,None,None,False
+            return None, None, None, False
 
         time = np.array(time) + 1e-3*self.get_causal_shift(machine)
-        return time,np.array(data),mapping,success    
+        return time, np.array(data), mapping, success
 
-    def fetch_data(self,machine,shot_num,c):
-        return self.fetch_data_basic(machine,shot_num,c)
+    def fetch_data(self, machine, shot_num, c):
+        return self.fetch_data_basic(machine, shot_num, c)
 
-    def is_defined_on_machine(self,machine):
+    def is_defined_on_machine(self, machine):
         return machine in self.machines
 
-    def is_defined_on_machines(self,machines):
+    def is_defined_on_machines(self, machines):
         return all([m in self.machines for m in machines])
 
-    def get_path(self,machine):
+    def get_path(self, machine):
         idx = self.get_idx(machine)
         return self.paths[idx]
 
-    def get_mapping_path(self,machine):
+    def get_mapping_path(self, machine):
         if self.mapping_paths is None:
             return None
         else:
             idx = self.get_idx(machine)
-            return self.mapping_paths[idx]    
+            return self.mapping_paths[idx]
 
-    def get_causal_shift(self,machine):
+    def get_causal_shift(self, machine):
         idx = self.get_idx(machine)
         return self.causal_shifts[idx]
 
-    def get_data_avail_tolerance(self,machine):
+    def get_data_avail_tolerance(self, machine):
         idx = self.get_idx(machine)
         return self.data_avail_tolerances[idx]
 
-    def get_idx(self,machine):
+    def get_idx(self, machine):
         assert(machine in self.machines)
-        idx = self.machines.index(machine)  
+        idx = self.machines.index(machine)
         return idx
 
-    def __eq__(self,other):
+    def __eq__(self, other):
         if other is None:
             return False
         return self.description.__eq__(other.description)
 
-    
-    def __ne__(self,other):
+    def __ne__(self, other):
         return self.description.__ne__(other.description)
 
-    def __lt__(self,other):
+    def __lt__(self, other):
         return self.description.__lt__(other.description)
-    
+
     def __hash__(self):
-       import hashlib
-       return int(hashlib.md5(self.description.encode('utf-8')).hexdigest(),16)
+        import hashlib
+        return int(
+            hashlib.md5(
+                self.description.encode('utf-8')).hexdigest(),
+            16)
 
     def __str__(self):
         return self.description
-    
+
     def __repr__(self):
         return self.description
 
+
 class ProfileSignal(Signal):
-    def __init__(self,description,paths,machines,tex_label=None,causal_shifts=None,mapping_range=(0,1),num_channels=32,data_avail_tolerances=None,is_strictly_positive=False,mapping_paths=None):
-        super(ProfileSignal, self).__init__(description,paths,machines,tex_label,causal_shifts,is_ip=False,data_avail_tolerances=data_avail_tolerances,is_strictly_positive=is_strictly_positive,mapping_paths=mapping_paths)
+    def __init__(
+            self,
+            description,
+            paths,
+            machines,
+            tex_label=None,
+            causal_shifts=None,
+            mapping_range=(
+                0,
+                1),
+            num_channels=32,
+            data_avail_tolerances=None,
+            is_strictly_positive=False,
+            mapping_paths=None):
+        super(
+            ProfileSignal,
+            self).__init__(
+            description,
+            paths,
+            machines,
+            tex_label,
+            causal_shifts,
+            is_ip=False,
+            data_avail_tolerances=data_avail_tolerances,
+            is_strictly_positive=is_strictly_positive,
+            mapping_paths=mapping_paths)
         self.mapping_range = mapping_range
         self.num_channels = num_channels
 
-    def load_data(self,prepath,shot,dtype='float32'):
-        data,succ = self.load_data_from_txt_safe(prepath,shot)
+    def load_data(self, prepath, shot, dtype='float32'):
+        data, succ = self.load_data_from_txt_safe(prepath, shot)
         if not succ:
-            return None,None,False
+            return None, None, False
 
         if np.ndim(data) == 1:
-            data = np.expand_dims(data,axis=0)
-            #_ = data[0,0]
-        T = data.shape[0]//2 #time is stored twice, once for mapping and once for signal
-        mapping = data[:T,1:]
-        remapping = np.linspace(self.mapping_range[0],self.mapping_range[1],self.num_channels)
-        t = data[:T,0] 
-        sig = data[T:,1:]
+            data = np.expand_dims(data, axis=0)
+        # time is stored twice, once for mapping and once for signal
+        T = data.shape[0]//2
+        mapping = data[:T, 1:]
+        remapping = np.linspace(
+            self.mapping_range[0],
+            self.mapping_range[1],
+            self.num_channels)
+        t = data[:T, 0]
+        sig = data[T:, 1:]
         if sig.shape[1] < 2:
-            print('Signal {}, shot {} should be profile but has only one channel. Possibly only one profile fit was run for the duration of the shot and was transposed during downloading. Need at least 2.'.format(self.description,shot.number))
-            return None,None,False
+            print('Signal {}, shot {} '.format(self.description, shot.number),
+                  'should be profile but has only one channel. Possibly only ',
+                  'one profile fit was run for the duration of the shot and ',
+                  'was transposed during downloading. Need at least 2.')
+            return None, None, False
         if len(t) <= 1 or (np.max(sig) == 0.0 and np.min(sig) == 0.0):
-            print('Signal {}, shot {} contains no data'.format(self.description,shot.number))
-            return None,None,False
+            print('Signal {}, shot {} '.format(self.description, shot.number),
+                  'contains no data.')
+            return None, None, False
         if np.any(np.isnan(t)) or np.any(np.isnan(sig)):
-            print('Signal {}, shot {} contains NAN'.format(self.description,shot.number))
-            return None,None,False
+            print('Signal {}, shot {} '.format(self.description, shot.number),
+                  'contains NaN value(s).')
+            return None, None, False
 
         timesteps = len(t)
-        sig_interp = np.zeros((timesteps,self.num_channels))
+        sig_interp = np.zeros((timesteps, self.num_channels))
         for i in range(timesteps):
-            _,order = np.unique(mapping[i,:],return_index=True) #make sure the mapping is ordered and unique
-            if sig[i,order].shape[0] > 2:
-                f = UnivariateSpline(mapping[i,order],sig[i,order],s=0,k=1,ext=3) #ext = 0 is extrapolation, ext = 3 is boundary value.
-                sig_interp[i,:] = f(remapping)
+            # make sure the mapping is ordered and unique
+            _, order = np.unique(mapping[i, :], return_index=True)
+            if sig[i, order].shape[0] > 2:
+                # ext = 0 is extrapolation, ext = 3 is boundary value.
+                f = UnivariateSpline(
+                    mapping[i, order], sig[i, order], s=0, k=1, ext=3)
+                sig_interp[i, :] = f(remapping)
             else:
-                print('Signal {}, shot {} has not enough points for linear interpolation. dfitpack.error: (m>k) failed for hidden m: fpcurf0:m=1'.format(self.description,shot.number))
-                return None,None,False
+                print('Signal {}, shot {} '.format(self.description,
+                                                   shot.number),
+                      'has insufficient points for linear interpolation. ',
+                      'dfitpack.error: (m>k) failed for hidden m: fpcurf0:m=1')
+                return None, None, False
 
-        return t,sig_interp,True
+        return t, sig_interp, True
 
-    def fetch_data(self,machine,shot_num,c):
-        time,data,mapping,success = self.fetch_data_basic(machine,shot_num,c)
+    def fetch_data(self, machine, shot_num, c):
+        time, data, mapping, success = self.fetch_data_basic(
+            machine, shot_num, c)
         path = self.get_path(machine)
         mapping_path = self.get_mapping_path(machine)
 
-        if mapping is not None and np.ndim(mapping) == 1:#make sure there is a mapping for every timestep
+        if mapping is not None and np.ndim(mapping) == 1:
+            # make sure there is a mapping for every timestep
             T = len(time)
-            mapping = np.tile(mapping,(T,1)).transpose()
-            assert(mapping.shape == data.shape), "shape of mapping and data is different"
-        if mapping_path is not None:#fetch the mapping separately
-            time_map,data_map,mapping_map,success_map = self.fetch_data_basic(machine,shot_num,c,path=mapping_path)
+            mapping = np.tile(mapping, (T, 1)).transpose()
+            assert mapping.shape == data.shape, (
+                "mapping and data shapes are different")
+        if mapping_path is not None:
+            # fetch the mapping separately
+            (time_map, data_map, mapping_map,
+             success_map) = self.fetch_data_basic(machine, shot_num, c,
+                                                  path=mapping_path)
             success = (success and success_map)
             if not success:
-                print("No success for signal {} and mapping {}".format(path,mapping_path))
+                print("No success for signal {} and mapping {}".format(
+                    path, mapping_path))
             else:
-                assert(np.all(time == time_map)), "time for signal {} and mapping {} don't align: \n{}\n\n{}\n".format(path,mapping_path,time,time_map)
+                assert np.all(time == time_map), (
+                    "time for signal {} and mapping {} ".format(path,
+                                                                mapping_path)
+                    + "don't align: \n{}\n\n{}\n".format(time, time_map))
                 mapping = data_map
 
         if not success:
-            return None,None,None,False
-        return time,data,mapping,success 
+            return None, None, None, False
+        return time, data, mapping, success
 
 
 class ChannelSignal(Signal):
-    def __init__(self,description,paths,machines,tex_label=None,causal_shifts=None,data_avail_tolerances=None,is_strictly_positive=False,mapping_paths=None):
-        super(ChannelSignal, self).__init__(description,paths,machines,tex_label,causal_shifts,is_ip=False,data_avail_tolerances=data_avail_tolerances,is_strictly_positive=is_strictly_positive,mapping_paths=mapping_paths)
-        nums,new_paths = self.get_channel_nums(paths)
+    def __init__(
+            self,
+            description,
+            paths,
+            machines,
+            tex_label=None,
+            causal_shifts=None,
+            data_avail_tolerances=None,
+            is_strictly_positive=False,
+            mapping_paths=None):
+        super(
+            ChannelSignal,
+            self).__init__(
+            description,
+            paths,
+            machines,
+            tex_label,
+            causal_shifts,
+            is_ip=False,
+            data_avail_tolerances=data_avail_tolerances,
+            is_strictly_positive=is_strictly_positive,
+            mapping_paths=mapping_paths)
+        nums, new_paths = self.get_channel_nums(paths)
         self.channel_nums = nums
         self.paths = new_paths
 
-    def get_channel_nums(self,paths):
-        regex = re.compile('channel\d+')
-        regex_int = re.compile('\d+')
+    def get_channel_nums(self, paths):
+        regex = re.compile(r'channel\d+')
+        regex_int = re.compile(r'\d+')
         nums = []
         new_paths = []
         for p in paths:
@@ -281,35 +373,43 @@ class ChannelSignal(Signal):
             else:
                 nums.append(int(regex_int.findall(res[0])[0]))
                 new_paths.append("/".join(elements[:-1]))
-        return nums,new_paths
+        return nums, new_paths
 
-    def get_channel_num(self,machine):
+    def get_channel_num(self, machine):
         idx = self.get_idx(machine)
         return self.channel_nums[idx]
 
-    def fetch_data(self,machine,shot_num,c):
-        time,data,mapping,success = self.fetch_data_basic(machine,shot_num,c)
-        mapping = None #we are not interested in the whole profile
+    def fetch_data(self, machine, shot_num, c):
+        time, data, mapping, success = self.fetch_data_basic(
+            machine, shot_num, c)
+        mapping = None  # we are not interested in the whole profile
         channel_num = self.get_channel_num(machine)
         if channel_num is not None and success:
             if np.ndim(data) != 2:
-                print("Channel Signal {} expected 2D array for shot {}".format(self,shot))
+                print("Channel Signal {} expected 2D array for shot {}".format(
+                    self, self.shot_number))
                 success = False
             else:
-                data = data[channel_num,:] #extract channel of interest
-        return time,data,mapping,success
+                data = data[channel_num, :]  # extract channel of interest
+        return time, data, mapping, success
 
-    def get_file_path(self,prepath,machine,shot_number):
+    def get_file_path(self, prepath, machine, shot_number):
         dirname = self.get_path(machine)
         num = self.get_channel_num(machine)
         if num is not None:
             dirname += "/channel{}".format(num)
-        return get_individual_shot_file(prepath + '/' + machine.name + '/' +dirname + '/',shot_number)
-
+        return get_individual_shot_file(prepath + '/' + machine.name + '/'
+                                        + dirname + '/', shot_number)
 
 
 class Machine(object):
-    def __init__(self,name,server,fetch_data_fn,max_cores = 8,current_threshold=0):
+    def __init__(
+            self,
+            name,
+            server,
+            fetch_data_fn,
+            max_cores=8,
+            current_threshold=0):
         self.name = name
         self.server = server
         self.max_cores = max_cores
@@ -317,24 +417,22 @@ class Machine(object):
         self.current_threshold = current_threshold
 
     def get_connection(self):
-        return Connection(server)
+        return Connection(self.server)
 
-    def __eq__(self,other):
+    def __eq__(self, other):
         return self.name.__eq__(other.name)
 
-    def __lt__(self,other):
+    def __lt__(self, other):
         return self.name.__lt__(other.name)
-    
-    def __ne__(self,other):
+
+    def __ne__(self, other):
         return self.name.__ne__(other.name)
-    
+
     def __hash__(self):
         return self.name.__hash__()
-    
+
     def __str__(self):
         return self.name
 
     def __repr__(self):
         return self.__str__()
-
-

--- a/plasma/primitives/hyperparameters.py
+++ b/plasma/primitives/hyperparameters.py
@@ -1,7 +1,9 @@
 import numpy as np
 import random
 import abc
-import yaml,os
+import yaml
+import os
+
 
 class Hyperparam(object):
 
@@ -9,21 +11,22 @@ class Hyperparam(object):
     def choice(self):
         return 0
 
-    def get_conf_entry(self,conf):
+    def get_conf_entry(self, conf):
         el = conf
         for sub_path in self.path:
             el = el[sub_path]
         return el
 
-    def assign_to_conf(self,conf,save_path):
+    def assign_to_conf(self, conf, save_path):
         val = self.choice()
-        print(" : ".join(self.path)+ ": {}".format(val))
+        print(" : ".join(self.path) + ": {}".format(val))
         el = conf
         for sub_path in self.path[:-1]:
             el = el[sub_path]
         el[self.path[-1]] = val
 
-        with open(os.path.join(save_path,"changed_params.out"), 'a+') as outfile:
+        with open(os.path.join(save_path, "changed_params.out"),
+                  'a+') as outfile:
             for el in self.path:
                 outfile.write("{} : ".format(el))
             outfile.write("{}\n".format(val))
@@ -31,56 +34,59 @@ class Hyperparam(object):
 
 class CategoricalHyperparam(Hyperparam):
 
-    def __init__(self,path,values):
+    def __init__(self, path, values):
         self.path = path
         self.values = values
 
     def choice(self):
         return random.choice(self.values)
 
+
 class GridCategoricalHyperparam(Hyperparam):
 
-    def __init__(self,path,values):
+    def __init__(self, path, values):
         self.path = path
         self.values = iter(values)
 
     def choice(self):
         return next(self.values)
 
+
 class ContinuousHyperparam(Hyperparam):
-    def __init__(self,path,lo,hi):
+    def __init__(self, path, lo, hi):
         self.path = path
-        self.lo =lo 
-        self.hi =hi 
+        self.lo = lo
+        self.hi = hi
 
     def choice(self):
-        return float(np.random.uniform(self.lo,self.hi))
+        return float(np.random.uniform(self.lo, self.hi))
+
 
 class LogContinuousHyperparam(Hyperparam):
-    def __init__(self,path,lo,hi):
+    def __init__(self, path, lo, hi):
         self.path = path
         self.lo = self.to_log(lo)
-        self.hi = self.to_log(hi) 
+        self.hi = self.to_log(hi)
 
-    def to_log(self,num_val):
+    def to_log(self, num_val):
         return np.log10(num_val)
 
     def choice(self):
-        return float(np.power(10,np.random.uniform(self.lo,self.hi)))
+        return float(np.power(10, np.random.uniform(self.lo, self.hi)))
 
 
 class IntegerHyperparam(Hyperparam):
-    def __init__(self,path,lo,hi):
+    def __init__(self, path, lo, hi):
         self.path = path
-        self.lo =lo 
-        self.hi =hi 
+        self.lo = lo
+        self.hi = hi
 
     def choice(self):
-        return int(np.random.random_integers(self.lo,self.hi))
+        return int(np.random.random_integers(self.lo, self.hi))
 
 
 class GenericHyperparam(Hyperparam):
-    def __init__(self,path,choice_fn):
+    def __init__(self, path, choice_fn):
         self.path = path
         self.choice_fn = choice_fn
 
@@ -89,24 +95,24 @@ class GenericHyperparam(Hyperparam):
 
 
 class HyperparamExperiment(object):
-    def __init__(self,path,conf_name = "conf.yaml"):
+    def __init__(self, path, conf_name="conf.yaml"):
         if not path.endswith('/'):
             path += '/'
         self.path = path
         self.finished = False
         self.success = False
-        self.logs_path = os.path.join(path,"csv_logs/")
+        self.logs_path = os.path.join(path, "csv_logs/")
         self.raw_logs_path = path[:-1] + ".out"
-        self.changed_path = os.path.join(path,"changed_params.out")
-        with open(os.path.join(self.path,conf_name), 'r') as yaml_file:
-                conf = yaml.load(yaml_file)
+        self.changed_path = os.path.join(path, "changed_params.out")
+        with open(os.path.join(self.path, conf_name), 'r') as yaml_file:
+            conf = yaml.load(yaml_file)
         self.name_to_monitor = conf['callbacks']['monitor']
         self.load_data()
         self.get_changed()
         self.get_maximum()
         self.read_raw_logs()
 
-    def __lt__(self,other):
+    def __lt__(self, other):
         return self.path.__lt__(other.path)
 
     def get_number(self):
@@ -125,8 +131,8 @@ class HyperparamExperiment(object):
 
     def summary(self):
         s = "Finished" if self.finished else "Running"
-        print("# {} [{}] maximum of {} at epoch {}".format(self.get_number(),s,*self.get_maximum(False)))
-        
+        print("# {} [{}] maximum of {} at epoch {}".format(
+            self.get_number(), s, *self.get_maximum(False)))
 
     def load_data(self):
         import pandas
@@ -164,16 +170,17 @@ class HyperparamExperiment(object):
             if lines[-1].strip() == 'done.':
                 self.finished = True
                 if lines[-2].strip() == 'finished.':
-                        self.success = True
+                    self.success = True
         print('finished: {}, success: {}'.format(self.finished, self.success))
 
-    def get_maximum(self,verbose=True):
+    def get_maximum(self, verbose=True):
         if len(self.epochs) > 0:
-            idx = np.argmax(self.values)        
+            idx = np.argmax(self.values)
             s = "Finished" if self.finished else "Running"
             if verbose:
-                #print(self.path)
-                print("[{}] maximum of {} at epoch {}".format(s,self.values[idx],self.epochs[idx]))
-            return self.values[idx],self.epochs[idx]
+                # print(self.path)
+                print("[{}] maximum of {} at epoch {}".format(
+                    s, self.values[idx], self.epochs[idx]))
+            return self.values[idx], self.epochs[idx]
         else:
-            return -1,-1
+            return -1, -1

--- a/plasma/primitives/ops.py
+++ b/plasma/primitives/ops.py
@@ -2,9 +2,10 @@ import numpy as np
 from mpi4py import MPI
 comm = MPI.COMM_WORLD
 
-#define a float16 mpi datatype
+# define a float16 mpi datatype
 mpi_float16 = MPI.BYTE.Create_contiguous(2).Commit()
 MPI._typedict['e'] = mpi_float16
+
 
 def sum_f16_cb(buffer_a, buffer_b, t):
     assert t == mpi_float16
@@ -12,5 +13,6 @@ def sum_f16_cb(buffer_a, buffer_b, t):
     array_b = np.frombuffer(buffer_b, dtype='float16')
     array_b += array_a
 
-#create new OP
+
+# create new OP
 mpi_sum_f16 = MPI.Op.Create(sum_f16_cb, commute=True)

--- a/plasma/primitives/shots.py
+++ b/plasma/primitives/shots.py
@@ -16,11 +16,12 @@ import random as rnd
 
 import numpy as np
 
-from plasma.utils.processing import train_test_split,cut_and_resample_signal
+from plasma.utils.processing import train_test_split, cut_and_resample_signal
 from plasma.utils.downloading import makedirs_process_safe
 
+
 class ShotListFiles(object):
-    def __init__(self,machine,prepath,paths,description=''):
+    def __init__(self, machine, prepath, paths, description=''):
         self.machine = machine
         self.prepath = prepath
         self.paths = paths
@@ -34,121 +35,105 @@ class ShotListFiles(object):
     def __repr__(self):
         return self.__str__()
 
-    def get_single_shot_numbers_and_disruption_times(self,full_path):
-        data = np.loadtxt(full_path,ndmin=1,dtype={'names':('num','disrupt_times'),
-                                                                  'formats':('i4','f4')})
+    def get_single_shot_numbers_and_disruption_times(self, full_path):
+        data = np.loadtxt(
+            full_path, ndmin=1, dtype={
+                'names': (
+                    'num', 'disrupt_times'), 'formats': (
+                    'i4', 'f4')})
         shots = np.array(list(zip(*data))[0])
         disrupt_times = np.array(list(zip(*data))[1])
         return shots, disrupt_times
 
-
     def get_shot_numbers_and_disruption_times(self):
         all_shots = []
         all_disruption_times = []
-        all_machines_arr = []
+        # all_machines_arr = []
         for path in self.paths:
             full_path = self.prepath + path
-            shots,disruption_times = self.get_single_shot_numbers_and_disruption_times(full_path)
+            shots, disruption_times = (
+                self.get_single_shot_numbers_and_disruption_times(full_path))
             all_shots.append(shots)
             all_disruption_times.append(disruption_times)
-        return np.concatenate(all_shots),np.concatenate(all_disruption_times)
-
+        return np.concatenate(all_shots), np.concatenate(all_disruption_times)
 
 
 class ShotList(object):
     '''
-    A wrapper class around list of Shot objects, providing utilities to 
+    A wrapper class around list of Shot objects, providing utilities to
     extract, load and transform Shots before passing them to an estimator.
 
     During distributed training, shot lists are split into sublists.
-    A sublist is a ShotList object having num_at_once shots. The ShotList contains an entire dataset 
-    as specified in the configuration file.
+    A sublist is a ShotList object having num_at_once shots. The ShotList
+    contains an entire dataset as specified in the configuration file.
     '''
 
-    def __init__(self,shots=None):
+    def __init__(self, shots=None):
         '''
         A ShotList is a list of 2D Numpy arrays.
         '''
         self.shots = []
         if shots is not None:
-            assert(all([isinstance(shot,Shot) for shot in shots]))
+            assert(all([isinstance(shot, Shot) for shot in shots]))
             self.shots = [shot for shot in shots]
 
-    def load_from_shot_list_files_object(self,shot_list_files_object,signals):
+    def load_from_shot_list_files_object(
+            self, shot_list_files_object, signals):
         machine = shot_list_files_object.machine
-        shot_numbers,disruption_times = shot_list_files_object.get_shot_numbers_and_disruption_times()
-        for number,t in list(zip(shot_numbers,disruption_times)):
-            self.append(Shot(number=number,t_disrupt=t,machine=machine,signals=[s for s in signals if s.is_defined_on_machine(machine)]))
+        shot_numbers, disruption_times = (
+            shot_list_files_object.get_shot_numbers_and_disruption_times())
+        for number, t in list(zip(shot_numbers, disruption_times)):
+            self.append(
+                Shot(number=number, t_disrupt=t, machine=machine,
+                     signals=[s for s in signals if
+                              s.is_defined_on_machine(machine)]
+                     )
+                )
 
-
-
-    def load_from_shot_list_files_objects(self,shot_list_files_objects,signals):
+    def load_from_shot_list_files_objects(
+            self, shot_list_files_objects, signals):
         for obj in shot_list_files_objects:
-            self.load_from_shot_list_files_object(obj,signals)
+            self.load_from_shot_list_files_object(obj, signals)
 
-    #         ######Generic Methods####
-
-    # @staticmethod 
-    # def get_shots_and_disruption_times(shots_and_disruption_times_path,machine):
-    #     data = np.loadtxt(shots_and_disruption_times_path,ndmin=1,dtype={'names':('num','disrupt_times'),
-    #                                                               'formats':('i4','f4')})
-    #     shots = np.array(list(zip(*data))[0])
-    #     disrupt_times = np.array(list(zip(*data))[1])
-    #     machines = np.array([machine]*len(shots))
-    #     return shots, disrupt_times, machines
-
-    # @staticmethod
-    # def get_multiple_shots_and_disruption_times(base_path,endings,machines):
-    #     all_shots = []
-    #     all_disruption_times = []
-    #     all_machines_arr = []
-    #     for (ending,machine) in zip(endings,machines):
-    #         path = base_path + ending
-    #         shots,disruption_times,machines_arr = ShotList.get_shots_and_disruption_times(path,machine)
-    #         all_shots.append(shots)
-    #         all_disruption_times.append(disruption_times)
-    #         all_machines_arr.append(machines_arr)
-    #     return np.concatenate(all_shots),np.concatenate(all_disruption_times),np.concatenate(all_machines_arr)
-
-
-    def split_train_test(self,conf):
-        shot_list_dir = conf['paths']['shot_list_dir']
+    def split_train_test(self, conf):
+        # shot_list_dir = conf['paths']['shot_list_dir']
         shot_files = conf['paths']['shot_files']
         shot_files_test = conf['paths']['shot_files_test']
         train_frac = conf['training']['train_frac']
         shuffle_training = conf['training']['shuffle_training']
         use_shots = conf['data']['use_shots']
         all_signals = conf['paths']['all_signals']
-        #split randomly
+        # split randomly
         use_shots_train = int(round(train_frac*use_shots))
         use_shots_test = int(round((1-train_frac)*use_shots))
         if len(shot_files_test) == 0:
-            shot_list_train,shot_list_test = train_test_split(self.shots,train_frac,shuffle_training)
-        #train and test list given
+            shot_list_train, shot_list_test = train_test_split(
+                self.shots, train_frac, shuffle_training)
+        # train and test list given
         else:
             shot_list_train = ShotList()
-            shot_list_train.load_from_shot_list_files_objects(shot_files,all_signals)
-                
+            shot_list_train.load_from_shot_list_files_objects(
+                shot_files, all_signals)
+
             shot_list_test = ShotList()
-            shot_list_test.load_from_shot_list_files_objects(shot_files_test,all_signals)
-        
-        
+            shot_list_test.load_from_shot_list_files_objects(
+                shot_files_test, all_signals)
+
         shot_numbers_train = [shot.number for shot in shot_list_train]
         shot_numbers_test = [shot.number for shot in shot_list_test]
-        print(len(shot_numbers_train),len(shot_numbers_test))
-        #make sure we only use pre-filtered valid shots
+        print(len(shot_numbers_train), len(shot_numbers_test))
+        # make sure we only use pre-filtered valid shots
         shots_train = self.filter_by_number(shot_numbers_train)
         shots_test = self.filter_by_number(shot_numbers_test)
-        return shots_train.random_sublist(use_shots_train),shots_test.random_sublist(use_shots_test)
+        return shots_train.random_sublist(
+            use_shots_train), shots_test.random_sublist(use_shots_test)
 
+    def split_direct(self, frac, do_shuffle=True):
+        shot_list_one, shot_list_two = train_test_split(
+            self.shots, frac, do_shuffle)
+        return ShotList(shot_list_one), ShotList(shot_list_two)
 
-    def split_direct(self,frac,do_shuffle=True):
-        shot_list_one,shot_list_two = train_test_split(self.shots,frac,do_shuffle)
-        return ShotList(shot_list_one),ShotList(shot_list_two)
-
-
-
-    def filter_by_number(self,numbers):
+    def filter_by_number(self, numbers):
         new_shot_list = ShotList()
         numbers = set(numbers)
         for shot in self.shots:
@@ -156,14 +141,14 @@ class ShotList(object):
                 new_shot_list.append(shot)
         return new_shot_list
 
-    def set_weights(self,weights):
+    def set_weights(self, weights):
         assert(len(weights) == len(self.shots))
-        for (i,w) in enumerate(weights):
+        for (i, w) in enumerate(weights):
             self.shots[i].weight = w
 
-    def sample_weighted_given_arr(self,p):
+    def sample_weighted_given_arr(self, p):
         p = p/np.sum(p)
-        idx = np.random.choice(range(len(self.shots)),p=p)
+        idx = np.random.choice(range(len(self.shots)), p=p)
         return self.shots[idx]
 
     def sample_shot(self):
@@ -174,19 +159,20 @@ class ShotList(object):
         p = np.array([shot.weight for shot in self.shots])
         return self.sample_weighted_given_arr(p)
 
-    def sample_single_class(self,disruptive):
+    def sample_single_class(self, disruptive):
         weights_d = 0.0
         weights_nd = 1.0
         if disruptive:
             weights_d = 1.0
             weights_nd = 0.0
-        p = np.array([weights_d if shot.is_disruptive_shot() else weights_nd for shot in self.shots ])
+        p = np.array([weights_d if shot.is_disruptive_shot()
+                      else weights_nd for shot in self.shots])
         return self.sample_weighted_given_arr(p)
 
-
     def sample_equal_classes(self):
-        weights_d,weights_nd = self.get_weights_d_nd()
-        p = np.array([weights_d if shot.is_disruptive_shot() else weights_nd for shot in self.shots ])
+        weights_d, weights_nd = self.get_weights_d_nd()
+        p = np.array([weights_d if shot.is_disruptive_shot()
+                      else weights_nd for shot in self.shots])
         return self.sample_weighted_given_arr(p)
 
     def get_weights_d_nd(self):
@@ -199,22 +185,22 @@ class ShotList(object):
         else:
             weights_d = 1.0*num_nd
             weights_nd = 1.0*num_d
-        max_weight = np.maximum(weights_d,weights_nd)
-        return weights_d/max_weight,weights_nd/max_weight
+        max_weight = np.maximum(weights_d, weights_nd)
+        return weights_d/max_weight, weights_nd/max_weight
 
-    def num_timesteps(self,prepath):
+    def num_timesteps(self, prepath):
         ls = [shot.num_timesteps(prepath) for shot in self.shots]
         timesteps_total = sum(ls)
-        timesteps_d = sum([ts for (i,ts) in enumerate(ls) if self.shots[i].is_disruptive_shot()])
+        timesteps_d = sum([ts for (i, ts) in enumerate(
+            ls) if self.shots[i].is_disruptive_shot()])
         timesteps_nd = timesteps_total-timesteps_d
-        return timesteps_total,timesteps_d,timesteps_nd
-
+        return timesteps_total, timesteps_d, timesteps_nd
 
     def num_disruptive(self):
         return len([shot for shot in self.shots if shot.is_disruptive_shot()])
 
     def __len__(self):
-        return len(self.shots) 
+        return len(self.shots)
 
     def __str__(self):
         return str([s.number for s in self.shots])
@@ -225,47 +211,45 @@ class ShotList(object):
     def next(self):
         return self.__iter__().next()
 
-    def __add__(self,other_list):
+    def __add__(self, other_list):
         return ShotList(self.shots + other_list.shots)
 
-    def index(self,item):
+    def index(self, item):
         return self.shots.index(item)
 
-    def __getitem__(self,key):
+    def __getitem__(self, key):
         return self.shots[key]
 
-    def random_sublist(self,num):
-        num = min(num,len(self))
-        shots_picked = np.random.choice(self.shots,size=num,replace=False)
+    def random_sublist(self, num):
+        num = min(num, len(self))
+        shots_picked = np.random.choice(self.shots, size=num, replace=False)
         return ShotList(shots_picked)
 
-    def sublists(self,num,do_shuffle=True,equal_size=False):
+    def sublists(self, num, do_shuffle=True, equal_size=False):
         lists = []
         if do_shuffle:
             self.shuffle()
-        for i in range(0,len(self),num):
+        for i in range(0, len(self), num):
             subl = self.shots[i:i+num]
             while equal_size and len(subl) < num:
                 subl.append(rnd.choice(self.shots))
             lists.append(subl)
         return [ShotList(l) for l in lists]
 
-
-
     def shuffle(self):
         np.random.shuffle(self.shots)
 
     def sort(self):
-        self.shots.sort() #will sort based on machine and number
+        self.shots.sort()  # will sort based on machine and number
 
     def as_list(self):
         return self.shots
 
-    def append(self,shot):
-        assert(isinstance(shot,Shot))
+    def append(self, shot):
+        assert(isinstance(shot, Shot))
         self.shots.append(shot)
 
-    def remove(self,shot):
+    def remove(self, shot):
         assert(shot in self.shots)
         self.shots.remove(shot)
         assert(shot not in self.shots)
@@ -274,75 +258,93 @@ class ShotList(object):
         for shot in self.shots:
             shot.make_light()
 
-    def append_if_valid(self,shot):
+    def append_if_valid(self, shot):
         if shot.valid:
             self.append(shot)
             return True
         else:
-            #print('Warning: shot {} not valid, omitting'.format(shot.number))
+            # print('Warning: shot {} not valid, omitting'.format(shot.number))
             return False
 
-        
 
 class Shot(object):
     '''
     A class representing a shot.
-    Each shot is a measurement of plasma properties (current, locked mode amplitude, etc.) as a function of time. 
+    Each shot is a measurement of plasma properties (current, locked mode
+    amplitude, etc.) as a function of time.
 
-    For 0D data, each shot is modeled as a 2D Numpy array - time vs a plasma property.
+    For 0D data, each shot is modeled as a 2D Numpy array - time vs a plasma
+    property.
     '''
 
-    def __init__(self,number=None,machine=None,signals=None,signals_dict=None,ttd=None,valid=None,is_disruptive=None,t_disrupt=None):
+    def __init__(
+            self,
+            number=None,
+            machine=None,
+            signals=None,
+            signals_dict=None,
+            ttd=None,
+            valid=None,
+            is_disruptive=None,
+            t_disrupt=None):
         '''
         Shot objects contain following attributes:
-    
+
          - number: integer, unique identifier of a shot
-         - t_disrupt: double, disruption time in milliseconds (second column in the shotlist input file)
-         - ttd: Numpy array of doubles, time profile of the shot converted to time-to-disruption values
-         - valid: boolean flag indicating whether plasma property (specifically, current) reaches a certain value during the shot
+         - t_disrupt: double, disruption time in milliseconds (second column in
+         the shotlist input file)
+
+         - ttd: Numpy array of doubles, time profile of the shot converted to
+           time-to-disruption values
+         - valid: boolean flag indicating whether plasma property
+           (specifically, current) reaches a certain value during the shot
          - is_disruptive: boolean flag indicating whether a shot is disruptive
         '''
-        self.number = number #Shot number
-        self.machine = machine #machine on which it is defined
-        self.signals = signals 
-        self.signals_dict = signals_dict #
-        self.ttd = ttd 
-        self.valid =valid 
+        self.number = number  # Shot number
+        self.machine = machine  # machine on which it is defined
+        self.signals = signals
+        self.signals_dict = signals_dict
+        self.ttd = ttd
+        self.valid = valid
         self.is_disruptive = is_disruptive
         self.t_disrupt = t_disrupt
         self.weight = 1.0
         self.augmentation_fn = None
         if t_disrupt is not None:
-            self.is_disruptive = Shot.is_disruptive_given_disruption_time(t_disrupt)
+            self.is_disruptive = Shot.is_disruptive_given_disruption_time(
+                t_disrupt)
         else:
-            print('Warning, disruption time (disruptivity) not set! Either set t_disrupt or is_disruptive')
+            print('Warning, disruption time (disruptivity) not set! ',
+                  'Either set t_disrupt or is_disruptive')
 
     def get_id_str(self):
-        return '{} : {}'.format(self.machine,self.number)
+        return '{} : {}'.format(self.machine, self.number)
 
-    def __lt__(self,other):
+    def __lt__(self, other):
         return self.get_id_str().__lt__(other.get_id_str())
 
-    def __eq__(self,other):
+    def __eq__(self, other):
         return self.get_id_str().__eq__(other.get_id_str())
 
     def __hash__(self):
-       import hashlib
-       return int(hashlib.md5(self.get_id_str().encode('utf-8')).hexdigest(),16)
+        import hashlib
+        return int(
+            hashlib.md5(
+                self.get_id_str().encode('utf-8')).hexdigest(),
+            16)
 
     def __str__(self):
         string = 'number: {}\n'.format(self.number)
         string += 'machine: {}\n'.format(self.machine)
-        string += 'signals: {}\n'.format(self.signals )
-        string += 'signals_dict: {}\n'.format(self.signals_dict )
-        string += 'ttd: {}\n'.format(self.ttd )
-        string += 'valid: {}\n'.format(self.valid )
+        string += 'signals: {}\n'.format(self.signals)
+        string += 'signals_dict: {}\n'.format(self.signals_dict)
+        string += 'ttd: {}\n'.format(self.ttd)
+        string += 'valid: {}\n'.format(self.valid)
         string += 'is_disruptive: {}\n'.format(self.is_disruptive)
         string += 't_disrupt: {}\n'.format(self.t_disrupt)
         return string
-     
 
-    def num_timesteps(self,prepath):
+    def num_timesteps(self, prepath):
         self.restore(prepath)
         ts = self.ttd.shape[0]
         self.make_light()
@@ -360,131 +362,155 @@ class Shot(object):
     def is_disruptive_shot(self):
         return self.is_disruptive
 
-    def get_data_arrays(self,use_signals,dtype='float32'):
+    def get_data_arrays(self, use_signals, dtype='float32'):
         t_array = self.ttd
-        signal_array = np.zeros((len(t_array),sum([sig.num_channels for sig in use_signals])),dtype=dtype)
+        signal_array = np.zeros(
+            (len(t_array), sum([sig.num_channels for sig in use_signals])),
+            dtype=dtype)
         curr_idx = 0
         for sig in use_signals:
-            signal_array[:,curr_idx:curr_idx+sig.num_channels] = self.signals_dict[sig]
+            signal_array[:, curr_idx:curr_idx
+                         + sig.num_channels] = self.signals_dict[sig]
             curr_idx += sig.num_channels
-        return t_array,signal_array
+        return t_array, signal_array
 
     def get_individual_signal_arrays(self):
-        #guarantee ordering
+        # guarantee ordering
         return [self.signals_dict[sig] for sig in self.signals]
 
-    def preprocess(self,conf):
+    def preprocess(self, conf):
         sys.stdout.write('\rrecomputing {}'.format(self.number))
         sys.stdout.flush()
-      #get minmax times
-        time_arrays,signal_arrays,t_min,t_max,valid = self.get_signals_and_times_from_file(conf) 
+        # get minmax times
+        time_arrays, signal_arrays, t_min, t_max, valid = (
+            self.get_signals_and_times_from_file(conf))
         self.valid = valid
-        #cut and resample
+        # cut and resample
         if self.valid:
-            self.cut_and_resample_signals(time_arrays,signal_arrays,t_min,t_max,conf)
+            self.cut_and_resample_signals(
+                time_arrays, signal_arrays, t_min, t_max, conf)
 
-    def get_signals_and_times_from_file(self,conf):
+    def get_signals_and_times_from_file(self, conf):
         valid = True
         t_min = -np.Inf
         t_max = np.Inf
-        t_thresh = -1
+        # t_thresh = -1
         signal_arrays = []
         time_arrays = []
 
-        #disruptive = self.t_disrupt >= 0
+        # disruptive = self.t_disrupt >= 0
 
         signal_prepath = conf['paths']['signal_prepath']
-        for (i,signal) in enumerate(self.signals):
-            t,sig,valid_signal = signal.load_data(signal_prepath,self,conf['data']['floatx'])
+        for (i, signal) in enumerate(self.signals):
+            t, sig, valid_signal = signal.load_data(
+                signal_prepath, self, conf['data']['floatx'])
             if not valid_signal:
-                return None,None,None,None,False
+                return None, None, None, None, False
             else:
                 assert(len(sig.shape) == 2)
                 assert(len(t.shape) == 1)
                 assert(len(t) > 1)
-                t_min = max(t_min,np.min(t))
+                t_min = max(t_min, np.min(t))
                 signal_arrays.append(sig)
                 time_arrays.append(t)
                 if self.is_disruptive and self.t_disrupt > np.max(t):
-                    if self.t_disrupt > np.max(t) + signal.get_data_avail_tolerance(self.machine):
-                        print('Shot {}: disruption event is not contained in valid time region of signal {} by {}s, omitting.'.format(self.number,signal,self.t_disrupt - np.max(t)))
-                        valid = False 
+                    t_max_total = (
+                        np.max(t) + signal.get_data_avail_tolerance(
+                            self.machine)
+                    )
+                    if (self.t_disrupt > t_max_total):
+                        print('Shot {}: disruption event '.format(self.number),
+                              'is not contained in valid time region of ',
+                              'signal {} by {}s, omitting.'.format(
+                                  self.number, signal,
+                                  self.t_disrupt - np.max(t)))
+                        valid = False
                     else:
-                        t_max = np.max(t) + signal.get_data_avail_tolerance(self.machine)
+                        t_max = np.max(
+                            t) + signal.get_data_avail_tolerance(self.machine)
                 else:
-                    t_max = min(t_max,np.max(t))
+                    t_max = min(t_max, np.max(t))
 
-        #make sure the shot is long enough.
+        # make sure the shot is long enough.
         dt = conf['data']['dt']
-        if (t_max - t_min)/dt <= (2*conf['model']['length']+conf['data']['T_min_warn']):
-            print('Shot {} contains insufficient data, omitting.'.format(self.number))
+        if (t_max - t_min)/dt <= (2*conf['model']
+                                  ['length']+conf['data']['T_min_warn']):
+            print(
+                'Shot {} contains insufficient data, omitting.'.format(
+                    self.number))
             valid = False
 
-        # if self.is_disruptive and self.t_disrupt > t_max+conf['data']['data_avail_tolerance']:
-        #     print('Shot {}: disruption event is not contained in valid time region by {}s, omitting.'.format(self.number,self.t_disrupt - t_max))
-        #     valid = False 
-        assert(t_max > t_min or not valid), "t max: {}, t_min: {}".format(t_max,t_min)
-                
-        
+        assert(
+            t_max > t_min or not valid), "t max: {}, t_min: {}".format(
+            t_max, t_min)
+
         if self.is_disruptive:
             assert(self.t_disrupt <= t_max or not valid)
             t_max = self.t_disrupt
 
-        return time_arrays,signal_arrays,t_min,t_max,valid
+        return time_arrays, signal_arrays, t_min, t_max, valid
 
-
-    def cut_and_resample_signals(self,time_arrays,signal_arrays,t_min,t_max,conf):
+    def cut_and_resample_signals(
+            self,
+            time_arrays,
+            signal_arrays,
+            t_min,
+            t_max,
+            conf):
         dt = conf['data']['dt']
         signals_dict = dict()
 
-        #resample signals
-        assert((len(signal_arrays) == len(time_arrays) == len(self.signals)) and len(signal_arrays) > 0)
+        # resample signals
+        assert((len(signal_arrays) == len(time_arrays)
+                == len(self.signals)) and len(signal_arrays) > 0)
         tr = 0
-        for (i,signal) in enumerate(self.signals):
-            tr,sigr = cut_and_resample_signal(time_arrays[i],signal_arrays[i],t_min,t_max,dt,conf['data']['floatx'])
+        for (i, signal) in enumerate(self.signals):
+            tr, sigr = cut_and_resample_signal(
+                time_arrays[i], signal_arrays[i], t_min, t_max, dt,
+                conf['data']['floatx'])
             signals_dict[signal] = sigr
 
-        ttd = self.convert_to_ttd(tr,conf)
-        self.signals_dict =signals_dict 
+        ttd = self.convert_to_ttd(tr, conf)
+        self.signals_dict = signals_dict
         self.ttd = ttd
 
-    def convert_to_ttd(self,tr,conf):
+    def convert_to_ttd(self, tr, conf):
         T_max = conf['data']['T_max']
         dt = conf['data']['dt']
         if self.is_disruptive:
             ttd = max(tr) - tr
-            ttd = np.clip(ttd,0,T_max)
+            ttd = np.clip(ttd, 0, T_max)
         else:
             ttd = T_max*np.ones_like(tr)
         ttd = np.log10(ttd + 1.0*dt/10)
         return ttd
 
-    def save(self,prepath):
+    def save(self, prepath):
         makedirs_process_safe(prepath)
         save_path = self.get_save_path(prepath)
-        np.savez(save_path,valid=self.valid,is_disruptive=self.is_disruptive,
-            signals_dict=self.signals_dict,ttd=self.ttd)
+        np.savez(save_path, valid=self.valid, is_disruptive=self.is_disruptive,
+                 signals_dict=self.signals_dict, ttd=self.ttd)
         print('...saved shot {}'.format(self.number))
 
-    def get_save_path(self,prepath):
-        return get_individual_shot_file(prepath,self.number,'.npz')
+    def get_save_path(self, prepath):
+        return get_individual_shot_file(prepath, self.number, '.npz')
 
-    def restore(self,prepath,light=False):
+    def restore(self, prepath, light=False):
         assert self.previously_saved(prepath), 'shot was never saved'
         save_path = self.get_save_path(prepath)
-        dat = np.load(save_path,encoding="latin1")
+        dat = np.load(save_path, encoding="latin1")
 
         self.valid = dat['valid'][()]
         self.is_disruptive = dat['is_disruptive'][()]
 
         if light:
             self.signals_dict = None
-            self.ttd = None 
+            self.ttd = None
         else:
             self.signals_dict = dat['signals_dict'][()]
             self.ttd = dat['ttd']
-  
-    def previously_saved(self,prepath):
+
+    def previously_saved(self, prepath):
         save_path = self.get_save_path(prepath)
         return os.path.isfile(save_path)
 
@@ -496,6 +522,8 @@ class Shot(object):
     def is_disruptive_given_disruption_time(t):
         return t >= 0
 
-#it used to be in utilities, but can't import globals in multiprocessing
-def get_individual_shot_file(prepath,shot_num,ext='.txt'):
-    return prepath + str(shot_num) + ext 
+# it used to be in utilities, but can't import globals in multiprocessing
+
+
+def get_individual_shot_file(prepath, shot_num, ext='.txt'):
+    return prepath + str(shot_num) + ext

--- a/plasma/utils/batch_jobs.py
+++ b/plasma/utils/batch_jobs.py
@@ -1,16 +1,16 @@
-from __future__ import division 
-from pprint import pprint
-import yaml
+from __future__ import division
 import datetime
 import uuid
-import sys,os,getpass
+import os
+# import getpass
 import subprocess as sp
-import numpy as np
+
 
 def generate_working_dirname(run_directory):
     s = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
     s += "_{}".format(uuid.uuid4())
     return run_directory + s
+
 
 def get_executable_name(conf):
     shallow = conf['model']['shallow']
@@ -20,21 +20,43 @@ def get_executable_name(conf):
     else:
         executable_name = conf['paths']['executable']
         use_mpi = True
-    return executable_name,use_mpi
+    return executable_name, use_mpi
 
 
-def start_slurm_job(subdir,num_nodes,i,conf,shallow,env_name="frnn",env_type="anaconda"):
-    executable_name,use_mpi = get_executable_name(conf)
-    os.system(" ".join(["cp -p",executable_name,subdir]))
-    script = create_slurm_script(subdir,num_nodes,i,executable_name,use_mpi,env_name,env_type)
-    sp.Popen("sbatch "+script,shell=True)
+def start_slurm_job(
+        subdir,
+        num_nodes,
+        i,
+        conf,
+        shallow,
+        env_name="frnn",
+        env_type="anaconda"):
+    executable_name, use_mpi = get_executable_name(conf)
+    os.system(" ".join(["cp -p", executable_name, subdir]))
+    script = create_slurm_script(
+        subdir,
+        num_nodes,
+        i,
+        executable_name,
+        use_mpi,
+        env_name,
+        env_type)
+    sp.Popen("sbatch "+script, shell=True)
 
 
-def create_jenkins_script(subdir,num_nodes,executable_name,test_configuration,env_name="frnn",env_type="anaconda"):
-    filename = "jenkins_{}_{}.cmd".format(test_configuration[0],test_configuration[1]) #version of Python and the dataset
-    filepath = os.path.join(subdir,filename)
-    user = getpass.getuser()
-    with open(filepath,"w") as f:
+def create_jenkins_script(
+        subdir,
+        num_nodes,
+        executable_name,
+        test_configuration,
+        env_name="frnn",
+        env_type="anaconda"):
+    filename = "jenkins_{}_{}.cmd".format(
+        test_configuration[0],
+        test_configuration[1])  # version of Python and the dataset
+    filepath = os.path.join(subdir, filename)
+    # user = getpass.getuser()
+    with open(filepath, "w") as f:
         f.write('#!/usr/bin/bash\n')
         f.write('export OMPI_MCA_btl=\"tcp,self,sm\"\n')
         f.write('echo \"Jenkins test {}\"\n'.format(test_configuration[1]))
@@ -48,36 +70,74 @@ def create_jenkins_script(subdir,num_nodes,executable_name,test_configuration,en
         f.write('module load cudnn/cuda-8.0/6.0\n')
         f.write('module load openmpi/cuda-8.0/intel-17.0/2.1.0/64\n')
         f.write('module load intel/17.0/64/17.0.4.196\n')
-        f.write('cd /home/alexeys/jenkins/workspace/FRNM/PPPL\n') 
+        f.write('cd /home/alexeys/jenkins/workspace/FRNM/PPPL\n')
         f.write('python setup.py install\n')
         f.write('cd {}\n'.format(subdir))
-        f.write('srun -N {} -n {} python {}\n'.format(num_nodes//2, num_nodes//2*4, executable_name))
+        f.write('srun -N {} -n {} python {}\n'.format(
+            num_nodes // 2, num_nodes // 2 * 4, executable_name))
 
     return filepath
 
-def start_jenkins_job(subdir,num_nodes,executable_name,test_configuration,env_name,env_type):
-    os.system(" ".join(["cp -p",executable_name,subdir]))
-    script = create_jenkins_script(subdir,num_nodes,executable_name,test_configuration,env_name,env_type)
-    sp.Popen("sh "+script,shell=True)
 
-def start_pbs_job(subdir,num_nodes,i,conf,shallow,env_name="frnn",env_type="anaconda"):
-    executable_name,use_mpi = get_executable_name(conf)
-    os.system(" ".join(["cp -p",executable_name,subdir]))
-    script = create_pbs_script(subdir,num_nodes,i,executable_name,use_mpi,env_name,env_type)
-    sp.Popen("qsub "+script,shell=True)
+def start_jenkins_job(
+        subdir,
+        num_nodes,
+        executable_name,
+        test_configuration,
+        env_name,
+        env_type):
+    os.system(" ".join(["cp -p", executable_name, subdir]))
+    script = create_jenkins_script(
+        subdir,
+        num_nodes,
+        executable_name,
+        test_configuration,
+        env_name,
+        env_type)
+    sp.Popen("sh "+script, shell=True)
 
 
-def create_slurm_script(subdir,num_nodes,idx,executable_name,use_mpi,env_name="frnn",env_type="anaconda"):
+def start_pbs_job(
+        subdir,
+        num_nodes,
+        i,
+        conf,
+        shallow,
+        env_name="frnn",
+        env_type="anaconda"):
+    executable_name, use_mpi = get_executable_name(conf)
+    os.system(" ".join(["cp -p", executable_name, subdir]))
+    script = create_pbs_script(
+        subdir,
+        num_nodes,
+        i,
+        executable_name,
+        use_mpi,
+        env_name,
+        env_type)
+    sp.Popen("qsub "+script, shell=True)
+
+
+def create_slurm_script(
+        subdir,
+        num_nodes,
+        idx,
+        executable_name,
+        use_mpi,
+        env_name="frnn",
+        env_type="anaconda"):
     filename = "run_{}_nodes.cmd".format(num_nodes)
     filepath = subdir+filename
-    user = getpass.getuser()
-    sbatch_header = create_slurm_header(num_nodes,use_mpi,idx)
-    with open(filepath,"w") as f:
+    # user = getpass.getuser()
+    sbatch_header = create_slurm_header(num_nodes, use_mpi, idx)
+    with open(filepath, "w") as f:
         for line in sbatch_header:
             f.write(line)
         f.write('module load '+env_type+'\n')
         f.write('source activate '+env_name+'\n')
-        f.write('module load cudatoolkit/8.0 cudnn/cuda-8.0/6.0 openmpi/cuda-8.0/intel-17.0/2.1.0/64\n')
+        f.write((
+            'module load cudatoolkit/8.0 cudnn/cuda-8.0/6.0 '
+            'openmpi/cuda-8.0/intel-17.0/2.1.0/64\n'))
         f.write('module load intel/17.0/64/17.0.5.239 intel-mkl/2017.3/4/64\n')
         # f.write('rm -f /tigress/{}/model_checkpoints/*.h5\n'.format(user))
         f.write('cd {}\n'.format(subdir))
@@ -87,27 +147,38 @@ def create_slurm_script(subdir,num_nodes,idx,executable_name,use_mpi,env_name="f
 
     return filepath
 
-def create_pbs_script(subdir,num_nodes,idx,executable_name,use_mpi,env_name="frnn",env_type="anaconda"):
+
+def create_pbs_script(
+        subdir,
+        num_nodes,
+        idx,
+        executable_name,
+        use_mpi,
+        env_name="frnn",
+        env_type="anaconda"):
     filename = "run_{}_nodes.cmd".format(num_nodes)
     filepath = subdir+filename
-    user = getpass.getuser()
-    sbatch_header = create_pbs_header(num_nodes,use_mpi,idx)
-    with open(filepath,"w") as f:
+    # user = getpass.getuser()
+    sbatch_header = create_pbs_header(num_nodes, use_mpi, idx)
+    with open(filepath, "w") as f:
         for line in sbatch_header:
             f.write(line)
-        #f.write('export HOME=/lustre/atlas/proj-shared/fus117\n')
-        #f.write('cd $HOME/PPPL/plasma-python/examples\n')
+        # f.write('export HOME=/lustre/atlas/proj-shared/fus117\n')
+        # f.write('cd $HOME/PPPL/plasma-python/examples\n')
         f.write('source $MODULESHOME/init/bash\n')
         f.write('module load tensorflow\n')
         # f.write('rm $HOME/tigress/alexeys/model_checkpoints/*\n')
         f.write('cd {}\n'.format(subdir))
-        f.write('aprun -n {} -N1 env KERAS_HOME={} singularity exec $TENSORFLOW_CONTAINER python3 {}\n'.format(str(num_nodes),subdir,executable_name))
+        f.write(
+            'aprun -n {} -N1 env KERAS_HOME={} singularity exec '
+            '$TENSORFLOW_CONTAINER python3 {}\n'.format(str(num_nodes), subdir,
+                                                        executable_name))
         f.write('echo "done."')
 
     return filepath
 
 
-def create_slurm_header(num_nodes,use_mpi,idx):
+def create_slurm_header(num_nodes, use_mpi, idx):
     if not use_mpi:
         assert(num_nodes == 1)
     lines = []
@@ -127,7 +198,8 @@ def create_slurm_header(num_nodes,use_mpi,idx):
     lines.append('\n\n')
     return lines
 
-def create_pbs_header(num_nodes,use_mpi,idx):
+
+def create_pbs_header(num_nodes, use_mpi, idx):
     if not use_mpi:
         assert(num_nodes == 1)
     lines = []
@@ -143,7 +215,12 @@ def create_pbs_header(num_nodes,use_mpi,idx):
 
 def copy_files_to_environment(subdir):
     from plasma.conf import conf
-    normalization_dir = os.path.dirname(conf['paths']['global_normalizer_path'])
+    normalization_dir = os.path.dirname(
+        conf['paths']['global_normalizer_path'])
     if os.path.isdir(normalization_dir):
         print("Copying normalization to")
-        os.system(" ".join(["cp -rp",normalization_dir,os.path.join(subdir,os.path.basename(normalization_dir))]))
+        os.system(" ".join(
+            ["cp -rp", normalization_dir,
+             os.path.join(subdir, os.path.basename(normalization_dir))]
+            )
+                  )

--- a/plasma/utils/downloading.py
+++ b/plasma/utils/downloading.py
@@ -1,4 +1,12 @@
 from __future__ import print_function
+import errno
+import os
+# from multiprocessing import Queue
+from functools import partial
+import multiprocessing as mp
+import sys
+import time
+import numpy as np
 '''
 http://www.mdsplus.org/index.php?title=Documentation:Tutorial:RemoteAccess&open=76203664636339686324830207&page=Documentation%2FThe+MDSplus+tutorial%2FRemote+data+access+in+MDSplus
 http://piscope.psfc.mit.edu/index.php/MDSplus_%26_python#Simple_example_of_reading_MDSplus_data
@@ -14,58 +22,57 @@ http://www.mdsplus.org/index.php?title=Documentation:Tutorial:MdsObjects&open=76
 - TEST
 '''
 try:
-    from MDSplus import *
+    from MDSplus import Connection
 except ImportError:
     pass
-#from pylab import *
-import numpy as np
-import sys
-import multiprocessing as mp
-from functools import partial
-from multiprocessing import Queue
-import os
-import errno
 
 # import gadata
-
 # from plasma.primitives.shots import ShotList
-
-#from signals import *
-
-#print("Importing numpy version"+np.__version__)
 
 
 def get_missing_value_array():
     return np.array([-1.0])
 
+
 def makedirs_process_safe(dirpath):
-    try: #can lead to race condition
+    try:  # can lead to race condition
         os.makedirs(dirpath)
     except OSError as e:
-        if e.errno == errno.EEXIST:# File exists, and it's a directory, another process beat us to creating this dir, that's OK.
+        # File exists, and it's a directory, another process beat us to
+        # creating this dir, that's OK.
+        if e.errno == errno.EEXIST:
             pass
-        else:# Our target dir exists as a file, or different error, reraise the error!
+        else:
+            # Our target dir exists as a file, or different error, reraise the
+            # error!
             raise
+
 
 def makedirdepth_process_safe(dirpath):
-    try: #can lead to race condition
+    try:  # can lead to race condition
         mkdirdepth(dirpath)
     except OSError as e:
-        if e.errno == errno.EEXIST:# File exists, and it's a directory, another process beat us to creating this dir, that's OK.
+        # File exists, and it's a directory, another process beat us to
+        # creating this dir, that's OK.
+        if e.errno == errno.EEXIST:
             pass
-        else:# Our target dir exists as a file, or different error, reraise the error!
+        else:
+            # Our target dir exists as a file, or different error, reraise the
+            # error!
             raise
 
+
 def mkdirdepth(filename):
-    folder=os.path.dirname(filename)
+    folder = os.path.dirname(filename)
     if not os.path.exists(folder):
         os.makedirs(folder)
 
-def format_save_path(prepath,signal_path,shot_num):
-    return prepath + signal_path  + '/{}.txt'.format(shot_num)
+
+def format_save_path(prepath, signal_path, shot_num):
+    return prepath + signal_path + '/{}.txt'.format(shot_num)
 
 
-def save_shot(shot_num_queue,c,signals,save_prepath,machine,sentinel=-1):
+def save_shot(shot_num_queue, c, signals, save_prepath, machine, sentinel=-1):
     missing_values = 0
     # if machine == 'd3d':
     #   reload(gadata) #reloads Gadata object with connection
@@ -76,99 +83,132 @@ def save_shot(shot_num_queue,c,signals,save_prepath,machine,sentinel=-1):
         shot_complete = True
         for signal in signals:
             signal_path = signal.get_path(machine)
-            save_path_full = signal.get_file_path(save_prepath,machine,shot_num)
+            save_path_full = signal.get_file_path(
+                save_prepath, machine, shot_num)
             success = False
             mapping = None
             if os.path.isfile(save_path_full):
                 if os.path.getsize(save_path_full) > 0:
-                    print('-',end='')
+                    print('-', end='')
                     success = True
                 else:
-                    print('Signal {}, shot {} was downloaded incorrectly (empty file). Redownloading.'.format(signal_path,shot_num))
+                    print(
+                        'Signal {}, shot {} '.format(signal_path, shot_num),
+                        'was downloaded incorrectly (empty file). ',
+                        'Redownloading.')
             if not success:
                 try:
                     try:
-                        time,data,mapping,success = signal.fetch_data(machine,shot_num,c) 
+                        time, data, mapping, success = (
+                            signal.fetch_data(machine, shot_num, c))
                         if not success:
-                            print('No success shot {}, signal {}'.format(shot_num,signal))
+                            print('No success shot {}, signal {}'.format(
+                                shot_num, signal))
                     except Exception as e:
                         print(e)
                         sys.stdout.flush()
-                        #missing_values += 1
-                        print('Signal {}, shot {} missing. Filling with zeros'.format(signal_path,shot_num))
+                        # missing_values += 1
+                        print('Signal {}, shot {} missing. '.format(
+                            signal_path, shot_num), 'Filling with zeros.')
                         success = False
 
-                    
                     if success:
-                        data_two_column = np.vstack((np.atleast_2d(time),np.atleast_2d(data))).transpose()
+                        data_two_column = np.vstack((np.atleast_2d(time),
+                                                     np.atleast_2d(data))
+                                                    ).transpose()
                         if mapping is not None:
-                            mapping_two_column = np.vstack((np.atleast_2d(time),np.atleast_2d(mapping))).transpose()
-                            # mapping_two_column = np.hstack((np.array([[0.0]]),np.atleast_2d(mapping)))
-                            data_two_column = np.vstack((mapping_two_column,data_two_column))
+                            mapping_two_column = np.vstack((
+                                np.atleast_2d(time), np.atleast_2d(mapping))
+                                                           ).transpose()
+                            data_two_column = np.vstack(
+                                (mapping_two_column, data_two_column))
                     makedirdepth_process_safe(save_path_full)
                     if success:
-                        np.savetxt(save_path_full,data_two_column,fmt = '%.5e')#fmt = '%f %f')
+                        np.savetxt(save_path_full, data_two_column, fmt='%.5e')
                     else:
-                        np.savetxt(save_path_full,get_missing_value_array(),fmt = '%.5e')
-                    print('.',end='')
-                except:
-                    print('Could not save shot {}, signal {}'.format(shot_num,signal_path))
+                        np.savetxt(save_path_full, get_missing_value_array(),
+                                   fmt='%.5e')
+                    print('.', end='')
+                except BaseException:
+                    print(
+                        'Could not save shot {}, signal {}'.format(
+                            shot_num, signal_path))
                     print('Warning: Incomplete!!!')
                     raise
             sys.stdout.flush()
             if not success:
                 missing_values += 1
                 shot_complete = False
-        #only add shot to list if it was complete
+        # only add shot to list if it was complete
         if shot_complete:
             print('saved shot {}'.format(shot_num))
-            #complete_queue.put(shot_num)
+            # complete_queue.put(shot_num)
         else:
             print('shot {} not complete. removing from list.'.format(shot_num))
     print('Finished with {} missing values total'.format(missing_values))
     return
 
 
-def download_shot_numbers(shot_numbers,save_prepath,machine,signals):
+def download_shot_numbers(shot_numbers, save_prepath, machine, signals):
     max_cores = machine.max_cores
     sentinel = -1
-    fn = partial(save_shot,signals=signals,save_prepath=save_prepath,machine=machine,sentinel=sentinel)
-    num_cores = min(mp.cpu_count(),max_cores) #can only handle 8 connections at once :(
+    fn = partial(save_shot, signals=signals, save_prepath=save_prepath,
+                 machine=machine, sentinel=sentinel)
+    # can only handle 8 connections at once :(
+    num_cores = min(mp.cpu_count(), max_cores)
     queue = mp.Queue()
-    #complete_shots = Array('i',zeros(len(shot_numbers)))# = mp.Queue()
-    
-    assert(len(shot_numbers) < 32000) # mp.queue can't handle larger queues yet!
+    # complete_shots = Array('i',zeros(len(shot_numbers)))# = mp.Queue()
+
+    # mp.queue can't handle larger queues yet!
+    assert(len(shot_numbers) < 32000)
     for shot_num in shot_numbers:
         queue.put(shot_num)
     for i in range(num_cores):
         queue.put(sentinel)
     connections = [Connection(machine.server) for _ in range(num_cores)]
-    processes = [mp.Process(target=fn,args=(queue,connections[i])) for i in range(num_cores)]
-    
+    processes = [
+        mp.Process(
+            target=fn,
+            args=(
+                queue,
+                connections[i])) for i in range(num_cores)]
+
     print('running in parallel on {} processes'.format(num_cores))
-    
+
     for p in processes:
         p.start()
     for p in processes:
         p.join()
 
 
-def download_all_shot_numbers(prepath,save_path,shot_list_files,signals_full):
+def download_all_shot_numbers(
+        prepath,
+        save_path,
+        shot_list_files,
+        signals_full):
     max_len = 30000
 
     machine = shot_list_files.machine
     signals = []
     for sig in signals_full:
         if not sig.is_defined_on_machine(machine):
-            print('Signal {} not defined on machine {}, omitting'.format(sig,machine))
+            print(
+                'Signal {} not defined on machine {}, omitting'.format(
+                    sig, machine))
         else:
             signals.append(sig)
-    save_prepath = prepath+save_path + '/' 
-    shot_numbers,_ = shot_list_files.get_shot_numbers_and_disruption_times()
-    shot_numbers_chunks = [shot_numbers[i:i+max_len] for i in xrange(0,len(shot_numbers),max_len)]#can only use queue of max size 30000
+    save_prepath = prepath+save_path + '/'
+    shot_numbers, _ = shot_list_files.get_shot_numbers_and_disruption_times()
+    # can only use queue of max size 30000
+    shot_numbers_chunks = [shot_numbers[i:i+max_len]
+                           for i in np.xrange(0, len(shot_numbers), max_len)]
     start_time = time.time()
     for shot_numbers_chunk in shot_numbers_chunks:
-        download_shot_numbers(shot_numbers_chunk,save_prepath,machine,signals)
-    
-    print('Finished downloading {} shots in {} seconds'.format(len(shot_numbers),time.time()-start_time))
+        download_shot_numbers(
+            shot_numbers_chunk,
+            save_prepath,
+            machine,
+            signals)
 
+    print('Finished downloading {} shots in {} seconds'.format(
+        len(shot_numbers), time.time()-start_time))

--- a/plasma/utils/evaluation.py
+++ b/plasma/utils/evaluation.py
@@ -1,27 +1,32 @@
 import numpy as np
 epsilon = 1e-7
 
-def get_loss_from_list(y_pred_list,y_true_list,target):
-    return np.mean([get_loss(yg,yp,target) for yp,yg in zip(y_pred_list,y_true_list)])
 
-def get_loss(y_true,y_pred,target):
-    return target.loss_np(y_true,y_pred)
+def get_loss_from_list(y_pred_list, y_true_list, target):
+    return np.mean([get_loss(yg, yp, target)
+                    for yp, yg in zip(y_pred_list, y_true_list)])
 
-def mae_np(y_true,y_pred):
+
+def get_loss(y_true, y_pred, target):
+    return target.loss_np(y_true, y_pred)
+
+
+def mae_np(y_true, y_pred):
     return np.mean(np.abs(y_pred-y_true))
 
-def mse_np(y_true,y_pred):
+
+def mse_np(y_true, y_pred):
     return np.mean((y_pred-y_true)**2)
 
-def binary_crossentropy_np(y_true,y_pred):
-    y_pred = np.clip(y_pred,epsilon,1-epsilon)
+
+def binary_crossentropy_np(y_true, y_pred):
+    y_pred = np.clip(y_pred, epsilon, 1-epsilon)
     return np.mean(- (y_true*np.log(y_pred) + (1-y_true)*np.log(1 - y_pred)))
 
-def hinge_np(y_true,y_pred):
-    return np.mean(np.maximum(0.0,1  - y_pred*y_true))
 
-def squared_hinge_np(y_true,y_pred):
-    return np.mean(np.maximum(0.0,1  - y_pred*y_true)**2)
+def hinge_np(y_true, y_pred):
+    return np.mean(np.maximum(0.0, 1 - y_pred*y_true))
 
 
-
+def squared_hinge_np(y_true, y_pred):
+    return np.mean(np.maximum(0.0, 1 - y_pred*y_true)**2)

--- a/plasma/utils/mpi_launch_tensorflow.py
+++ b/plasma/utils/mpi_launch_tensorflow.py
@@ -2,156 +2,206 @@ from __future__ import print_function
 from mpi4py import MPI
 
 from hostlist import expand_hostlist
-import socket,os,math
+import socket
+import os
+import math
+
 
 def get_host_to_id_mapping():
-  return {host:i for (i,host) in enumerate(expand_hostlist( os.environ['SLURM_NODELIST']))}
+    return {
+        host: i for (
+            i, host) in enumerate(
+            expand_hostlist(
+                os.environ['SLURM_NODELIST']))}
+
 
 def get_my_host_id():
-  return get_host_to_id_mapping()[socket.gethostname()]
+    return get_host_to_id_mapping()[socket.gethostname()]
 
 
 def get_host_list(port):
-  return [ '{}:{}'.format(host,port) for host in expand_hostlist( os.environ['SLURM_NODELIST']) ]
+    return [
+        '{}:{}'.format(
+            host,
+            port) for host in expand_hostlist(
+            os.environ['SLURM_NODELIST'])]
 
-def get_worker_host_list(base_port,workers_per_host):
-  hosts = expand_hostlist( os.environ['SLURM_NODELIST'])
-  ports = [base_port + i for i in range(workers_per_host)]
-  l = []
-  for h in hosts:
-    for p in ports:
-      l.append('{}:{}'.format(h,p))
-  return l
 
-def get_worker_host(base_port,workers_per_host,task_id):
-  return get_worker_host_list(base_port,workers_per_host)[task_id]
+def get_worker_host_list(base_port, workers_per_host):
+    hosts = expand_hostlist(os.environ['SLURM_NODELIST'])
+    ports = [base_port + i for i in range(workers_per_host)]
+    worker_hlist = []
+    for h in hosts:
+        for p in ports:
+            worker_hlist.append('{}:{}'.format(h, p))
+    return worker_hlist
 
-def get_ps_host_list(base_port,num_ps):
-  assert(num_ps < 10000000)
-  port = base_port
-  l = []
-  hosts = expand_hostlist( os.environ['SLURM_NODELIST'])
-  while True:
-    for host in hosts:
-      if len(l) >= num_ps:
-        return l
-      l.append('{}:{}'.format(host,port))
-    port += 1  
 
-def get_ps_host(base_port,num_ps,num_workers,task_id):
-  return get_ps_host_list(base_port,num_ps)[task_id - num_workers]
+def get_worker_host(base_port, workers_per_host, task_id):
+    return get_worker_host_list(base_port, workers_per_host)[task_id]
 
-def get_mpi_cluster_server_jobname(num_ps = 1,num_workers = None):      
-  import tensorflow as tf
-  NUM_GPUS = 4
-  comm = MPI.COMM_WORLD
-  task_index = comm.Get_rank()
-  task_num = comm.Get_size()
-  num_hosts = len(get_host_list(1))
 
-  num_workers_per_host = NUM_GPUS
-  if num_workers is None or num_workers == 0 or num_workers > num_workers_per_host*num_hosts:
-    if num_workers > num_workers_per_host*num_hosts:
-      print('Num workers too large (more than one per GPU). Setting to default of {} for {} hosts'.format(num_workers_per_host*num_hosts,num_hosts))
-    if num_workers == 0:
-      print('Num workers set to 0, should be positive. Setting to default of {} for {} hosts'.format(num_workers_per_host*num_hosts,num_hosts))
-    num_workers = num_workers_per_host*num_hosts 
-  
-  
-  tasks_per_node = task_num / num_hosts
+def get_ps_host_list(base_port, num_ps):
+    assert(num_ps < 10000000)
+    port = base_port
+    ps_hlist = []
+    hosts = expand_hostlist(os.environ['SLURM_NODELIST'])
+    while True:
+        for host in hosts:
+            if len(ps_hlist) >= num_ps:
+                return ps_hlist
+            ps_hlist.append('{}:{}'.format(host, port))
+        port += 1
 
-  max_ps = num_hosts*(tasks_per_node - num_workers_per_host)
-  print("tasks_per_node {} num_workers_per_host {} num_hosts {}".format(tasks_per_node,num_workers_per_host,num_hosts))
-  if num_ps == 0 or num_ps > max_ps:
-    print('Invalid number of ps {} (maximum {}, minimum 0)'.format(num_ps,max_ps))
-    if num_ps == 0:
-      print('Setting to 1')
-      num_ps = 1
+
+def get_ps_host(base_port, num_ps, num_workers, task_id):
+    return get_ps_host_list(base_port, num_ps)[task_id - num_workers]
+
+
+def get_mpi_cluster_server_jobname(num_ps=1, num_workers=None):
+    import tensorflow as tf
+    NUM_GPUS = 4
+    comm = MPI.COMM_WORLD
+    task_index = comm.Get_rank()
+    task_num = comm.Get_size()
+    num_hosts = len(get_host_list(1))
+
+    num_workers_per_host = NUM_GPUS
+    # TODO(KGF): this error handling is completely duplicated below
+    if (num_workers is None or num_workers == 0
+            or num_workers > num_workers_per_host*num_hosts):
+        if num_workers > num_workers_per_host*num_hosts:
+            print('Num workers too large (more than one per GPU). ',
+                  'Setting to default of {} for {} hosts'.format(
+                      num_workers_per_host * num_hosts, num_hosts))
+        if num_workers == 0:
+            print('Num workers set to 0, should be positive. ',
+                  'Setting to default of {} for {} hosts'.format(
+                      num_workers_per_host * num_hosts, num_hosts))
+        num_workers = num_workers_per_host*num_hosts
+
+    tasks_per_node = task_num / num_hosts
+
+    max_ps = num_hosts*(tasks_per_node - num_workers_per_host)
+    print("tasks_per_node {} num_workers_per_host {} num_hosts {}".format(
+        tasks_per_node, num_workers_per_host, num_hosts))
+    if num_ps == 0 or num_ps > max_ps:
+        print(
+            'Invalid number of ps {} (maximum {}, minimum 0)'.format(
+                num_ps, max_ps))
+        if num_ps == 0:
+            print('Setting to 1')
+            num_ps = 1
+        else:
+            print('Setting to {}'.format(max_ps))
+            num_ps = max_ps
+    num_ps_per_host = int(math.ceil(1.0*num_ps/num_hosts))
+
+    task_index = task_index % tasks_per_node
+
+    if task_index < NUM_GPUS:
+        job_name = 'worker'
+        num_per_host = num_workers_per_host
+        global_task_index = get_my_host_id()*num_per_host+task_index
     else:
-      print('Setting to {}'.format(max_ps))
-      num_ps = max_ps
-  num_ps_per_host = int(math.ceil(1.0*num_ps/num_hosts))
+        job_name = 'ps'
+        task_index = task_index - NUM_GPUS
+        num_per_host = num_ps_per_host
+        os.environ['CUDA_VISIBLE_DEVICES'] = ''
+        global_task_index = num_hosts*task_index+get_my_host_id()
+
+    #     if job_name == "ps":
+    # if job_name == "worker":
+    #   os.environ['CUDA_VISIBLE_DEVICES'] = '{}'.format(MY_GPU)
+    num_total = num_workers + num_ps
+    assert(task_num >= num_total)
+
+    if task_index == 0:
+        print('{} superfluous processes'.format(task_num - num_total))
+        print(
+            '{} superfluous workers'.format(
+                num_workers_per_host
+                * num_hosts
+                - num_workers))
+        print('{} superfluous ps'.format(num_ps_per_host*num_hosts - num_ps))
+
+    print(
+        '{}, task_id: {}, host_id: {}'.format(
+            socket.gethostname(),
+            task_index,
+            get_my_host_id()))
+
+    worker_hosts = get_worker_host_list(
+        2222, num_workers_per_host)[:num_workers]
+    ps_hosts = get_ps_host_list(2322, num_ps)
+    if global_task_index == 0:
+        print(
+            'ps_hosts: {}\n, worker hosts: {}\n'.format(
+                ps_hosts,
+                worker_hosts))
+    # Create a cluster from the parameter server and worker hosts.
+    if job_name == 'ps' and global_task_index >= num_ps:
+        exit(0)
+    if job_name == 'worker' and global_task_index >= num_workers:
+        exit(0)
+
+    cluster = tf.train.ClusterSpec({"ps": ps_hosts, "worker": worker_hosts})
+    # Create and start a server for the local task.
+    server = tf.train.Server(
+        cluster,
+        job_name=job_name,
+        task_index=global_task_index)
+
+    return cluster, server, job_name, global_task_index, num_workers
 
 
-  task_index = task_index % tasks_per_node 
-  
-  if task_index < NUM_GPUS:
-      job_name = 'worker'
-      num_per_host = num_workers_per_host
-      global_task_index = get_my_host_id()*num_per_host+task_index
-  else:
-      job_name = 'ps'
-      task_index = task_index - NUM_GPUS 
-      num_per_host = num_ps_per_host
-      os.environ['CUDA_VISIBLE_DEVICES'] = ''
-      global_task_index = num_hosts*task_index+get_my_host_id()
+def get_mpi_task_index(num_workers=None):
+    NUM_GPUS = 4
+    comm = MPI.COMM_WORLD
+    task_index = comm.Get_rank()
+    task_num = comm.Get_size()
+    num_hosts = len(get_host_list(1))
 
-  #     if job_name == "ps":
-  # if job_name == "worker":
-  #   os.environ['CUDA_VISIBLE_DEVICES'] = '{}'.format(MY_GPU)
-  num_total = num_workers + num_ps 
-  assert(task_num >= num_total)
-  
-  if task_index == 0:
-      print('{} superfluous processes'.format(task_num - num_total))
-      print('{} superfluous workers'.format(num_workers_per_host*num_hosts - num_workers))
-      print('{} superfluous ps'.format(num_ps_per_host*num_hosts - num_ps))
-  
-  
-  print('{}, task_id: {}, host_id: {}'.format(socket.gethostname(),task_index,get_my_host_id()))
-  
-  worker_hosts = get_worker_host_list(2222,num_workers_per_host)[:num_workers]
-  ps_hosts = get_ps_host_list(2322,num_ps)
-  if global_task_index == 0:
-      print('ps_hosts: {}\n, worker hosts: {}\n'.format(ps_hosts,worker_hosts))
-  # Create a cluster from the parameter server and worker hosts.
-  if job_name == 'ps' and global_task_index >= num_ps: 
-      exit(0)
-  if job_name == 'worker' and global_task_index >= num_workers:
-      exit(0)
+    num_workers_per_host = NUM_GPUS
+    if (num_workers is None or num_workers == 0
+            or num_workers > num_workers_per_host*num_hosts):
+        if num_workers > num_workers_per_host*num_hosts:
+            print('Num workers too large (more than one per GPU). ',
+                  'Setting to default of {} for {} hosts'.format(
+                      num_workers_per_host * num_hosts, num_hosts))
+        if num_workers == 0:
+            print('Num workers set to 0, should be positive. ',
+                  'Setting to default of {} for {} hosts'.format(
+                      num_workers_per_host * num_hosts, num_hosts))
+        num_workers = num_workers_per_host*num_hosts
 
-  cluster = tf.train.ClusterSpec({"ps": ps_hosts, "worker": worker_hosts})
-  # Create and start a server for the local task.
-  server = tf.train.Server(cluster,job_name=job_name,task_index=global_task_index)
-  
-  return cluster,server,job_name,global_task_index,num_workers
+    tasks_per_node = task_num / num_hosts
+    task_index = task_index % tasks_per_node
 
-def get_mpi_task_index(num_workers = None):      
-  NUM_GPUS = 4
-  comm = MPI.COMM_WORLD
-  task_index = comm.Get_rank()
-  task_num = comm.Get_size()
-  num_hosts = len(get_host_list(1))
+    if task_index < NUM_GPUS:
+        job_name = 'worker'
+        num_per_host = num_workers_per_host
+        global_task_index = get_my_host_id()*num_per_host+task_index
+    else:
+        exit(0)
 
-  num_workers_per_host = NUM_GPUS
-  if num_workers is None or num_workers == 0 or num_workers > num_workers_per_host*num_hosts:
-    if num_workers > num_workers_per_host*num_hosts:
-      print('Num workers too large (more than one per GPU). Setting to default of {} for {} hosts'.format(num_workers_per_host*num_hosts,num_hosts))
-    if num_workers == 0:
-      print('Num workers set to 0, should be positive. Setting to default of {} for {} hosts'.format(num_workers_per_host*num_hosts,num_hosts))
-    num_workers = num_workers_per_host*num_hosts 
-  
-  
-  tasks_per_node = task_num / num_hosts
-  task_index = task_index % tasks_per_node 
-  
-  if task_index < NUM_GPUS:
-      job_name = 'worker'
-      num_per_host = num_workers_per_host
-      global_task_index = get_my_host_id()*num_per_host+task_index
-  else:
-      exit(0) 
+    num_total = num_workers
+    assert(task_num >= num_total)
 
-  num_total = num_workers 
-  assert(task_num >= num_total)
-  
-  if task_index == 0:
-      print('{} superfluous workers'.format(num_workers_per_host*num_hosts - num_workers))
-      print('{} total workers'.format(num_workers))
-  
-  
-  print('{}, task_id: {}, host_id: {}'.format(socket.gethostname(),task_index,get_my_host_id()))
-  if job_name == 'worker' and global_task_index >= num_workers:
-      exit(0)
-  
-  return global_task_index,num_workers
+    if task_index == 0:
+        print(
+            '{} superfluous workers'.format(
+                num_workers_per_host
+                * num_hosts
+                - num_workers))
+        print('{} total workers'.format(num_workers))
+
+    print(
+        '{}, task_id: {}, host_id: {}'.format(
+            socket.gethostname(),
+            task_index,
+            get_my_host_id()))
+    if job_name == 'worker' and global_task_index >= num_workers:
+        exit(0)
+
+    return global_task_index, num_workers

--- a/plasma/utils/performance.py
+++ b/plasma/utils/performance.py
@@ -1,29 +1,38 @@
 from __future__ import print_function
-import matplotlib
-matplotlib.use('Agg')#for machines that don't have a display
-from matplotlib import rc
-rc('font',**{'family':'serif','sans-serif':['Times']})
-rc('text', usetex=True)
-import matplotlib.pyplot as plt
-import os
-from pprint import pprint
-import numpy as np
+from plasma.preprocessor.normalize import VarNormalizer as Normalizer
+from plasma.primitives.shots import ShotList  # , Shot
 from scipy import stats
+import numpy as np
+from pprint import pprint
+import os
+import matplotlib.pyplot as plt
+from matplotlib import rc
+import matplotlib
+matplotlib.use('Agg')  # for machines that don't have a display
+rc('font', **{'family': 'serif', 'sans-serif': ['Times']})
+rc('text', usetex=True)
 
-from plasma.preprocessor.normalize import VarNormalizer as Normalizer 
-from plasma.conf import conf
-from plasma.primitives.shots import Shot,ShotList
 
 class PerformanceAnalyzer():
-    def __init__(self,results_dir=None,shots_dir=None,i = 0,T_min_warn = None,T_max_warn = None, verbose = False,pred_ttd=False,conf=None):
+    def __init__(
+            self,
+            results_dir=None,
+            shots_dir=None,
+            i=0,
+            T_min_warn=None,
+            T_max_warn=None,
+            verbose=False,
+            pred_ttd=False,
+            conf=None):
         self.T_min_warn = T_min_warn
         self.T_max_warn = T_max_warn
         dt = conf['data']['dt']
         T_max_warn_def = int(round(conf['data']['T_warning']/dt))
-        T_min_warn_def = conf['data']['T_min_warn']#int(round(conf['data']['T_min_warn']/dt))
-        if T_min_warn == None:
+        # int(round(conf['data']['T_min_warn']/dt))
+        T_min_warn_def = conf['data']['T_min_warn']
+        if T_min_warn is None:
             self.T_min_warn = T_min_warn_def
-        if T_max_warn == None:
+        if T_max_warn is None:
             self.T_max_warn = T_max_warn_def
         self.verbose = verbose
         self.results_dir = results_dir
@@ -47,214 +56,239 @@ class PerformanceAnalyzer():
 
         self.normalizer = None
 
-
-
-    def get_metrics_vs_p_thresh(self,mode):
+    def get_metrics_vs_p_thresh(self, mode):
         if mode == 'train':
             all_preds = self.pred_train
             all_truths = self.truth_train
             all_disruptive = self.disruptive_train
-
 
         elif mode == 'test':
             all_preds = self.pred_test
             all_truths = self.truth_test
             all_disruptive = self.disruptive_test
 
-        return self.get_metrics_vs_p_thresh_custom(all_preds,all_truths,all_disruptive)
+        return self.get_metrics_vs_p_thresh_custom(
+            all_preds, all_truths, all_disruptive)
 
-
-
-    def get_metrics_vs_p_thresh_custom(self,all_preds,all_truths,all_disruptive):
-        return self.get_metrics_vs_p_thresh_fast(all_preds,all_truths,all_disruptive)
+    def get_metrics_vs_p_thresh_custom(
+            self, all_preds, all_truths, all_disruptive):
+        return self.get_metrics_vs_p_thresh_fast(
+            all_preds, all_truths, all_disruptive)
         P_thresh_range = self.get_p_thresh_range()
         correct_range = np.zeros_like(P_thresh_range)
         accuracy_range = np.zeros_like(P_thresh_range)
         fp_range = np.zeros_like(P_thresh_range)
         missed_range = np.zeros_like(P_thresh_range)
         early_alarm_range = np.zeros_like(P_thresh_range)
-        
-        for i,P_thresh in enumerate(P_thresh_range):
-            correct,accuracy,fp_rate,missed,early_alarm_rate = self.summarize_shot_prediction_stats(P_thresh,all_preds,all_truths,all_disruptive)
+
+        for i, P_thresh in enumerate(P_thresh_range):
+            correct, accuracy, fp_rate, missed, early_alarm_rate = (
+                self.summarize_shot_prediction_stats(
+                    P_thresh, all_preds, all_truths, all_disruptive))
             correct_range[i] = correct
-            accuracy_range[i] = accuracy 
-            fp_range[i] = fp_rate 
+            accuracy_range[i] = accuracy
+            fp_range[i] = fp_rate
             missed_range[i] = missed
             early_alarm_range[i] = early_alarm_rate
-        
-        return correct_range,accuracy_range,fp_range,missed_range,early_alarm_range
 
+        return (correct_range, accuracy_range, fp_range, missed_range,
+                early_alarm_range)
 
     def get_p_thresh_range(self):
-        #return self.conf['data']['target'].threshold_range(self.conf['data']['T_warning'])
-        if np.any(self.p_thresh_range) == None:
-                all_preds_tr = self.pred_train
-                all_truths_tr = self.truth_train
-                all_disruptive_tr = self.disruptive_train
-                all_preds_te = self.pred_test
-                all_truths_te = self.truth_test
-                all_disruptive_te = self.disruptive_test
-        
-                early_th_tr,correct_th_tr,late_th_tr,nd_th_tr = self.get_threshold_arrays(all_preds_tr,all_truths_tr,all_disruptive_tr)
-                early_th_te,correct_th_te,late_th_te,nd_th_te = self.get_threshold_arrays(all_preds_te,all_truths_te,all_disruptive_te)
-                all_thresholds = np.sort(np.concatenate((early_th_tr,correct_th_tr,late_th_tr,nd_th_tr,early_th_te,correct_th_te,late_th_te,nd_th_te)))
-                self.p_thresh_range = all_thresholds
-        #print(np.unique(self.p_thresh_range))
-        return self.p_thresh_range
-                
+        if np.any(self.p_thresh_range) is None:
+            all_preds_tr = self.pred_train
+            all_truths_tr = self.truth_train
+            all_disruptive_tr = self.disruptive_train
+            all_preds_te = self.pred_test
+            all_truths_te = self.truth_test
+            all_disruptive_te = self.disruptive_test
 
-    def get_metrics_vs_p_thresh_fast(self,all_preds,all_truths,all_disruptive):
-        all_disruptive = np.array(all_disruptive)        
+            early_th_tr, correct_th_tr, late_th_tr, nd_th_tr = (
+                self.get_threshold_arrays(all_preds_tr, all_truths_tr,
+                                          all_disruptive_tr))
+            early_th_te, correct_th_te, late_th_te, nd_th_te = (
+                self.get_threshold_arrays(all_preds_te, all_truths_te,
+                                          all_disruptive_te))
+            all_thresholds = np.sort(np.concatenate(
+                (early_th_tr, correct_th_tr, late_th_tr, nd_th_tr, early_th_te,
+                 correct_th_te, late_th_te, nd_th_te)))
+            self.p_thresh_range = all_thresholds
+        # print(np.unique(self.p_thresh_range))
+        return self.p_thresh_range
+
+    def get_metrics_vs_p_thresh_fast(
+            self, all_preds, all_truths, all_disruptive):
+        all_disruptive = np.array(all_disruptive)
         if self.pred_train is not None:
-                p_thresh_range = self.get_p_thresh_range()
+            p_thresh_range = self.get_p_thresh_range()
         else:
-                early_th,correct_th,late_th,nd_th = self.get_threshold_arrays(all_preds,all_truths,all_disruptive)
-                p_thresh_range = np.sort(np.concatenate((early_th,correct_th,late_th,nd_th)))
+            early_th, correct_th, late_th, nd_th = self.get_threshold_arrays(
+                all_preds, all_truths, all_disruptive)
+            p_thresh_range = np.sort(np.concatenate(
+                (early_th, correct_th, late_th, nd_th)))
         correct_range = np.zeros_like(p_thresh_range)
         accuracy_range = np.zeros_like(p_thresh_range)
         fp_range = np.zeros_like(p_thresh_range)
         missed_range = np.zeros_like(p_thresh_range)
         early_alarm_range = np.zeros_like(p_thresh_range)
 
-        early_th,correct_th,late_th,nd_th = self.get_threshold_arrays(all_preds,all_truths,all_disruptive)
+        early_th, correct_th, late_th, nd_th = self.get_threshold_arrays(
+            all_preds, all_truths, all_disruptive)
 
-        for i,thresh in enumerate(p_thresh_range):
-            #correct,accuracy,fp_rate,missed,early_alarm_rate = self.summarize_shot_prediction_stats(thresh,all_preds,all_truths,all_disruptive)
-            correct,accuracy,fp_rate,missed,early_alarm_rate = self.get_shot_prediction_stats_from_threshold_arrays(early_th,correct_th,late_th,nd_th,thresh)
+        for i, thresh in enumerate(p_thresh_range):
+            correct, accuracy, fp_rate, missed, early_alarm_rate = (
+                self.get_shot_prediction_stats_from_threshold_arrays(
+                    early_th, correct_th, late_th, nd_th, thresh))
             correct_range[i] = correct
-            accuracy_range[i] = accuracy 
-            fp_range[i] = fp_rate 
+            accuracy_range[i] = accuracy
+            fp_range[i] = fp_rate
             missed_range[i] = missed
             early_alarm_range[i] = early_alarm_rate
-        
-        return correct_range,accuracy_range,fp_range,missed_range,early_alarm_range
 
-    def get_shot_prediction_stats_from_threshold_arrays(self,early_th,correct_th,late_th,nd_th,thresh):
-        indices = np.where(np.logical_and(correct_th > thresh,early_th <= thresh))[0]
+        return (correct_range, accuracy_range, fp_range, missed_range,
+                early_alarm_range)
+
+    def get_shot_prediction_stats_from_threshold_arrays(
+            self, early_th, correct_th, late_th, nd_th, thresh):
+        # indices = np.where(np.logical_and(
+        #     correct_th > thresh, early_th <= thresh))[0]
         FPs = np.sum(nd_th > thresh)
-        TNs = len(nd_th) - FPs 
+        TNs = len(nd_th) - FPs
 
-        earlies = np.sum(early_th > thresh) 
-        TPs = np.sum(np.logical_and(early_th <= thresh,correct_th > thresh)) 
-        lates = np.sum(np.logical_and(np.logical_and(early_th <= thresh,correct_th <= thresh),late_th > thresh))
-        FNs = np.sum(np.logical_and(np.logical_and(early_th <= thresh,correct_th <= thresh),late_th <= thresh))
+        earlies = np.sum(early_th > thresh)
+        TPs = np.sum(np.logical_and(early_th <= thresh, correct_th > thresh))
+        lates = np.sum(np.logical_and(np.logical_and(
+            early_th <= thresh, correct_th <= thresh), late_th > thresh))
+        FNs = np.sum(np.logical_and(np.logical_and(
+            early_th <= thresh, correct_th <= thresh), late_th <= thresh))
 
-        return self.get_accuracy_and_fp_rate_from_stats(TPs,FPs,FNs,TNs,earlies,lates)
+        return self.get_accuracy_and_fp_rate_from_stats(
+            TPs, FPs, FNs, TNs, earlies, lates)
 
-
-    def get_shot_difficulty(self,preds,truths,disruptives):
+    def get_shot_difficulty(self, preds, truths, disruptives):
         disruptives = np.array(disruptives)
-        d_early_thresholds, d_correct_thresholds,d_late_thresholds, nd_thresholds = self.get_threshold_arrays(preds,truths,disruptives)
-        d_thresholds = np.maximum(d_early_thresholds,d_correct_thresholds)
-        #rank shots by difficulty. rank 1 is assigned to lowest value, should be highest difficulty
-        d_ranks = stats.rankdata(d_thresholds,method='min')#difficulty is highest when threshold is low, can't detect disruption
-        nd_ranks = stats.rankdata(-nd_thresholds,method='min')#difficulty is highest when threshold is high, can't avoid false positive 
+        (d_early_thresholds, d_correct_thresholds, d_late_thresholds,
+         nd_thresholds) = self.get_threshold_arrays(preds, truths, disruptives)
+        d_thresholds = np.maximum(d_early_thresholds, d_correct_thresholds)
+        # rank shots by difficulty. rank 1 is assigned to lowest value, should
+        # be highest difficulty
+        # difficulty is highest when threshold is low, can't detect disruption
+        d_ranks = stats.rankdata(d_thresholds, method='min')
+        # difficulty is highest when threshold is high, can't avoid false
+        # positive
+        nd_ranks = stats.rankdata(-nd_thresholds, method='min')
         ranking_fac = self.saved_conf['training']['ranking_difficulty_fac']
-        facs_d = np.linspace(ranking_fac,1,len(d_ranks))[d_ranks-1]
-        facs_nd = np.linspace(ranking_fac,1,len(nd_ranks))[nd_ranks-1]
+        facs_d = np.linspace(ranking_fac, 1, len(d_ranks))[d_ranks-1]
+        facs_nd = np.linspace(ranking_fac, 1, len(nd_ranks))[nd_ranks-1]
         ret_facs = np.ones(len(disruptives))
         ret_facs[disruptives] = facs_d
         ret_facs[~disruptives] = facs_nd
-        #print("setting shot difficulty")
-        #print(disruptives)
-        #print(d_thresholds)
-        #print(nd_thresholds)
-        #print(ret_facs)
+        # print("setting shot difficulty")
+        # print(disruptives)
+        # print(d_thresholds)
+        # print(nd_thresholds)
+        # print(ret_facs)
         return ret_facs
 
-    def get_threshold_arrays(self,preds,truths,disruptives):
-        num_d = np.sum(disruptives)
-        num_nd = np.sum(~disruptives)
-        nd_thresholds = [] 
-        d_early_thresholds = [] 
-        d_correct_thresholds = [] 
-        d_late_thresholds = [] 
+    def get_threshold_arrays(self, preds, truths, disruptives):
+        # num_d = np.sum(disruptives)
+        # num_nd = np.sum(~disruptives)
+        nd_thresholds = []
+        d_early_thresholds = []
+        d_correct_thresholds = []
+        d_late_thresholds = []
         for i in range(len(preds)):
             pred = 1.0*preds[i]
             truth = truths[i]
             pred[:self.get_ignore_indices()] = -np.inf
-            is_disruptive = disruptives[i] 
+            is_disruptive = disruptives[i]
             if is_disruptive:
-                max_acceptable = self.create_acceptable_region(truth,'max')
-                min_acceptable = self.create_acceptable_region(truth,'min')
-                correct_indices = np.logical_and(max_acceptable, ~min_acceptable)
+                max_acceptable = self.create_acceptable_region(truth, 'max')
+                min_acceptable = self.create_acceptable_region(truth, 'min')
+                correct_indices = np.logical_and(
+                    max_acceptable, ~min_acceptable)
                 early_indices = ~max_acceptable
                 late_indices = min_acceptable
                 if np.sum(late_indices) == 0:
-                        d_late_thresholds.append(-np.inf)
+                    d_late_thresholds.append(-np.inf)
                 else:
-                        d_late_thresholds.append(np.max(pred[late_indices]))
+                    d_late_thresholds.append(np.max(pred[late_indices]))
                 if np.sum(early_indices) == 0:
-                        d_early_thresholds.append(-np.inf)
+                    d_early_thresholds.append(-np.inf)
                 else:
-                        d_early_thresholds.append(np.max(pred[early_indices]))
-                        
+                    d_early_thresholds.append(np.max(pred[early_indices]))
+
                 d_correct_thresholds.append(np.max(pred[correct_indices]))
             else:
                 nd_thresholds.append(np.max(pred))
-        return np.array(d_early_thresholds), np.array(d_correct_thresholds),np.array(d_late_thresholds), np.array(nd_thresholds)
-     
+        return (np.array(d_early_thresholds), np.array(d_correct_thresholds),
+                np.array(d_late_thresholds), np.array(nd_thresholds))
 
-
-
-
-
-    def summarize_shot_prediction_stats_by_mode(self,P_thresh,mode,verbose=False):
+    def summarize_shot_prediction_stats_by_mode(
+            self, P_thresh, mode, verbose=False):
 
         if mode == 'train':
             all_preds = self.pred_train
             all_truths = self.truth_train
             all_disruptive = self.disruptive_train
 
-
         elif mode == 'test':
             all_preds = self.pred_test
             all_truths = self.truth_test
             all_disruptive = self.disruptive_test
 
-        return self.summarize_shot_prediction_stats(P_thresh,all_preds,all_truths,all_disruptive,verbose)
+        return self.summarize_shot_prediction_stats(
+            P_thresh, all_preds, all_truths, all_disruptive, verbose)
 
-
-    def summarize_shot_prediction_stats(self,P_thresh,all_preds,all_truths,all_disruptive,verbose=False):
-        TPs,FPs,FNs,TNs,earlies,lates = (0,0,0,0,0,0)
+    def summarize_shot_prediction_stats(
+            self,
+            P_thresh,
+            all_preds,
+            all_truths,
+            all_disruptive,
+            verbose=False):
+        TPs, FPs, FNs, TNs, earlies, lates = (0, 0, 0, 0, 0, 0)
 
         for i in range(len(all_preds)):
             preds = all_preds[i]
             truth = all_truths[i]
             is_disruptive = all_disruptive[i]
 
-
-            TP,FP,FN,TN,early,late = self.get_shot_prediction_stats(P_thresh,preds,truth,is_disruptive)
+            TP, FP, FN, TN, early, late = self.get_shot_prediction_stats(
+                P_thresh, preds, truth, is_disruptive)
             TPs += TP
             FPs += FP
             FNs += FN
             TNs += TN
             earlies += early
             lates += late
-            
+
         disr = earlies + lates + TPs + FNs
         nondisr = FPs + TNs
         if verbose:
-            print('total: {}, tp: {} fp: {} fn: {} tn: {} early: {} late: {} disr: {} nondisr: {}'.format(len(all_preds),TPs,FPs,FNs,TNs,earlies,lates,disr,nondisr))
-       
-        return self.get_accuracy_and_fp_rate_from_stats(TPs,FPs,FNs,TNs,earlies,lates,verbose)
+            print('total: {}, tp: {} fp: {} fn: {} tn: {} '.format(
+                len(all_preds), TPs, FPs, FNs, TNs,),
+                  'early: {} late: {} disr: {} nondisr: {}'.format(
+                      earlies, lates, disr, nondisr))
 
+        return self.get_accuracy_and_fp_rate_from_stats(
+            TPs, FPs, FNs, TNs, earlies, lates, verbose)
 
+    # we are interested in the predictions of the *first alarm*
 
-    #we are interested in the predictions of the *first alarm*
-    def get_shot_prediction_stats(self,P_thresh,pred,truth,is_disruptive):
+    def get_shot_prediction_stats(self, P_thresh, pred, truth, is_disruptive):
         if self.pred_ttd:
             predictions = pred < P_thresh
         else:
             predictions = pred > P_thresh
-        predictions = np.reshape(predictions,(len(predictions),))
-        
-        max_acceptable = self.create_acceptable_region(truth,'max')
-        min_acceptable = self.create_acceptable_region(truth,'min')
-        
+        predictions = np.reshape(predictions, (len(predictions),))
+
+        max_acceptable = self.create_acceptable_region(truth, 'max')
+        min_acceptable = self.create_acceptable_region(truth, 'min')
+
         early = late = TP = TN = FN = FP = 0
-      
-        positives = self.get_positives(predictions)#where(predictions)[0]
+
+        positives = self.get_positives(predictions)  # where(predictions)[0]
         if len(positives) == 0:
             if is_disruptive:
                 FN = 1
@@ -263,7 +297,8 @@ class PerformanceAnalyzer():
         else:
             if is_disruptive:
                 first_pred_idx = positives[0]
-                if max_acceptable[first_pred_idx] and ~min_acceptable[first_pred_idx]:
+                if (max_acceptable[first_pred_idx]
+                        and ~min_acceptable[first_pred_idx]):
                     TP = 1
                 elif min_acceptable[first_pred_idx]:
                     late = 1
@@ -271,51 +306,52 @@ class PerformanceAnalyzer():
                     early = 1
             else:
                 FP = 1
-        return TP,FP,FN,TN,early,late
+        return TP, FP, FN, TN, early, late
 
     def get_ignore_indices(self):
         return self.saved_conf['model']['ignore_timesteps']
 
-
-    def get_positives(self,predictions):
+    def get_positives(self, predictions):
         indices = np.arange(len(predictions))
-        return np.where(np.logical_and(predictions,indices >= self.get_ignore_indices()))[0]
+        return np.where(
+            np.logical_and(
+                predictions,
+                indices >= self.get_ignore_indices()))[0]
 
-
-    def create_acceptable_region(self,truth,mode):
+    def create_acceptable_region(self, truth, mode):
         if mode == 'min':
             acceptable_timesteps = self.T_min_warn
         elif mode == 'max':
             acceptable_timesteps = self.T_max_warn
         else:
             print('Error Invalid Mode for acceptable region')
-            exit(1) 
+            exit(1)
 
-        acceptable = np.zeros_like(truth,dtype=bool)
+        acceptable = np.zeros_like(truth, dtype=bool)
         if acceptable_timesteps > 0:
             acceptable[-acceptable_timesteps:] = True
         return acceptable
 
-
-    def get_accuracy_and_fp_rate_from_stats(self,tp,fp,fn,tn,early,late,verbose=False):
+    def get_accuracy_and_fp_rate_from_stats(
+            self, tp, fp, fn, tn, early, late, verbose=False):
         total = tp + fp + fn + tn + early + late
-        disr = early + late + tp + fn 
+        disr = early + late + tp + fn
         nondisr = fp + tn
-        
+
         if disr == 0:
             early_alarm_rate = 0
             missed = 0
-            accuracy = 0 
+            accuracy = 0
         else:
             early_alarm_rate = 1.0*early/disr
             missed = 1.0*(late + fn)/disr
             accuracy = 1.0*tp/disr
         if nondisr == 0:
             fp_rate = 0
-        else: 
+        else:
             fp_rate = 1.0*fp/nondisr
         correct = 1.0*(tp + tn)/total
-        
+
         if verbose:
             print('accuracy: {}'.format(accuracy))
             print('missed: {}'.format(missed))
@@ -323,15 +359,14 @@ class PerformanceAnalyzer():
             print('false positive rate: {}'.format(fp_rate))
             print('correct: {}'.format(correct))
 
-        return correct,accuracy,fp_rate,missed,early_alarm_rate
-
-
+        return correct, accuracy, fp_rate, missed, early_alarm_rate
 
     def load_ith_file(self):
         results_files = os.listdir(self.results_dir)
         print(results_files)
         dat = np.load(self.results_dir + results_files[self.i])
-        print("Loading results file {}".format(self.results_dir + results_files[self.i]))
+        print("Loading results file {}".format(
+            self.results_dir + results_files[self.i]))
 
         if self.verbose:
             print('configuration: {} '.format(dat['conf']))
@@ -345,44 +380,54 @@ class PerformanceAnalyzer():
         self.shot_list_test = ShotList(dat['shot_list_test'][()])
         self.shot_list_train = ShotList(dat['shot_list_train'][()])
         self.saved_conf = dat['conf'][()]
-        self.conf['data']['T_warning'] = self.saved_conf['data']['T_warning'] #all files must agree on T_warning due to output of truth vs. normalized shot ttd.
-        for mode in ['test','train']:
-            print('{}: loaded {} shot ({}) disruptive'.format(mode,self.get_num_shots(mode),self.get_num_disruptive_shots(mode)))
+        # all files must agree on T_warning due to output of truth vs.
+        # normalized shot ttd.
+        self.conf['data']['T_warning'] = self.saved_conf['data']['T_warning']
+        for mode in ['test', 'train']:
+            print(
+                '{}: loaded {} shot ({}) disruptive'.format(
+                    mode,
+                    self.get_num_shots(mode),
+                    self.get_num_disruptive_shots(mode)))
         if self.verbose:
             self.print_conf()
-        #self.assert_same_lists(self.shot_list_test,self.truth_test,self.disruptive_test)
-        #self.assert_same_lists(self.shot_list_train,self.truth_train,self.disruptive_train)
+        # self.assert_same_lists(self.shot_list_test,self.truth_test,self.disruptive_test)
+        # self.assert_same_lists(self.shot_list_train,self.truth_train,self.disruptive_train)
 
-    def assert_same_lists(self,shot_list,truth_arr,disr_arr):
+    def assert_same_lists(self, shot_list, truth_arr, disr_arr):
         assert(len(shot_list) == len(truth_arr))
         for i in range(len(shot_list)):
-                shot_list.shots[i].restore("/tigress/jk7/processed_shots/")
-                s = shot_list.shots[i].ttd
-                if not truth_arr[i].shape[0] == s.shape[0]-30:
-                        print(i)
-                        print(shot_list.shots[i].number)
-                        print((s.shape,truth_arr[i].shape,disr_arr[i]))
-                assert(truth_arr[i].shape[0] == s.shape[0]-30)
+            shot_list.shots[i].restore("/tigress/jk7/processed_shots/")
+            s = shot_list.shots[i].ttd
+            if not truth_arr[i].shape[0] == s.shape[0]-30:
+                print(i)
+                print(shot_list.shots[i].number)
+                print((s.shape, truth_arr[i].shape, disr_arr[i]))
+            assert(truth_arr[i].shape[0] == s.shape[0]-30)
         print("Same Shape!")
-   
-    def print_conf(self):
-        pprint(self.saved_conf) 
 
-    def get_num_shots(self,mode):
+    def print_conf(self):
+        pprint(self.saved_conf)
+
+    def get_num_shots(self, mode):
         if mode == 'test':
             return len(self.disruptive_test)
         if mode == 'train':
             return len(self.disruptive_train)
 
-    def get_num_disruptive_shots(self,mode):
+    def get_num_disruptive_shots(self, mode):
         if mode == 'test':
             return sum(self.disruptive_test)
         if mode == 'train':
             return sum(self.disruptive_train)
 
-
-    def hist_alarms(self,alarms,title_str='alarms',save_figure=False,linestyle='-'):
-        fontsize=15
+    def hist_alarms(
+            self,
+            alarms,
+            title_str='alarms',
+            save_figure=False,
+            linestyle='-'):
+        fontsize = 15
         T_min_warn = self.T_min_warn
         T_max_warn = self.T_max_warn
         if len(alarms) > 0:
@@ -392,40 +437,45 @@ class PerformanceAnalyzer():
             T_max_warn /= 1000.0
             plt.figure()
             alarms += 0.0001
-            bins=np.logspace(np.log10(min(alarms)),np.log10(max(alarms)),40)
-            #bins=linspace(min(alarms),max(alarms),100)
-            #        hist(alarms,bins=bins,alpha=1.0,histtype='step',normed=True,log=False,cumulative=-1)
-            #
-            plt.step(np.concatenate((alarms[::-1], alarms[[0]])), 1.0*np.arange(alarms.size+1)/(alarms.size),linestyle=linestyle,linewidth=1.5)
+            # bins = np.logspace(np.log10(min(alarms)), np.log10(max(alarms)),
+            #                    40)
+
+            # bins=linspace(min(alarms), max(alarms), 100)
+            #        hist(alarms, bins=bins, alpha=1.0, histtype='step',
+            #        normed=True, log=False, cumulative=-1)
+            plt.step(np.concatenate((alarms[::-1], alarms[[0]])),
+                     1.0*np.arange(alarms.size+1)/(alarms.size),
+                     linestyle=linestyle, linewidth=1.5)
 
             plt.gca().set_xscale('log')
-            plt.axvline(T_min_warn,color='r',linewidth=0.5)
-            #if T_max_warn < np.max(alarms):
+            plt.axvline(T_min_warn, color='r', linewidth=0.5)
+            # if T_max_warn < np.max(alarms):
             #    plt.axvline(T_max_warn,color='r',linewidth=0.5)
-            plt.xlabel('Time to disruption [s]',size=fontsize)
-            plt.ylabel('Fraction of detected disruptions',size=fontsize)
-            plt.xlim([1e-4,4e1])#max(alarms)*10])
-            plt.ylim([0,1])
+            plt.xlabel('Time to disruption [s]', size=fontsize)
+            plt.ylabel('Fraction of detected disruptions', size=fontsize)
+            plt.xlim([1e-4, 4e1])  # max(alarms)*10])
+            plt.ylim([0, 1])
             plt.grid()
             plt.title(title_str)
-            plt.setp(plt.gca().get_yticklabels(),fontsize=fontsize)
-            plt.setp(plt.gca().get_xticklabels(),fontsize=fontsize)
+            plt.setp(plt.gca().get_yticklabels(), fontsize=fontsize)
+            plt.setp(plt.gca().get_xticklabels(), fontsize=fontsize)
             plt.show()
             if save_figure:
-                plt.savefig('accum_disruptions.png',dpi=200,bbox_inches='tight')
+                plt.savefig(
+                    'accum_disruptions.png',
+                    dpi=200,
+                    bbox_inches='tight')
         else:
             print(title_str + ": No alarms!")
 
-
-
-    def gather_first_alarms(self,P_thresh,mode):
+    def gather_first_alarms(self, P_thresh, mode):
         if mode == 'train':
-            pred_list = self.pred_train 
-            disruptive_list = self.disruptive_train 
+            pred_list = self.pred_train
+            disruptive_list = self.disruptive_train
         elif mode == 'test':
-            pred_list = self.pred_test 
-            disruptive_list = self.disruptive_test 
-        
+            pred_list = self.pred_test
+            disruptive_list = self.disruptive_test
+
         alarms = []
         disr_alarms = []
         nondisr_alarms = []
@@ -435,8 +485,9 @@ class PerformanceAnalyzer():
                 predictions = pred < P_thresh
             else:
                 predictions = pred > P_thresh
-            predictions = np.reshape(predictions,(len(predictions),))
-            positives = self.get_positives(predictions) #where(predictions)[0]
+            predictions = np.reshape(predictions, (len(predictions),))
+            positives = self.get_positives(
+                predictions)  # where(predictions)[0]
             if len(positives) > 0:
                 alarm_ttd = len(pred) - 1.0 - positives[0]
                 alarms.append(alarm_ttd)
@@ -447,36 +498,45 @@ class PerformanceAnalyzer():
             else:
                 if disruptive_list[i]:
                     disr_alarms.append(-1)
-        return np.array(alarms),np.array(disr_alarms),np.array(nondisr_alarms)
-                
+        return np.array(alarms), np.array(
+            disr_alarms), np.array(nondisr_alarms)
 
-    def compute_tradeoffs_and_print(self,mode):
+    def compute_tradeoffs_and_print(self, mode):
         P_thresh_range = self.get_p_thresh_range()
-        correct_range, accuracy_range, fp_range,missed_range,early_alarm_range = self.get_metrics_vs_p_thresh(mode)
-        fp_threshs = [0.01,0.05,0.1]
-        missed_threshs = [0.01,0.05,0.0]
- #       missed_threshs = [0.01,0.05,0.1,0.2,0.3]
+        (correct_range, accuracy_range, fp_range, missed_range,
+         early_alarm_range) = self.get_metrics_vs_p_thresh(mode)
+        fp_threshs = [0.01, 0.05, 0.1]
+        missed_threshs = [0.01, 0.05, 0.0]
+        # missed_threshs = [0.01, 0.05, 0.1, 0.2, 0.3]
 
-        #first index where...
-        for fp_thresh in fp_threshs: 
+        # first index where...
+        for fp_thresh in fp_threshs:
             print('============= FP RATE < {} ============='.format(fp_thresh))
             if(any(fp_range < fp_thresh)):
                 idx = np.where(fp_range <= fp_thresh)[0][0]
                 P_thresh_opt = P_thresh_range[idx]
-                self.summarize_shot_prediction_stats_by_mode(P_thresh_opt,mode,verbose=True)
-                print('============= AT P_THRESH = {} ============='.format(P_thresh_opt))
+                self.summarize_shot_prediction_stats_by_mode(
+                    P_thresh_opt, mode, verbose=True)
+                print(
+                    '============= AT P_THRESH = {} ============='.format(
+                        P_thresh_opt))
             else:
-                print('No such P_thresh found') 
+                print('No such P_thresh found')
             print('')
 
-        #last index where
-        for missed_thresh in missed_threshs: 
-            print('============= MISSED RATE < {} ============='.format(missed_thresh))
+        # last index where
+        for missed_thresh in missed_threshs:
+            print(
+                '============= MISSED RATE < {} ============='.format(
+                    missed_thresh))
             if(any(missed_range < missed_thresh)):
                 idx = np.where(missed_range <= missed_thresh)[0][-1]
                 P_thresh_opt = P_thresh_range[idx]
-                self.summarize_shot_prediction_stats_by_mode(P_thresh_opt,mode,verbose=True)
-                print('============= AT P_THRESH = {} ============='.format(P_thresh_opt))
+                self.summarize_shot_prediction_stats_by_mode(
+                    P_thresh_opt, mode, verbose=True)
+                print(
+                    '============= AT P_THRESH = {} ============='.format(
+                        P_thresh_opt))
             else:
                 print('No such P_thresh found')
             print('')
@@ -485,17 +545,18 @@ class PerformanceAnalyzer():
         print('============= TEST PERFORMANCE: =============')
         idx = np.where(missed_range <= fp_range)[0][-1]
         P_thresh_opt = P_thresh_range[idx]
-        self.summarize_shot_prediction_stats_by_mode(P_thresh_opt,mode,verbose=True)
+        self.summarize_shot_prediction_stats_by_mode(
+            P_thresh_opt, mode, verbose=True)
         P_thresh_ret = P_thresh_opt
         return P_thresh_ret
 
-
     def compute_tradeoffs_and_print_from_training(self):
         P_thresh_range = self.get_p_thresh_range()
-        correct_range, accuracy_range, fp_range,missed_range,early_alarm_range = self.get_metrics_vs_p_thresh('train')
+        (correct_range, accuracy_range, fp_range, missed_range,
+         early_alarm_range) = self.get_metrics_vs_p_thresh('train')
 
-        fp_threshs = [0.01,0.05,0.1]
-        missed_threshs = [0.01,0.05,0.0]
+        fp_threshs = [0.01, 0.05, 0.1]
+        missed_threshs = [0.01, 0.05, 0.0]
 #        missed_threshs = [0.01,0.05,0.1,0.2,0.3]
         P_thresh_default = 0.03
         P_thresh_ret = P_thresh_default
@@ -503,33 +564,38 @@ class PerformanceAnalyzer():
         first_idx = 0 if not self.pred_ttd else -1
         last_idx = -1 if not self.pred_ttd else 0
 
-        #first index where...
-        for fp_thresh in fp_threshs: 
+        # first index where...
+        for fp_thresh in fp_threshs:
 
-            print('============= TRAINING FP RATE < {} ============='.format(fp_thresh))
+            print('============= TRAINING FP RATE < {} ============='.format(
+                fp_thresh))
             print('============= TEST PERFORMANCE: =============')
             if(any(fp_range < fp_thresh)):
                 idx = np.where(fp_range <= fp_thresh)[0][first_idx]
                 P_thresh_opt = P_thresh_range[idx]
-                self.summarize_shot_prediction_stats_by_mode(P_thresh_opt,'test',verbose=True)
-                print('============= AT P_THRESH = {} ============='.format(P_thresh_opt))
+                self.summarize_shot_prediction_stats_by_mode(
+                    P_thresh_opt, 'test', verbose=True)
+                print('============= AT P_THRESH = {} ============='.format(
+                    P_thresh_opt))
             else:
                 print('No such P_thresh found')
             P_thresh_opt = P_thresh_default
             print('')
 
-        #last index where
-        for missed_thresh in missed_threshs: 
-
-            print('============= TRAINING MISSED RATE < {} ============='.format(missed_thresh))
+        # last index where
+        for missed_thresh in missed_threshs:
+            print('============= TRAINING MISSED RATE < {} ==========='.format(
+                missed_thresh))
             print('============= TEST PERFORMANCE: =============')
             if(any(missed_range < missed_thresh)):
                 idx = np.where(missed_range <= missed_thresh)[0][last_idx]
                 P_thresh_opt = P_thresh_range[idx]
-                self.summarize_shot_prediction_stats_by_mode(P_thresh_opt,'test',verbose=True)
+                self.summarize_shot_prediction_stats_by_mode(
+                    P_thresh_opt, 'test', verbose=True)
                 if missed_thresh == 0.05:
                     P_thresh_ret = P_thresh_opt
-                print('============= AT P_THRESH = {} ============='.format(P_thresh_opt))
+                print('============= AT P_THRESH = {} ============='.format(
+                    P_thresh_opt))
             else:
                 print('No such P_thresh found')
             P_thresh_opt = P_thresh_default
@@ -540,20 +606,25 @@ class PerformanceAnalyzer():
         if(any(missed_range <= fp_range)):
             idx = np.where(missed_range <= fp_range)[0][last_idx]
             P_thresh_opt = P_thresh_range[idx]
-            self.summarize_shot_prediction_stats_by_mode(P_thresh_opt,'test',verbose=True)
+            self.summarize_shot_prediction_stats_by_mode(
+                P_thresh_opt, 'test', verbose=True)
             P_thresh_ret = P_thresh_opt
-            print('============= AT P_THRESH = {} ============='.format(P_thresh_opt))
+            print('============= AT P_THRESH = {} ============='.format(
+                P_thresh_opt))
         else:
             print('No such P_thresh found')
         return P_thresh_ret
 
+    def compute_tradeoffs_and_plot(self, mode, save_figure=True,
+                                   plot_string='', linestyle="-"):
+        (correct_range, accuracy_range, fp_range, missed_range,
+         early_alarm_range) = self.get_metrics_vs_p_thresh(mode)
 
-    def compute_tradeoffs_and_plot(self,mode,save_figure=True,plot_string='',linestyle="-"):
-        correct_range, accuracy_range, fp_range,missed_range,early_alarm_range = self.get_metrics_vs_p_thresh(mode)
+        return self.tradeoff_plot(accuracy_range, missed_range, fp_range,
+                                  early_alarm_range, save_figure=save_figure,
+                                  plot_string=plot_string, linestyle=linestyle)
 
-        return self.tradeoff_plot(accuracy_range,missed_range,fp_range,early_alarm_range,save_figure=save_figure,plot_string=plot_string,linestyle=linestyle)
-
-    def get_prediction_type(self,TP,FP,FN,TN,early,late):
+    def get_prediction_type(self, TP, FP, FN, TN, early, late):
         if TP:
             return 'TP'
         elif FP:
@@ -567,9 +638,14 @@ class PerformanceAnalyzer():
         elif late:
             return 'late'
 
-    def plot_individual_shot(self,P_thresh_opt,shot_num,normalize=True,plot_signals=True):
+    def plot_individual_shot(
+            self,
+            P_thresh_opt,
+            shot_num,
+            normalize=True,
+            plot_signals=True):
         success = False
-        for mode in ['test','train']:
+        for mode in ['test', 'train']:
             if mode == 'test':
                 pred = self.pred_test
                 truth = self.truth_test
@@ -580,30 +656,49 @@ class PerformanceAnalyzer():
                 truth = self.truth_train
                 is_disruptive = self.disruptive_train
                 shot_list = self.shot_list_train
-            for i,shot in enumerate(shot_list):
+            for i, shot in enumerate(shot_list):
                 if shot.number == shot_num:
                     t = truth[i]
                     p = pred[i]
                     is_disr = is_disruptive[i]
 
-                    TP,FP,FN,TN,early,late =self.get_shot_prediction_stats(P_thresh_opt,p,t,is_disr)
-                    prediction_type = self.get_prediction_type(TP,FP,FN,TN,early,late)
+                    TP, FP, FN, TN, early, late = (
+                        self.get_shot_prediction_stats(P_thresh_opt, p, t,
+                                                       is_disr))
+                    prediction_type = self.get_prediction_type(TP, FP, FN, TN,
+                                                               early, late)
                     print(prediction_type)
-                    self.plot_shot(shot,True,normalize,t,p,P_thresh_opt,prediction_type,extra_filename = '_indiv')
+                    self.plot_shot(
+                        shot,
+                        True,
+                        normalize,
+                        t,
+                        p,
+                        P_thresh_opt,
+                        prediction_type,
+                        extra_filename='_indiv')
                     success = True
         if not success:
             print("Shot {} not found".format(shot_num))
-                
 
-    def get_prediction_type_for_individual_shot(self,P_thresh,shot,mode='test'):
-        p,t,is_disr = self.get_pred_truth_disr_by_shot(shot)
+    def get_prediction_type_for_individual_shot(
+            self, P_thresh, shot, mode='test'):
+        p, t, is_disr = self.get_pred_truth_disr_by_shot(shot)
 
-        TP,FP,FN,TN,early,late =self.get_shot_prediction_stats(P_thresh,p,t,is_disr)
-        prediction_type = self.get_prediction_type(TP,FP,FN,TN,early,late)
+        TP, FP, FN, TN, early, late = self.get_shot_prediction_stats(
+            P_thresh, p, t, is_disr)
+        prediction_type = self.get_prediction_type(TP, FP, FN, TN, early, late)
         return prediction_type
 
-
-    def example_plots(self,P_thresh_opt,mode='test',types_to_plot = ['FP'],max_plot = 5,normalize=True,plot_signals=True,extra_filename=''):
+    def example_plots(
+            self,
+            P_thresh_opt,
+            mode='test',
+            types_to_plot=['FP'],
+            max_plot=5,
+            normalize=True,
+            plot_signals=True,
+            extra_filename=''):
         if mode == 'test':
             pred = self.pred_test
             truth = self.truth_test
@@ -623,126 +718,201 @@ class PerformanceAnalyzer():
             is_disr = is_disruptive[i]
             shot = shot_list.shots[i]
 
-            TP,FP,FN,TN,early,late =self.get_shot_prediction_stats(P_thresh_opt,p,t,is_disr)
-            prediction_type = self.get_prediction_type(TP,FP,FN,TN,early,late)
-            if not all(_ in set(['FP','TP','FN','TN','late','early','any']) for _ in types_to_plot):
+            TP, FP, FN, TN, early, late = self.get_shot_prediction_stats(
+                P_thresh_opt, p, t, is_disr)
+            prediction_type = self.get_prediction_type(
+                TP, FP, FN, TN, early, late)
+            if not all(_ in set(['FP', 'TP', 'FN', 'TN', 'late',
+                                 'early', 'any']) for _ in types_to_plot):
                 print('warning, unkown types_to_plot')
                 return
-            if ('any' in types_to_plot or prediction_type in types_to_plot) and plotted < max_plot:
+            if (('any' in types_to_plot or prediction_type in types_to_plot)
+                    and plotted < max_plot):
                 if plot_signals:
-                    self.plot_shot(shot,True,normalize,t,p,P_thresh_opt,prediction_type,extra_filename=extra_filename)
+                    self.plot_shot(
+                        shot,
+                        True,
+                        normalize,
+                        t,
+                        p,
+                        P_thresh_opt,
+                        prediction_type,
+                        extra_filename=extra_filename)
                 else:
                     plt.figure()
-                    plt.semilogy((t+0.001)[::-1],label='ground truth')
-                    plt.plot(p[::-1],'g',label='neural net prediction')
-                    plt.axvline(self.T_min_warn,color='r',label='max warning time')
-                    plt.axvline(self.T_max_warn,color='r',label='min warning time')
-                    plt.axhline(P_thresh_opt,color='k',label='trigger threshold')
+                    plt.semilogy((t+0.001)[::-1], label='ground truth')
+                    plt.plot(p[::-1], 'g', label='neural net prediction')
+                    plt.axvline(
+                        self.T_min_warn,
+                        color='r',
+                        label='max warning time')
+                    plt.axvline(
+                        self.T_max_warn,
+                        color='r',
+                        label='min warning time')
+                    plt.axhline(
+                        P_thresh_opt,
+                        color='k',
+                        label='trigger threshold')
                     plt.xlabel('TTD [ms]')
-                    plt.legend(loc = (1.0,0.6))
-                    plt.ylim([1e-7,1.1e0])
+                    plt.legend(loc=(1.0, 0.6))
+                    plt.ylim([1e-7, 1.1e0])
                     plt.grid()
-                    plt.savefig('fig_{}.png'.format(shot.number),bbox_inches='tight')
+                    plt.savefig(
+                        'fig_{}.png'.format(
+                            shot.number),
+                        bbox_inches='tight')
                 plotted += 1
 
-    def plot_shot(self,shot,save_fig=True,normalize=True,truth=None,prediction=None,P_thresh_opt=None,prediction_type='',extra_filename=''):
+    def plot_shot(
+            self,
+            shot,
+            save_fig=True,
+            normalize=True,
+            truth=None,
+            prediction=None,
+            P_thresh_opt=None,
+            prediction_type='',
+            extra_filename=''):
         if self.normalizer is None and normalize:
             if self.conf is not None:
-                self.saved_conf['paths']['normalizer_path'] = self.conf['paths']['normalizer_path']
+                self.saved_conf['paths']['normalizer_path'] = (
+                    self.conf['paths']['normalizer_path'])
             nn = Normalizer(self.saved_conf)
             nn.train()
             self.normalizer = nn
             self.normalizer.set_inference_mode(True)
-    
+
         if(shot.previously_saved(self.shots_dir)):
             shot.restore(self.shots_dir)
-            if shot.signals_dict is not None: #make sure shot was saved with data
-                t_disrupt = shot.t_disrupt
-                is_disruptive =  shot.is_disruptive
+            if shot.signals_dict is not None:
+                # make sure shot was saved with data
+                # t_disrupt = shot.t_disrupt
+                # is_disruptive = shot.is_disruptive
                 if normalize:
                     self.normalizer.apply(shot)
-    
+
                 use_signals = self.saved_conf['paths']['use_signals']
-                fontsize= 15
-                lower_lim = 0 #len(pred)
+                fontsize = 15
+                lower_lim = 0  # len(pred)
                 plt.close()
-                colors = ["b","k"]
-                lss = ["-","--"]
-                f,axarr = plt.subplots(len(use_signals)+1,1,sharex=True,figsize=(10,15))#, squeeze=False)
+                # colors = ["b", "k"]
+                # lss = ["-", "--"]
+                f, axarr = plt.subplots(
+                    len(use_signals)+1, 1, sharex=True, figsize=(10, 15))
                 plt.title(prediction_type)
                 assert(np.all(shot.ttd.flatten() == truth.flatten()))
-                xx = range(len(prediction)) #list(reversed(range(len(pred))))
-                for i,sig in enumerate(use_signals):
+                xx = range(len(prediction))  # list(reversed(range(len(pred))))
+                for i, sig in enumerate(use_signals):
                     ax = axarr[i]
                     num_channels = sig.num_channels
                     sig_arr = shot.signals_dict[sig]
                     if num_channels == 1:
-        #                 if j == 0:
-                        ax.plot(xx,sig_arr[:,0],linewidth=2)#,linestyle=lss[j],color=colors[j])
-        #                 else:
-        #                     ax.plot(xx,sig_arr[:,0],linewidth=2)#,linestyle=lss[j],color=colors[j],label = labels[sig])
-                        ax.plot([],linestyle="none",label = sig.description)#labels[sig])
-                        if np.min(sig_arr[:,0]) < 0:
-                            ax.set_ylim([-6,6])
-                            ax.set_yticks([-5,0,5])
-        #                     ax.plot(xx,sig_arr[:,0],linewidth=2)#,linestyle=lss[j],color=colors[j],label = labels[sig])
-                        ax.plot([],linestyle="none",label = sig.description)#labels[sig])
-                        if np.min(sig_arr[:,0]) < 0:
-                            ax.set_ylim([-6,6])
-                            ax.set_yticks([-5,0,5])
+                        ax.plot(xx, sig_arr[:, 0], linewidth=2)
+                        ax.plot([], linestyle="none", label=sig.description)
+                        if np.min(sig_arr[:, 0]) < 0:
+                            ax.set_ylim([-6, 6])
+                            ax.set_yticks([-5, 0, 5])
+                        ax.plot([], linestyle="none", label=sig.description)
+                        if np.min(sig_arr[:, 0]) < 0:
+                            ax.set_ylim([-6, 6])
+                            ax.set_yticks([-5, 0, 5])
                         else:
-                            ax.set_ylim([0,8])
-                            ax.set_yticks([0,5])
-        #                 ax.set_ylabel(labels[sig],size=fontsize)
+                            ax.set_ylim([0, 8])
+                            ax.set_yticks([0, 5])
                     else:
-                        ax.imshow(sig_arr[:,:].T, aspect='auto', label = sig.description,cmap="inferno" )
-                        ax.set_ylim([0,num_channels])
-                        ax.text(lower_lim+200, 45, sig.description, bbox={'facecolor': 'white', 'pad': 10},fontsize=fontsize-5)
-                        ax.set_yticks([0,num_channels/2])
-                        ax.set_yticklabels(["0","0.5"])
-                        ax.set_ylabel("$\\rho$",size=fontsize)
-                    ax.legend(loc="best",labelspacing=0.1,fontsize=fontsize,frameon=False)
-                    ax.axvline(len(truth)-self.T_min_warn,color='r',linewidth=0.5)
-                    plt.setp(ax.get_xticklabels(),visible=False)
-                    plt.setp(ax.get_yticklabels(),fontsize=fontsize)
+                        ax.imshow(sig_arr[:, :].T, aspect='auto',
+                                  label=sig.description, cmap="inferno")
+                        ax.set_ylim([0, num_channels])
+                        ax.text(lower_lim+200, 45, sig.description,
+                                bbox={'facecolor': 'white', 'pad': 10},
+                                fontsize=fontsize-5)
+                        ax.set_yticks([0, num_channels/2])
+                        ax.set_yticklabels(["0", "0.5"])
+                        ax.set_ylabel("$\\rho$", size=fontsize)
+                    ax.legend(
+                        loc="best",
+                        labelspacing=0.1,
+                        fontsize=fontsize,
+                        frameon=False)
+                    ax.axvline(
+                        len(truth)
+                        - self.T_min_warn,
+                        color='r',
+                        linewidth=0.5)
+                    plt.setp(ax.get_xticklabels(), visible=False)
+                    plt.setp(ax.get_yticklabels(), fontsize=fontsize)
                     f.subplots_adjust(hspace=0)
-                    #print(sig)
-                    #print('min: {}, max: {}'.format(np.min(sig_arr), np.max(sig_arr)))
-                ax = axarr[-1] 
-                #         ax.semilogy((-truth+0.0001),label='ground truth')
-                #         ax.plot(-prediction+0.0001,'g',label='neural net prediction')
-                #         ax.axhline(-P_thresh_opt,color='k',label='trigger threshold')
-        #         nn = np.min(pred)
-                ax.plot(xx,truth,'g',label='target',linewidth=2)
-        #         ax.axhline(0.4,linestyle="--",color='k',label='threshold')
-                ax.plot(xx,prediction,'b',label='RNN output',linewidth=2)
-                ax.axhline(P_thresh_opt,linestyle="--",color='k',label='threshold')
-                ax.set_ylim([-2,2])
-                ax.set_yticks([-1,0,1])
+                ax = axarr[-1]
+                # ax.semilogy((-truth+0.0001),label='ground truth')
+                # ax.plot(-prediction+0.0001,'g',label='neural net prediction')
+                # ax.axhline(-P_thresh_opt,color='k',label='trigger threshold')
+                # nn = np.min(pred)
+                ax.plot(xx, truth, 'g', label='target', linewidth=2)
+                # ax.axhline(0.4,linestyle="--",color='k',label='threshold')
+                ax.plot(xx, prediction, 'b', label='RNN output', linewidth=2)
+                ax.axhline(P_thresh_opt, linestyle="--", color='k',
+                           label='threshold')
+                ax.set_ylim([-2, 2])
+                ax.set_yticks([-1, 0, 1])
                 # if len(truth)-T_max_warn >= 0:
-                #     ax.axvline(len(truth)-T_max_warn,color='r')#,label='max warning time')
-                ax.axvline(len(truth)-self.T_min_warn,color='r',linewidth=0.5)#,label='min warning time')
-                ax.set_xlabel('T [ms]',size=fontsize)
+                # ax.axvline(len(truth)-T_max_warn,color='r')#,label='max
+                # warning time')
+                # ,label='min warning time')
+                ax.axvline(
+                    len(truth)
+                    - self.T_min_warn,
+                    color='r',
+                    linewidth=0.5)
+                ax.set_xlabel('T [ms]', size=fontsize)
                 # ax.axvline(2400)
-                ax.legend(loc = (0.5,0.7),fontsize=fontsize-5,labelspacing=0.1,frameon=False)
-                plt.setp(ax.get_yticklabels(),fontsize=fontsize)
-                plt.setp(ax.get_xticklabels(),fontsize=fontsize)
+                ax.legend(
+                    loc=(
+                        0.5,
+                        0.7),
+                    fontsize=fontsize-5,
+                    labelspacing=0.1,
+                    frameon=False)
+                plt.setp(ax.get_yticklabels(), fontsize=fontsize)
+                plt.setp(ax.get_xticklabels(), fontsize=fontsize)
                 # plt.xlim(0,200)
-                plt.xlim([lower_lim,len(truth)])
+                plt.xlim([lower_lim, len(truth)])
         #         plt.savefig("{}.png".format(num),dpi=200,bbox_inches="tight")
                 if save_fig:
-                    plt.savefig('sig_fig_{}{}.png'.format(shot.number,extra_filename),bbox_inches='tight')
-                    np.savez('sig_{}{}.npz'.format(shot.number,extra_filename),shot=shot,T_min_warn=self.T_min_warn,T_max_warn=self.T_max_warn,prediction=prediction,truth=truth,use_signals=use_signals,P_thresh=P_thresh_opt)
-                #plt.show()
+                    plt.savefig(
+                        'sig_fig_{}{}.png'.format(
+                            shot.number,
+                            extra_filename),
+                        bbox_inches='tight')
+                    np.savez(
+                        'sig_{}{}.npz'.format(
+                            shot.number,
+                            extra_filename),
+                        shot=shot,
+                        T_min_warn=self.T_min_warn,
+                        T_max_warn=self.T_max_warn,
+                        prediction=prediction,
+                        truth=truth,
+                        use_signals=use_signals,
+                        P_thresh=P_thresh_opt)
+                # plt.show()
         else:
             print("Shot hasn't been processed")
 
-
-
-    def plot_shot_old(self,shot,save_fig=True,normalize=True,truth=None,prediction=None,P_thresh_opt=None,prediction_type='',extra_filename=''):
+    def plot_shot_old(
+            self,
+            shot,
+            save_fig=True,
+            normalize=True,
+            truth=None,
+            prediction=None,
+            P_thresh_opt=None,
+            prediction_type='',
+            extra_filename=''):
         if self.normalizer is None and normalize:
             if self.conf is not None:
-                self.saved_conf['paths']['normalizer_path'] = self.conf['paths']['normalizer_path']
+                self.saved_conf['paths']['normalizer_path'] = (
+                    self.conf['paths']['normalizer_path'])
             nn = Normalizer(self.saved_conf)
             nn.train()
             self.normalizer = nn
@@ -750,100 +920,155 @@ class PerformanceAnalyzer():
 
         if(shot.previously_saved(self.shots_dir)):
             shot.restore(self.shots_dir)
-            t_disrupt = shot.t_disrupt
-            is_disruptive =  shot.is_disruptive
+            # t_disrupt = shot.t_disrupt
+            # is_disruptive = shot.is_disruptive
             if normalize:
                 self.normalizer.apply(shot)
 
             use_signals = self.saved_conf['paths']['use_signals']
-            f,axarr = plt.subplots(len(use_signals)+1,1,sharex=True,figsize=(13,13))#, squeeze=False)
+            f, axarr = plt.subplots(len(use_signals)+1, 1, sharex=True,
+                                    figsize=(13, 13))
             plt.title(prediction_type)
-            #all files must agree on T_warning due to output of truth vs. normalized shot ttd.
+            # all files must agree on T_warning due to output of truth vs.
+            # normalized shot ttd.
             assert(np.all(shot.ttd.flatten() == truth.flatten()))
-            for i,sig in enumerate(use_signals):
+            for i, sig in enumerate(use_signals):
                 num_channels = sig.num_channels
                 ax = axarr[i]
                 sig_arr = shot.signals_dict[sig]
                 if num_channels == 1:
-                    ax.plot(sig_arr[:,0],label = sig.description)
+                    ax.plot(sig_arr[:, 0], label=sig.description)
                 else:
-                    ax.imshow(sig_arr[:,:].T, aspect='auto', label = sig.description + " (profile)")
-                    ax.set_ylim([0,num_channels])
-                ax.legend(loc='best',fontsize=8)
-                plt.setp(ax.get_xticklabels(),visible=False)
-                plt.setp(ax.get_yticklabels(),fontsize=7)
+                    ax.imshow(sig_arr[:, :].T, aspect='auto',
+                              label=sig.description + " (profile)")
+                    ax.set_ylim([0, num_channels])
+                ax.legend(loc='best', fontsize=8)
+                plt.setp(ax.get_xticklabels(), visible=False)
+                plt.setp(ax.get_yticklabels(), fontsize=7)
                 f.subplots_adjust(hspace=0)
-                #print(sig)
-                #print('min: {}, max: {}'.format(np.min(sig_arr), np.max(sig_arr)))
-                ax = axarr[-1] 
+                # print(sig)
+                # print('min: {}, max: {}'.format(np.min(sig_arr),
+                # np.max(sig_arr)))
+                ax = axarr[-1]
             if self.pred_ttd:
-                ax.semilogy((-truth+0.0001),label='ground truth')
-                ax.plot(-prediction+0.0001,'g',label='neural net prediction')
-                ax.axhline(-P_thresh_opt,color='k',label='trigger threshold')
+                ax.semilogy((-truth+0.0001), label='ground truth')
+                ax.plot(-prediction+0.0001, 'g', label='neural net prediction')
+                ax.axhline(-P_thresh_opt, color='k', label='trigger threshold')
             else:
-                ax.plot((truth+0.001),label='ground truth')
-                ax.plot(prediction,'g',label='neural net prediction')
-                ax.axhline(P_thresh_opt,color='k',label='trigger threshold')
-            #ax.set_ylim([1e-5,1.1e0])
-            ax.set_ylim([-2,2])
+                ax.plot((truth+0.001), label='ground truth')
+                ax.plot(prediction, 'g', label='neural net prediction')
+                ax.axhline(P_thresh_opt, color='k', label='trigger threshold')
+            # ax.set_ylim([1e-5,1.1e0])
+            ax.set_ylim([-2, 2])
             if len(truth)-self.T_max_warn >= 0:
-                ax.axvline(len(truth)-self.T_max_warn,color='r',label='min warning time')
-            ax.axvline(len(truth)-self.T_min_warn,color='r',label='max warning time')
+                ax.axvline(
+                    len(truth)-self.T_max_warn,
+                    color='r',
+                    label='min warning time')
+            ax.axvline(
+                len(truth)
+                - self.T_min_warn,
+                color='r',
+                label='max warning time')
             ax.set_xlabel('T [ms]')
-            #ax.legend(loc = 'lower left',fontsize=10)
-            plt.setp(ax.get_yticklabels(),fontsize=7)
-            # ax.grid()           
+            # ax.legend(loc = 'lower left',fontsize=10)
+            plt.setp(ax.get_yticklabels(), fontsize=7)
+            # ax.grid()
             if save_fig:
-                plt.savefig('sig_fig_{}{}.png'.format(shot.number,extra_filename),bbox_inches='tight')
-                np.savez('sig_{}{}.npz'.format(shot.number,extra_filename),shot=shot,T_min_warn=self.T_min_warn,T_max_warn=self.T_max_warn,prediction=prediction,truth=truth,use_signals=use_signals,P_thresh=P_thresh_opt)
+                plt.savefig(
+                    'sig_fig_{}{}.png'.format(
+                        shot.number,
+                        extra_filename),
+                    bbox_inches='tight')
+                np.savez(
+                    'sig_{}{}.npz'.format(
+                        shot.number,
+                        extra_filename),
+                    shot=shot,
+                    T_min_warn=self.T_min_warn,
+                    T_max_warn=self.T_max_warn,
+                    prediction=prediction,
+                    truth=truth,
+                    use_signals=use_signals,
+                    P_thresh=P_thresh_opt)
             plt.close()
         else:
             print("Shot hasn't been processed")
 
-
-    def tradeoff_plot(self,accuracy_range,missed_range,fp_range,early_alarm_range,save_figure=False,plot_string='',linestyle="-"):
-        fontsize=15
+    def tradeoff_plot(
+            self,
+            accuracy_range,
+            missed_range,
+            fp_range,
+            early_alarm_range,
+            save_figure=False,
+            plot_string='',
+            linestyle="-"):
+        fontsize = 15
         plt.figure()
         P_thresh_range = self.get_p_thresh_range()
         # semilogx(P_thresh_range,accuracy_range,label="accuracy")
         if self.pred_ttd:
-            plt.semilogx(abs(P_thresh_range[::-1]),missed_range,'r',label="missed",linestyle=linestyle)
-            plt.plot(abs(P_thresh_range[::-1]),fp_range,'k',label="false positives",linestyle=linestyle)
+            plt.semilogx(abs(P_thresh_range[::-1]),
+                         missed_range,
+                         'r',
+                         label="missed",
+                         linestyle=linestyle)
+            plt.plot(abs(P_thresh_range[::-1]),
+                     fp_range,
+                     'k',
+                     label="false positives",
+                     linestyle=linestyle)
         else:
-            plt.plot(P_thresh_range,missed_range,'r',label="missed",linestyle=linestyle)
-            plt.plot(P_thresh_range,fp_range,'k',label="false positives",linestyle=linestyle)
+            plt.plot(
+                P_thresh_range,
+                missed_range,
+                'r',
+                label="missed",
+                linestyle=linestyle)
+            plt.plot(
+                P_thresh_range,
+                fp_range,
+                'k',
+                label="false positives",
+                linestyle=linestyle)
         # plot(P_thresh_range,early_alarm_range,'c',label="early alarms")
-        plt.legend(loc=(1.0,.6))
-        plt.xlabel('Alarm threshold',size=fontsize)
+        plt.legend(loc=(1.0, .6))
+        plt.xlabel('Alarm threshold', size=fontsize)
         plt.grid()
-        title_str = 'metrics{}'.format(plot_string.replace('_',' '))
+        title_str = 'metrics{}'.format(plot_string.replace('_', ' '))
         plt.title(title_str)
         if save_figure:
-            plt.savefig(title_str + '.png',bbox_inches='tight')
+            plt.savefig(title_str + '.png', bbox_inches='tight')
         plt.close('all')
-        plt.plot(fp_range,1-missed_range,'-b',linestyle=linestyle)
+        plt.plot(fp_range, 1-missed_range, '-b', linestyle=linestyle)
         ax = plt.gca()
-        plt.xlabel('FP rate',size=fontsize)
-        plt.ylabel('TP rate',size=fontsize)
-        major_ticks = np.arange(0,1.01,0.2)
-        minor_ticks = np.arange(0,1.01,0.05)
+        plt.xlabel('FP rate', size=fontsize)
+        plt.ylabel('TP rate', size=fontsize)
+        major_ticks = np.arange(0, 1.01, 0.2)
+        minor_ticks = np.arange(0, 1.01, 0.05)
         ax.set_xticks(major_ticks)
         ax.set_yticks(major_ticks)
-        ax.set_xticks(minor_ticks,minor=True)
-        ax.set_yticks(minor_ticks,minor=True)
-        plt.setp(plt.gca().get_yticklabels(),fontsize=fontsize)
-        plt.setp(plt.gca().get_xticklabels(),fontsize=fontsize)
+        ax.set_xticks(minor_ticks, minor=True)
+        ax.set_yticks(minor_ticks, minor=True)
+        plt.setp(plt.gca().get_yticklabels(), fontsize=fontsize)
+        plt.setp(plt.gca().get_xticklabels(), fontsize=fontsize)
         ax.grid(which='both')
-        ax.grid(which='major',alpha=0.5)
-        ax.grid(which='minor',alpha=0.3)
-        plt.xlim([0,1])
-        plt.ylim([0,1])
+        ax.grid(which='major', alpha=0.5)
+        ax.grid(which='minor', alpha=0.3)
+        plt.xlim([0, 1])
+        plt.ylim([0, 1])
         if save_figure:
-            plt.savefig(title_str + '_roc.png',bbox_inches='tight',dpi=200)
-        print('ROC area ({}) is {}'.format(plot_string,self.roc_from_missed_fp(missed_range,fp_range)))
-        return P_thresh_range,missed_range,fp_range
+            plt.savefig(title_str + '_roc.png', bbox_inches='tight', dpi=200)
+        print(
+            'ROC area ({}) is {}'.format(
+                plot_string,
+                self.roc_from_missed_fp(
+                    missed_range,
+                    fp_range)))
+        return P_thresh_range, missed_range, fp_range
 
-    def get_pred_truth_disr_by_shot(self,shot):
+    def get_pred_truth_disr_by_shot(self, shot):
         if shot in self.shot_list_test:
             mode = 'test'
         elif shot in self.shot_list_train:
@@ -866,50 +1091,49 @@ class PerformanceAnalyzer():
         p = pred[i]
         is_disr = is_disruptive[i]
         shot = shot_list.shots[i]
-        return p,t,is_disr
+        return p, t, is_disr
 
-    def save_shot(self,shot,P_thresh_opt = 0,extra_filename=''):
+    def save_shot(self, shot, P_thresh_opt=0, extra_filename=''):
         if self.normalizer is None:
             if self.conf is not None:
-                self.saved_conf['paths']['normalizer_path'] = self.conf['paths']['normalizer_path']
+                self.saved_conf['paths']['normalizer_path'] = (
+                    self.conf['paths']['normalizer_path'])
             nn = Normalizer(self.saved_conf)
             nn.train()
             self.normalizer = nn
             self.normalizer.set_inference_mode(True)
- 
+
         shot.restore(self.shots_dir)
-        t_disrupt = shot.t_disrupt
-        is_disruptive =  shot.is_disruptive
+        # t_disrupt = shot.t_disrupt
+        # is_disruptive = shot.is_disruptive
         self.normalizer.apply(shot)
 
-
-
-        pred,truth,is_disr = self.get_pred_truth_disr_by_shot(shot)
+        pred, truth, is_disr = self.get_pred_truth_disr_by_shot(shot)
         use_signals = self.saved_conf['paths']['use_signals']
-        np.savez('sig_{}{}.npz'.format(shot.number,extra_filename),shot=shot,T_min_warn=self.T_min_warn,T_max_warn=self.T_max_warn,prediction=pred,truth=truth,use_signals=use_signals,P_thresh=P_thresh_opt)
+        np.savez('sig_{}{}.npz'.format(shot.number, extra_filename),
+                 shot=shot, T_min_warn=self.T_min_warn,
+                 T_max_warn=self.T_max_warn, prediction=pred,
+                 truth=truth, use_signals=use_signals, P_thresh=P_thresh_opt)
 
-    def get_roc_area_by_mode(self,mode='test'):
+    def get_roc_area_by_mode(self, mode='test'):
         if mode == 'test':
             pred = self.pred_test
             truth = self.truth_test
             is_disruptive = self.disruptive_test
-            shot_list = self.shot_list_test
+            # shot_list = self.shot_list_test
         else:
             pred = self.pred_train
             truth = self.truth_train
             is_disruptive = self.disruptive_train
-            shot_list = self.shot_list_train
-        return self.get_roc_area(pred,truth,is_disruptive)
+            # shot_list = self.shot_list_train
+        return self.get_roc_area(pred, truth, is_disruptive)
 
-    def get_roc_area(self,all_preds,all_truths,all_disruptive):
-        correct_range, accuracy_range, fp_range,missed_range,early_alarm_range = \
-         self.get_metrics_vs_p_thresh_custom(all_preds,all_truths,all_disruptive)
+    def get_roc_area(self, all_preds, all_truths, all_disruptive):
+        (correct_range, accuracy_range, fp_range, missed_range,
+         early_alarm_range) = self.get_metrics_vs_p_thresh_custom(
+             all_preds, all_truths, all_disruptive)
 
-        return self.roc_from_missed_fp(missed_range,fp_range)
+        return self.roc_from_missed_fp(missed_range, fp_range)
 
-    def roc_from_missed_fp(self,missed_range,fp_range):
-        #print(fp_range)
-        #print(missed_range)
-        return -np.trapz(1-missed_range,x=fp_range)
-
-
+    def roc_from_missed_fp(self, missed_range, fp_range):
+        return -np.trapz(1 - missed_range, x=fp_range)

--- a/plasma/utils/state_reset.py
+++ b/plasma/utils/state_reset.py
@@ -1,32 +1,35 @@
 from __future__ import print_function
 import keras.backend as K
-import numpy as np
+
 
 def get_states(model):
-	all_states = [] 
-	for layer in model.layers:
-		if hasattr(layer,"states"):
-			layer_states = []
-			for state in layer.states:
-				#print(K.get_value(state)[0][0:3])
-				layer_states.append(K.get_value(state))
-			all_states.append(layer_states)
-	# print(all_states)
-	return all_states
+    all_states = []
+    for layer in model.layers:
+        if hasattr(layer, "states"):
+            layer_states = []
+            for state in layer.states:
+                # print(K.get_value(state)[0][0:3])
+                layer_states.append(K.get_value(state))
+            all_states.append(layer_states)
+    # print(all_states)
+    return all_states
+
 
 def set_states(model, all_states):
-	i = 0
-	for layer in model.layers:
-		if hasattr(layer,"states"):
-			layer.reset_states(all_states[i])
-			i += 1
+    i = 0
+    for layer in model.layers:
+        if hasattr(layer, "states"):
+            layer.reset_states(all_states[i])
+            i += 1
+
 
 def reset_states(model, batches_to_reset):
-	old_states = get_states(model)
-	model.reset_states()
-	new_states = get_states(model)
-	for i,layer_states in enumerate(new_states):
-		for j,within_layer_state in enumerate(layer_states):
-			assert(len(batches_to_reset) == within_layer_state.shape[0])
-			within_layer_state[~batches_to_reset,:] = old_states[i][j][~batches_to_reset,:]
-	set_states(model,new_states)
+    old_states = get_states(model)
+    model.reset_states()
+    new_states = get_states(model)
+    for i, layer_states in enumerate(new_states):
+        for j, within_layer_state in enumerate(layer_states):
+            assert(len(batches_to_reset) == within_layer_state.shape[0])
+            within_layer_state[~batches_to_reset,
+                               :] = old_states[i][j][~batches_to_reset, :]
+    set_states(model, new_states)

--- a/plasma/version.py
+++ b/plasma/version.py
@@ -8,9 +8,11 @@ version_info = tuple(re.split(r"[-\.]", __version__))
 
 specification = ".".join(version_info[:2])
 
+
 def compatible(serializedVersion):
     selfMajor, selfMinor = map(int, version_info[:2])
-    otherMajor, otherMinor = map(int, re.split(r"[-\.]", serializedVersion)[:2])
+    otherMajor, otherMinor = map(int,
+                                 re.split(r"[-\.]", serializedVersion)[:2])
     if selfMajor >= otherMajor:
         return True
     elif selfMinor >= otherMinor:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,29 @@
 [metadata]
 description-file = README.md
+
+[flake8]
+max-line-length = 79
+# exclude = cpplint.py
+ignore =
+       # Subset of DEFAULT_IGNORE error codes from pycodestyle
+       # (not universally accepted / not enforced by PEP 8 document)
+       # E1: Indentation
+       # E121: continuation line under-indented for hanging indent (allow fewer than 4 spaces w/ hanging indent)
+       E121,
+       # E123: closing bracket does not match indentation of opening bracket’s line
+       E123,
+       # E126: continuation line over-indented for hanging inden (allow fewer than 4 spaces w/ hanging indent)
+       E126,
+       # E2: Whitespace
+       # E226: missing whitespace around arithmetic operator (allow nx+1, ...)
+       E226,
+       # E241: multiple spaces after ‘,’
+       E241,
+       # E7: Statements
+       # E704: multiple statements on one line (def)
+       E704,
+       # E731: Do not assign a lambda expression, use a def
+       E731,
+       # W5: Line break warning
+       # W503: line break before binary operator (use mutually exclusive W504)
+       W503

--- a/setup.py
+++ b/setup.py
@@ -1,40 +1,46 @@
 import os
-import sys
 import subprocess
 from setuptools import setup, find_packages
 
 import plasma.version
 
 try:
-    os.environ['MPICC'] = subprocess.check_output("which mpicc", shell=True).decode("utf-8") 
-except:
-    print ("Please set up the OpenMPI environment")
+    os.environ['MPICC'] = subprocess.check_output(
+        "which mpicc", shell=True).decode("utf-8")
+except BaseException:
+    print("Please set up the OpenMPI environment")
     exit(1)
 
-setup(name = "plasma",
-      version = plasma.version.__version__,
-      packages = find_packages(),
-      #scripts = [""],
-      description = "PPPL deep learning package.",
-      long_description = """Add description here""",
-      author = "Julian Kates-Harbeck, Alexey Svyatkovskiy",
-      author_email = "jkatesharbeck@g.harvard.edu",
-      maintainer = "Alexey Svyatkovskiy",
-      maintainer_email = "alexeys@princeton.edu",
-      #url = "http://",
-      download_url = "https://github.com/PPPLDeepLearning/plasma-python",
-      #license = "Apache Software License v2",
-      test_suite = "tests",
-      install_requires = ['keras>2.0.8','pathos','matplotlib==2.0.2','hyperopt','mpi4py','xgboost'],
-      tests_require = [],
-      classifiers = ["Development Status :: 3 - Alpha",
-                     "Environment :: Console",
-                     "Intended Audience :: Science/Research",
-                     "Programming Language :: Python",
-                     "Topic :: Scientific/Engineering :: Information Analysis",
-                     "Topic :: Scientific/Engineering :: Physics",
-                     "Topic :: Scientific/Engineering :: Mathematics",
-                     "Topic :: System :: Distributed Computing",
-                     ],
-      platforms = "Any",
+setup(name="plasma",
+      version=plasma.version.__version__,
+      packages=find_packages(),
+      # scripts = [""],
+      description="PPPL deep learning package.",
+      long_description="""Add description here""",
+      author="Julian Kates-Harbeck, Alexey Svyatkovskiy",
+      author_email="jkatesharbeck@g.harvard.edu",
+      maintainer="Alexey Svyatkovskiy",
+      maintainer_email="alexeys@princeton.edu",
+      # url = "http://",
+      download_url="https://github.com/PPPLDeepLearning/plasma-python",
+      # license = "Apache Software License v2",
+      test_suite="tests",
+      install_requires=[
+          'keras>2.0.8',
+          'pathos',
+          'matplotlib==2.0.2',
+          'hyperopt',
+          'mpi4py',
+          'xgboost'],
+      tests_require=[],
+      classifiers=["Development Status :: 3 - Alpha",
+                   "Environment :: Console",
+                   "Intended Audience :: Science/Research",
+                   "Programming Language :: Python",
+                   "Topic :: Scientific/Engineering :: Information Analysis",
+                   "Topic :: Scientific/Engineering :: Physics",
+                   "Topic :: Scientific/Engineering :: Mathematics",
+                   "Topic :: System :: Distributed Computing",
+                   ],
+      platforms="Any",
       )

--- a/tests/testbasic.py
+++ b/tests/testbasic.py
@@ -1,5 +1,5 @@
-import sys
 import unittest
+
 
 class TestBasic(unittest.TestCase):
     pass


### PR DESCRIPTION
Most of the [PEP 8](https://www.python.org/dev/peps/pep-0008/) recommendations are adopted, including the restrictive 79 character limit per line.  Ignored/excluded PEP 8 rules are listed in the `[flake8]` block of `setup.cfg` and are described in the adjacent comments. 

Travis CI is now configured to run the linter as a preliminary build stage for all builds. If `flake8` emits a warning or error, the main install+test build stage will be aborted, and Travis will report the overall build as failed. 

### Detailed summary

- Selects the [`flake8`](http://flake8.pycqa.org/en/latest/) Python module as the tool to be used for checking Python style. This command line utility wraps the PyFlakes, `pycodestyle` (formerly `pep8`), and [McCabe](https://github.com/PyCQA/mccabe) (for checking code complexity) tools. 
  - `flake8` is probably the most popular Python linter, and it was straightforward to setup these lightweight checks. 
  - [Pylint](https://www.pylint.org/) is also a popular tool, but I am less familiar with it. 
- Adds linting rules to `setup.cfg`
  - The configuration could alternatively be stored in hidden file `.flake8`, if preferred. 
- Applies `autopep8` tool to all Python files currently in the project
- Manually fixes remaining `flake8` error code violations that `autopep8` was unable to correct and fixed some ugly indentation that resulted from the automated conversion. 
  - Tried to eliminate the "considered deprecated" usages of `\` line continuation characters in favor of explicit delimiters `()` and hanging indents. 

### To-do
- [ ] Switch Jenkins server and workspace
- [ ] Add `flake8` check to Jenkins builds
- [ ] Continue updating Travis CI YAML. Should apt-based `addons` be replaced by `virtualenv`?
- [ ] Refactor the heavily-duplicated parts of the code