### PR TITLE
Directly transmit predictions in parallel instead of implicitly pickling them

### DIFF
--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -12,7 +12,6 @@ from plasma.utils.state_reset import reset_states
 # Keras "Using TensorFlow backend" stderr messages do not interfere in stdout
 from plasma.conf import conf
 from mpi4py import MPI
-from pkg_resources import parse_version, get_distribution, DistributionNotFound
 import random
 from packaging import version
 import contextlib
@@ -59,10 +58,6 @@ if g.backend == 'tf' or g.backend == 'tensorflow':
         os.environ['CUDA_VISIBLE_DEVICES'] = '{}'.format(g.MY_GPU)
         # ,mode=NanGuardMode'
     os.environ['KERAS_BACKEND'] = 'tensorflow'  # default setting
-    try:
-        g.tf_ver = parse_version(get_distribution(g.backendpackage).version)
-    except DistributionNotFound:
-        g.tf_ver = parse_version(get_distribution('tensorflow').version)
     # compat/compat.py first committed on 2018-06-29 for Py 2 vs 3
     # (around, but not present in, the release of v1.9.0)
     # v2 compatiblity code added, then moved from compat.py in Nov and Dec 2018
@@ -74,6 +69,7 @@ if g.backend == 'tf' or g.backend == 'tensorflow':
     #     import tensorflow.compat.v1 as tf
     # else:
     import tensorflow as tf
+    g.tf_ver = tf.__version__ # setting g.tf_ver moved after the import Summer 2021
     # TODO(KGF): above, builder.py (bug workaround), mpi_launch_tensorflow.py,
     # and runner.py are the only files that import tensorflow directly
 
@@ -861,7 +857,7 @@ def mpi_train(conf, shot_list_train, shot_list_validate, loader,
     conf['num_workers'] = g.comm.Get_size()
 
     specific_builder = builder.ModelBuilder(conf)
-    if g.tf_ver >= parse_version('1.14.0'):
+    if version.parse(g.tf_ver) >= version.parse('1.14.0'):
         # Internal TensorFlow flags, subject to change (v1.14.0+ only?)
         try:
             from tensorflow.python.util import module_wrapper as depr

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -791,9 +791,6 @@ def mpi_make_predictions(conf, shot_list, loader, custom_path=None):
     if g.task_index != 0:
         loader.verbose = False
 
-    #g.write_unique('num workers= {}\nlen(shot_sublists)={}, num_shots = {}\n'.format(g.num_workers, len(shot_sublists), len(shot_list)))
-    freeme = False
-
     # MPI loop works by predicting in batches of the 
     # largest possible multiple of len(shot_sublists) < num_workers
     # i.e. if there are 9 shot_sublists and 4 workers,
@@ -805,29 +802,23 @@ def mpi_make_predictions(conf, shot_list, loader, custom_path=None):
     #      or aggregate predictions with other workers, after each worker has made a prediction
     #      which happens every num_workers iterations in the for loop
     #      (i.e. worker 0 will aggregate predictions with workers 1-3 at the end of i=3)
+    # During the aggregation step, each worker is uses its color (which denotes whether it was
+    # predicting or not predicting during the last few runs of the for loop) to split the main comm
+    # The predictors (color = 1) share their predictions with first each other, and then to everyone
+    # the nonpredictors (color = 2) only recieve the global predictions from the predictors
     color = 2
-    #g.write_all('I shall predict {} times\n'.format(times_i_will_predict))
     for (i, shot_sublist) in enumerate(shot_sublists):
         shpz = []
         max_length = -1 # So non shot predictive workers don't have a real length
-        #g.write_all('My task index = {}, i mod num_workers = {}\n'.format(g.task_index, i%g.num_workers))
         if i % g.num_workers == g.task_index:
-            #g.write_all('Creating new comm at i={}\n'.format(i))
             color = 1
-            #g.comm.Barrier()
-            #temp_predictor_only_comm = MPI.Comm.Split(g.comm, color, i)
-            #freeme = True
-            # Create new MPI comm to pass around rank
-            #g.write_all('Starting to load and predict subroutine, i={}\n'.format(i))
             X, y, shot_lengths, disr = loader.load_as_X_y_pred(shot_sublist)
-            #g.write_all('X, y, lengths, disr loaded, shot_lengths shape: {} \n'.format(len(shot_lengths)))
 
             # load data and fit on data
             y_p = model.predict(X, batch_size=conf['model']['pred_batch_size'])
             model.reset_states()
             y_p = loader.batch_output_to_array(y_p)
             y = loader.batch_output_to_array(y)
-            #g.write_all('Finished le prediction\n')
 
             # cut arrays back
             y_p = [arr[:shot_lengths[j]] for (j, arr) in enumerate(y_p)]
@@ -840,8 +831,7 @@ def mpi_make_predictions(conf, shot_list, loader, custom_path=None):
         if (i % g.num_workers == g.num_workers - 1
                 or i == len(shot_sublists) - 1):
             # Create numpy block from y list which is used in MPI
-            # Pads y_prime and y_gold with zeros to make it all fit
-            #g.write_all('In second area, my color is {}, i={}\n'.format(color,i))
+            # Pads y_prime and y_gold with zeros to maximum shot length within block being transferred
             g.comm.Barrier()
             if color ==1:
                 shpz = [max(y.shape) for y in y_prime]
@@ -849,28 +839,19 @@ def mpi_make_predictions(conf, shot_list, loader, custom_path=None):
                 g.write_all(' max length = {}\n'.format(max_length))
             g.comm.Barrier()
             max_length = g.comm.allreduce(max_length, MPI.MAX) 
-            #g.write_all('Calculated shpz\n')
             if color == 1:
                 y_prime_numpy = np.stack([np.pad(sublist, pad_width=((0,max_length-max(sublist.shape)),(0,0))) for sublist in y_prime])
                 y_gold_numpy = np.stack([np.pad(sublist, pad_width=((0,max_length-max(sublist.shape)),(0,0))) for sublist in y_gold])
             
-            #g.write_all('Entered second area\n')
             g.comm.Barrier()
             temp_predictor_only_comm = MPI.Comm.Split(g.comm, color, i)
-            freeme = True
             g.comm.Barrier()
             # Create numpy array to store all processors output, then aggregate and unpad using MPI gathered shape list
-            #g.write_all('getting shapez, i contribute {} shpz\n'.format(len(shpz)))
             shpzg = g.comm.allgather(shpz)
             shpzg = list(itertools.chain(*shpzg))
             g.comm.Barrier()
-            #g.write_all('shpzg shape before preproc={}\n'.format(len(shpzg)))
             shpzg = [s for s in shpzg if s != []]
-            #g.write_all('shpzg shape after preproc={}\n'.format(len(shpzg)))
             max_length = g.comm.allreduce(max_length, MPI.MAX) 
-            #g.write_unique(str(shpzg)+'\n')
-            #g.write_all('gotting shapez\n')
-            # Todo: Figure out if empty shots are added to fit batch length
             if color == 1:
                 num_pred = temp_predictor_only_comm.size
             else:
@@ -879,49 +860,28 @@ def mpi_make_predictions(conf, shot_list, loader, custom_path=None):
             y_goldg  = np.zeros((num_pred*conf['model']['pred_batch_size'],max_length,1), dtype=conf['data']['floatx'])
             y_primeg_flattend = np.zeros(y_primeg.flatten().shape)
             y_goldg_flattend  = np.zeros(y_goldg.flatten().shape)
-            #g.write_all('initialized golbals, i = {}\n'.format(i))
-            # TODO (IMD) Support more floating point types
-            # ValueError: message: cannot infer count, number of entries 10652818 is not a multiple of required number of blocks 9
-            # Need to send an unequal sized array I think
             if color == 1:
-                #g.write_all('y_prime_numpy.shape = {}\n'.format(y_prime_numpy.shape))
-                #g.write_all('y_prime_numpy_flattend.shape = {}\n'.format(y_prime_numpy.flatten().shape))
-                #g.write_all('y_gold_numpy.shape = {}\n'.format(y_gold_numpy.shape))
-                #g.write_all('y_gold_numpy_flattend.shape = {}\n'.format(y_gold_numpy.flatten().shape))
-                #g.write_all('y_prime_g.shape = {}\n'.format(y_primeg.shape))
-                #g.write_all('y_primeg_flattend.shape = {}\n'.format(y_primeg_flattend.shape))
-                #g.write_all('y_goldg_flattend.shape = {}, i={}\n'.format(y_goldg_flattend.shape,i))
                 # Ensure that numpy arrays have correct dimensions before gathering them
                 assert num_pred*max(y_prime_numpy.flatten().shape) == max(y_primeg_flattend.shape)
                 assert num_pred*max(y_gold_numpy.flatten().shape) == max(y_goldg_flattend.shape)
-                #g.write_all('Passed asserts for i = {}\n'.format(i))
                 temp_predictor_only_comm.Barrier()
                 temp_predictor_only_comm.Allgather(y_prime_numpy.flatten(), y_primeg_flattend)
                 temp_predictor_only_comm.Allgather(y_gold_numpy.flatten(), y_goldg_flattend)
                 temp_predictor_only_comm.Barrier()
-                #g.write_all('Passed Allgather color=1 for i = {}\n'.format(i))
             # Process 0 broadcast y_primeg adn y_goldg to all processors, including ones
             # not involved in calculating predictions so they can each create their own 
             # y_prime_global and y_gold_global
-            #g.write_all('Waiting on Barrier before broadcast at i={}\n'.format(i))
             g.comm.Barrier()
-            #g.write_all('Broadcasting y_primeg and y_goldg to every\n')
             g.comm.Bcast(y_primeg_flattend, root=0)
             g.comm.Bcast(y_goldg_flattend, root=0) 
             g.comm.Barrier()
-            #g.write_all('All gathered initialized golbals len1={}, len2={}\n'.format(len(y_primeg_flattend), len(y_goldg_flattend)))
             y_primeg_flattend = np.split(y_primeg_flattend, num_pred)
             y_goldg_flattend = np.split(y_goldg_flattend, num_pred)
             y_primeg = [y.reshape((128, max_length, 1)) for y in y_primeg_flattend]
             y_goldg = [y.reshape((128, max_length, 1)) for y in y_goldg_flattend]
-            #g.write_all('primeg length: {}\n'.format(len(y_primeg)))
             y_primeg = np.concatenate(y_primeg, axis=0)
-            #g.write_all('primeg shape after stack: {}\n'.format(y_primeg.shape))
             y_goldg  = np.concatenate(y_goldg, axis=0)
-            # Unpad
-            #g.write_all('unpadding len(shpzg)={}, shpzg[0]={}\n'.format(len(shpzg),shpzg[0]))
-            # need to have subgroups gather a broadcast y_prmeg (maybe do above)
-            # TODO
+            # Unpad each shot to its true length
             for idx, s in enumerate(shpzg):
                 trim = lambda nparry, s: nparry[0:int(s),:]
                 y_prime_global.append(trim(y_primeg[idx],s))
@@ -933,17 +893,11 @@ def mpi_make_predictions(conf, shot_list, loader, custom_path=None):
             y_prime = []
             y_gold = []
             disruptive = [] 
-            color = 0
-            #g.write_all('y_prime_global len ={}\n'.format(len(y_prime_global)))
+            color = 2
+            temp_predictor_only_comm.Free()
 
         if g.task_index == 0:
             pbar.add(1.0*len(shot_sublist))
-
-        if freeme:
-            #g.write_all('Freeing extra comm at i={}\n'.format(i))
-            temp_predictor_only_comm.Free()
-            freeme = False
-            color = 2
 
     y_prime_global = y_prime_global[:len(shot_list)]
     y_gold_global = y_gold_global[:len(shot_list)]

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -854,10 +854,8 @@ def mpi_make_predictions(conf, shot_list, loader, custom_path=None):
                 # Ensure that numpy arrays have correct dimensions before gathering them
                 assert num_pred*max(y_prime_numpy.flatten().shape) == max(y_primeg_flattend.shape)
                 assert num_pred*max(y_gold_numpy.flatten().shape) == max(y_goldg_flattend.shape)
-                temp_predictor_only_comm.Barrier()
                 temp_predictor_only_comm.Allgather(y_prime_numpy.flatten(), y_primeg_flattend)
                 temp_predictor_only_comm.Allgather(y_gold_numpy.flatten(), y_goldg_flattend)
-                temp_predictor_only_comm.Barrier()
             # Process 0 broadcast y_primeg and y_goldg to all processors, including ones
             # not involved in calculating predictions so they can each create their own 
             # y_prime_global and y_gold_global
@@ -878,7 +876,6 @@ def mpi_make_predictions(conf, shot_list, loader, custom_path=None):
 
             disruptive_global += concatenate_sublists(
                 g.comm.allgather(disruptive))
-            g.comm.Barrier()
             y_prime = []
             y_gold = []
             disruptive = [] 

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -876,8 +876,8 @@ def mpi_make_predictions(conf, shot_list, loader, custom_path=None):
             g.comm.Barrier()
             y_primeg_flattend = np.split(y_primeg_flattend, num_pred)
             y_goldg_flattend = np.split(y_goldg_flattend, num_pred)
-            y_primeg = [y.reshape((128, max_length, 1)) for y in y_primeg_flattend]
-            y_goldg = [y.reshape((128, max_length, 1)) for y in y_goldg_flattend]
+            y_primeg = [y.reshape((conf['model']['pred_batch_size'], max_length, 1)) for y in y_primeg_flattend]
+            y_goldg = [y.reshape((conf['model']['pred_batch_size'], max_length, 1)) for y in y_goldg_flattend]
             y_primeg = np.concatenate(y_primeg, axis=0)
             y_goldg  = np.concatenate(y_goldg, axis=0)
             # Unpad each shot to its true length

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -14,6 +14,7 @@ from plasma.conf import conf
 from mpi4py import MPI
 from pkg_resources import parse_version, get_distribution, DistributionNotFound
 import random
+import itertools
 '''
 #########################################################
 This file trains a deep learning model to predict
@@ -767,7 +768,7 @@ def mpi_make_predictions(conf, shot_list, loader, custom_path=None):
     if g.task_index != 0:
         loader.verbose = False
 
-    g.write_unique('num workers= {}\nlen(shot_sublists)={}, num_shots = {}\n'.format(g.num_workers, len(shot_sublists), len(shot_list)))
+    #g.write_unique('num workers= {}\nlen(shot_sublists)={}, num_shots = {}\n'.format(g.num_workers, len(shot_sublists), len(shot_list)))
     freeme = False
 
     # MPI loop works by predicting in batches of the 
@@ -781,17 +782,12 @@ def mpi_make_predictions(conf, shot_list, loader, custom_path=None):
     #      or aggregate predictions with other workers, after each worker has made a prediction
     #      which happens every num_workers iterations in the for loop
     #      (i.e. worker 0 will aggregate predictions with workers 1-3 at the end of i=3)
-    if g.task_index < len(shot_sublists) % g.num_workers:
-        times_i_will_predict = len(shot_sublists)//g.num_workers + 1
-    else:
-        times_i_will_predict = len(shot_sublists)//g.num_workers
-    times_predicted = 0
-    color = 0
-    g.write_all('I shall predict {} times\n'.format(times_i_will_predict))
+    color = 2
+    #g.write_all('I shall predict {} times\n'.format(times_i_will_predict))
     for (i, shot_sublist) in enumerate(shot_sublists):
         shpz = []
         max_length = -1 # So non shot predictive workers don't have a real length
-        g.write_all('My task index = {}, i mod num_workers = {}\n'.format(g.task_index, i%g.num_workers))
+        #g.write_all('My task index = {}, i mod num_workers = {}\n'.format(g.task_index, i%g.num_workers))
         if i % g.num_workers == g.task_index:
             #g.write_all('Creating new comm at i={}\n'.format(i))
             color = 1
@@ -799,17 +795,16 @@ def mpi_make_predictions(conf, shot_list, loader, custom_path=None):
             #temp_predictor_only_comm = MPI.Comm.Split(g.comm, color, i)
             #freeme = True
             # Create new MPI comm to pass around rank
-            g.write_all('Starting to load and predict subroutine, i={}\n'.format(i))
+            #g.write_all('Starting to load and predict subroutine, i={}\n'.format(i))
             X, y, shot_lengths, disr = loader.load_as_X_y_pred(shot_sublist)
-            g.write_all('X, y, lengths, disr loaded, shot_lengths shape: {} \n'.format(len(shot_lengths)))
+            #g.write_all('X, y, lengths, disr loaded, shot_lengths shape: {} \n'.format(len(shot_lengths)))
 
             # load data and fit on data
             y_p = model.predict(X, batch_size=conf['model']['pred_batch_size'])
             model.reset_states()
             y_p = loader.batch_output_to_array(y_p)
             y = loader.batch_output_to_array(y)
-            times_predicted += 1
-            g.write_all('Finished le prediction\n')
+            #g.write_all('Finished le prediction\n')
 
             # cut arrays back
             y_p = [arr[:shot_lengths[j]] for (j, arr) in enumerate(y_p)]
@@ -823,7 +818,7 @@ def mpi_make_predictions(conf, shot_list, loader, custom_path=None):
                 or i == len(shot_sublists) - 1):
             # Create numpy block from y list which is used in MPI
             # Pads y_prime and y_gold with zeros to make it all fit
-            g.write_all('In second area, my color is {}, i={}\n'.format(color,i))
+            #g.write_all('In second area, my color is {}, i={}\n'.format(color,i))
             g.comm.Barrier()
             if color ==1:
                 shpz = [max(y.shape) for y in y_prime]
@@ -831,28 +826,27 @@ def mpi_make_predictions(conf, shot_list, loader, custom_path=None):
                 g.write_all(' max length = {}\n'.format(max_length))
             g.comm.Barrier()
             max_length = g.comm.allreduce(max_length, MPI.MAX) 
-            g.write_all('Calculated shpz\n')
+            #g.write_all('Calculated shpz\n')
             if color == 1:
                 y_prime_numpy = np.stack([np.pad(sublist, pad_width=((0,max_length-max(sublist.shape)),(0,0))) for sublist in y_prime])
                 y_gold_numpy = np.stack([np.pad(sublist, pad_width=((0,max_length-max(sublist.shape)),(0,0))) for sublist in y_gold])
             
-            g.write_all('Entered second area\n')
+            #g.write_all('Entered second area\n')
             g.comm.Barrier()
             temp_predictor_only_comm = MPI.Comm.Split(g.comm, color, i)
             freeme = True
             g.comm.Barrier()
             # Create numpy array to store all processors output, then aggregate and unpad using MPI gathered shape list
-            g.write_all('getting shapez, i contribute {} shpz\n'.format(len(shpz)))
+            #g.write_all('getting shapez, i contribute {} shpz\n'.format(len(shpz)))
             shpzg = g.comm.allgather(shpz)
-            import itertools
             shpzg = list(itertools.chain(*shpzg))
             g.comm.Barrier()
-            g.write_all('shpzg shape before preproc={}\n'.format(len(shpzg)))
+            #g.write_all('shpzg shape before preproc={}\n'.format(len(shpzg)))
             shpzg = [s for s in shpzg if s != []]
-            g.write_all('shpzg shape after preproc={}\n'.format(len(shpzg)))
+            #g.write_all('shpzg shape after preproc={}\n'.format(len(shpzg)))
             max_length = g.comm.allreduce(max_length, MPI.MAX) 
-            g.write_unique(str(shpzg)+'\n')
-            g.write_all('gotting shapez\n')
+            #g.write_unique(str(shpzg)+'\n')
+            #g.write_all('gotting shapez\n')
             # Todo: Figure out if empty shots are added to fit batch length
             if color == 1:
                 num_pred = temp_predictor_only_comm.size
@@ -862,47 +856,47 @@ def mpi_make_predictions(conf, shot_list, loader, custom_path=None):
             y_goldg  = np.zeros((num_pred*conf['model']['pred_batch_size'],max_length,1), dtype=conf['data']['floatx'])
             y_primeg_flattend = np.zeros(y_primeg.flatten().shape)
             y_goldg_flattend  = np.zeros(y_goldg.flatten().shape)
-            g.write_all('initialized golbals, i = {}\n'.format(i))
+            #g.write_all('initialized golbals, i = {}\n'.format(i))
             # TODO (IMD) Support more floating point types
             # ValueError: message: cannot infer count, number of entries 10652818 is not a multiple of required number of blocks 9
             # Need to send an unequal sized array I think
             if color == 1:
-                g.write_all('y_prime_numpy.shape = {}\n'.format(y_prime_numpy.shape))
-                g.write_all('y_prime_numpy_flattend.shape = {}\n'.format(y_prime_numpy.flatten().shape))
-                g.write_all('y_gold_numpy.shape = {}\n'.format(y_gold_numpy.shape))
-                g.write_all('y_gold_numpy_flattend.shape = {}\n'.format(y_gold_numpy.flatten().shape))
-                g.write_all('y_prime_g.shape = {}\n'.format(y_primeg.shape))
-                g.write_all('y_primeg_flattend.shape = {}\n'.format(y_primeg_flattend.shape))
-                g.write_all('y_goldg_flattend.shape = {}, i={}\n'.format(y_goldg_flattend.shape,i))
+                #g.write_all('y_prime_numpy.shape = {}\n'.format(y_prime_numpy.shape))
+                #g.write_all('y_prime_numpy_flattend.shape = {}\n'.format(y_prime_numpy.flatten().shape))
+                #g.write_all('y_gold_numpy.shape = {}\n'.format(y_gold_numpy.shape))
+                #g.write_all('y_gold_numpy_flattend.shape = {}\n'.format(y_gold_numpy.flatten().shape))
+                #g.write_all('y_prime_g.shape = {}\n'.format(y_primeg.shape))
+                #g.write_all('y_primeg_flattend.shape = {}\n'.format(y_primeg_flattend.shape))
+                #g.write_all('y_goldg_flattend.shape = {}, i={}\n'.format(y_goldg_flattend.shape,i))
                 # Ensure that numpy arrays have correct dimensions before gathering them
                 assert num_pred*max(y_prime_numpy.flatten().shape) == max(y_primeg_flattend.shape)
                 assert num_pred*max(y_gold_numpy.flatten().shape) == max(y_goldg_flattend.shape)
-                g.write_all('Passed asserts for i = {}\n'.format(i))
+                #g.write_all('Passed asserts for i = {}\n'.format(i))
                 temp_predictor_only_comm.Barrier()
                 temp_predictor_only_comm.Allgather(y_prime_numpy.flatten(), y_primeg_flattend)
                 temp_predictor_only_comm.Allgather(y_gold_numpy.flatten(), y_goldg_flattend)
                 temp_predictor_only_comm.Barrier()
-                g.write_all('Passed Allgather color=1 for i = {}\n'.format(i))
+                #g.write_all('Passed Allgather color=1 for i = {}\n'.format(i))
             # Process 0 broadcast y_primeg adn y_goldg to all processors, including ones
             # not involved in calculating predictions so they can each create their own 
             # y_prime_global and y_gold_global
-            g.write_all('Waiting on Barrier before broadcast at i={}\n'.format(i))
+            #g.write_all('Waiting on Barrier before broadcast at i={}\n'.format(i))
             g.comm.Barrier()
-            g.write_all('Broadcasting y_primeg and y_goldg to every\n')
+            #g.write_all('Broadcasting y_primeg and y_goldg to every\n')
             g.comm.Bcast(y_primeg_flattend, root=0)
             g.comm.Bcast(y_goldg_flattend, root=0) 
             g.comm.Barrier()
-            g.write_all('All gathered initialized golbals len1={}, len2={}\n'.format(len(y_primeg_flattend), len(y_goldg_flattend)))
+            #g.write_all('All gathered initialized golbals len1={}, len2={}\n'.format(len(y_primeg_flattend), len(y_goldg_flattend)))
             y_primeg_flattend = np.split(y_primeg_flattend, num_pred)
             y_goldg_flattend = np.split(y_goldg_flattend, num_pred)
             y_primeg = [y.reshape((128, max_length, 1)) for y in y_primeg_flattend]
             y_goldg = [y.reshape((128, max_length, 1)) for y in y_goldg_flattend]
-            g.write_all('primeg length: {}\n'.format(len(y_primeg)))
+            #g.write_all('primeg length: {}\n'.format(len(y_primeg)))
             y_primeg = np.concatenate(y_primeg, axis=0)
-            g.write_all('primeg shape after stack: {}\n'.format(y_primeg.shape))
+            #g.write_all('primeg shape after stack: {}\n'.format(y_primeg.shape))
             y_goldg  = np.concatenate(y_goldg, axis=0)
             # Unpad
-            g.write_all('unpadding len(shpzg)={}, shpzg[0]={}\n'.format(len(shpzg),shpzg[0]))
+            #g.write_all('unpadding len(shpzg)={}, shpzg[0]={}\n'.format(len(shpzg),shpzg[0]))
             # need to have subgroups gather a broadcast y_prmeg (maybe do above)
             # TODO
             for idx, s in enumerate(shpzg):
@@ -917,13 +911,13 @@ def mpi_make_predictions(conf, shot_list, loader, custom_path=None):
             y_gold = []
             disruptive = [] 
             color = 0
-            g.write_all('y_prime_global len ={}\n'.format(len(y_prime_global)))
+            #g.write_all('y_prime_global len ={}\n'.format(len(y_prime_global)))
 
         if g.task_index == 0:
             pbar.add(1.0*len(shot_sublist))
 
         if freeme:
-            g.write_all('Freeing extra comm at i={}\n'.format(i))
+            #g.write_all('Freeing extra comm at i={}\n'.format(i))
             temp_predictor_only_comm.Free()
             freeme = False
             color = 2
@@ -941,11 +935,11 @@ def mpi_make_predictions_and_evaluate(conf, shot_list, loader,
     y_prime, y_gold, disruptive = mpi_make_predictions(
         conf, shot_list, loader, custom_path)
     analyzer = PerformanceAnalyzer(conf=conf)
-    g.write_all('Afterwards y_prime length = {}\n'.format(len(y_prime)))
-    g.write_all('Afterwards y_prime[0] shape = {}\n'.format(y_prime[0].shape))
-    g.write_all('Afterwards y_gold length = {}\n'.format(len(y_gold)))
-    g.write_all('Afterwards y_gold[0] shape = {}\n'.format(y_gold[0].shape))
-    g.write_all('Afterwards distruptive length = {}\n'.format(len(disruptive)))
+    #g.write_all('Afterwards y_prime length = {}\n'.format(len(y_prime)))
+    #g.write_all('Afterwards y_prime[0] shape = {}\n'.format(y_prime[0].shape))
+    #g.write_all('Afterwards y_gold length = {}\n'.format(len(y_gold)))
+    #g.write_all('Afterwards y_gold[0] shape = {}\n'.format(y_gold[0].shape))
+    #g.write_all('Afterwards distruptive length = {}\n'.format(len(disruptive)))
     roc_area = analyzer.get_roc_area(y_prime, y_gold, disruptive)
     shot_list.set_weights(
         analyzer.get_shot_difficulty(y_prime, y_gold, disruptive))

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -837,13 +837,11 @@ def mpi_make_predictions(conf, shot_list, loader, custom_path=None):
             g.write_unique(str(shpzg)+'\n')
             g.write_all('gotting shapez\n')
             # Todo: Figure out if empty shots are added to fit batch length
-            y_primeg = np.zeros((9*128,max_length,1), dtype=conf['data']['floatx'])
-            y_goldg  = np.zeros((9*128,max_length,1), dtype=conf['data']['floatx'])
+            y_primeg = np.zeros((len(shot_sublists)*conf['model']['pred_batch_size'],max_length,1), dtype=conf['data']['floatx'])
+            y_goldg  = np.zeros((len(shot_sublists)*conf['model']['pred_batch_size'],max_length,1), dtype=conf['data']['floatx'])
             y_primeg_flattend = np.zeros(y_primeg.flatten().shape)
             y_goldg_flattend  = np.zeros(y_goldg.flatten().shape)
             g.write_all('initialized golbals\n')
-            if conf['data']['floatx'] == 'float32':
-                dtype_mpi = MPI.FLOAT
             # TODO (IMD) Support more floating point types
             # ValueError: message: cannot infer count, number of entries 10652818 is not a multiple of required number of blocks 9
             # Need to send an unequal sized array I think

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -836,7 +836,6 @@ def mpi_make_predictions(conf, shot_list, loader, custom_path=None):
             if color ==1:
                 shpz = [max(y.shape) for y in y_prime]
                 max_length = max([max(y.shape) for y in y_p])
-                g.write_all(' max length = {}\n'.format(max_length))
             g.comm.Barrier()
             max_length = g.comm.allreduce(max_length, MPI.MAX) 
             if color == 1:
@@ -868,7 +867,7 @@ def mpi_make_predictions(conf, shot_list, loader, custom_path=None):
                 temp_predictor_only_comm.Allgather(y_prime_numpy.flatten(), y_primeg_flattend)
                 temp_predictor_only_comm.Allgather(y_gold_numpy.flatten(), y_goldg_flattend)
                 temp_predictor_only_comm.Barrier()
-            # Process 0 broadcast y_primeg adn y_goldg to all processors, including ones
+            # Process 0 broadcast y_primeg and y_goldg to all processors, including ones
             # not involved in calculating predictions so they can each create their own 
             # y_prime_global and y_gold_global
             g.comm.Barrier()
@@ -912,11 +911,6 @@ def mpi_make_predictions_and_evaluate(conf, shot_list, loader,
     y_prime, y_gold, disruptive = mpi_make_predictions(
         conf, shot_list, loader, custom_path)
     analyzer = PerformanceAnalyzer(conf=conf)
-    #g.write_all('Afterwards y_prime length = {}\n'.format(len(y_prime)))
-    #g.write_all('Afterwards y_prime[0] shape = {}\n'.format(y_prime[0].shape))
-    #g.write_all('Afterwards y_gold length = {}\n'.format(len(y_gold)))
-    #g.write_all('Afterwards y_gold[0] shape = {}\n'.format(y_gold[0].shape))
-    #g.write_all('Afterwards distruptive length = {}\n'.format(len(disruptive)))
     roc_area = analyzer.get_roc_area(y_prime, y_gold, disruptive)
     shot_list.set_weights(
         analyzer.get_shot_difficulty(y_prime, y_gold, disruptive))

--- a/plasma/models/mpi_runner.py
+++ b/plasma/models/mpi_runner.py
@@ -849,9 +849,15 @@ def mpi_make_predictions(conf, shot_list, loader, custom_path=None):
             # Need to send an unequal sized array I think
             if color == 1:
                 g.write_all('y_prime_numpy.shape = {}\n'.format(y_prime_numpy.shape))
+                g.write_all('y_prime_numpy_flattend.shape = {}\n'.format(y_prime_numpy.flatten().shape))
                 g.write_all('y_gold_numpy.shape = {}\n'.format(y_gold_numpy.shape))
+                g.write_all('y_gold_numpy_flattend.shape = {}\n'.format(y_gold_numpy.flatten().shape))
                 g.write_all('y_prime_g.shape = {}\n'.format(y_primeg.shape))
-                # Todo send flattened and then unflatten - DOES FLATTENING, GATHERING, AND THEN RESHAPING SCREW WITH ORDERING?
+                g.write_all('y_primeg_flattend.shape = {}\n'.format(y_primeg_flattend.shape))
+                g.write_all('y_goldg_flattend.shape = {}\n'.format(y_goldg_flattend.shape))
+                # Ensure that numpy arrays have correct dimensions before gathering them
+                assert len(shot_sublists)*max(y_prime_numpy.flatten().shape) == max(y_primeg_flattend.shape)
+                assert len(shot_sublists)*max(y_gold_numpy.flatten().shape) == max(y_goldg_flattend.shape)
                 temp_predictor_only_comm.Allgather(y_prime_numpy.flatten(), y_primeg_flattend)
                 temp_predictor_only_comm.Allgather(y_gold_numpy.flatten(), y_goldg_flattend)
             # Process 0 broadcast y_primeg adn y_goldg to all processors, including ones


### PR DESCRIPTION
`mpi4py` lowercase methods implicitly pickle all data before using them in MPI. This uses the uppercase `mpi4py` methods, which directly uses MPI with no modifications to data, to transmit the predictions in order to overcome a memory problem when creating multiple predictions of size >1. MPI can only transmit 1D arrays, so the multidimensional prediction `numpy.array`'s need to be flat packed before shipping. 

If it fits it ships. One low rate, anywhere in the nation. 