### PR TITLE
Disable 2x features that are broken on TensorFlow 2.1.3 on Traverse

### DIFF
--- a/plasma/models/builder.py
+++ b/plasma/models/builder.py
@@ -24,6 +24,7 @@ import os
 import sys
 import numpy as np
 from copy import deepcopy
+from packaging import version
 from plasma.utils.downloading import makedirs_process_safe
 from plasma.utils.hashing import general_object_hash
 from plasma.models.tcn import TCN
@@ -393,7 +394,10 @@ class ModelBuilder(object):
         # TODO(KGF): model.save(..., save_format='tf') disabled in r1.15
         # Same with tf.keras.models.save_model(..., save_format="tf").
         # Need to use experimental API until r2.x
-        model.save(full_model_save_dir, overwrite=True, save_format='tf')
+        if (version.parse(g.tf_ver) > version.parse('2.1.0')
+                and version.parse(g.tf_ver).minor != 1):
+            # errors out in TF 2.1.3 on Traverse (latest version on IBM WMLCE 1.7.0)
+            model.save(full_model_save_dir, overwrite=True, save_format='tf')
 
         # try:
         if _has_tf2onnx:


### PR DESCRIPTION
- TF Profiler (not released until 2.2.0)
- SavedModel export:
```
tensorflow.python.framework.errors_impl.InaccessibleTensorError: The tensor 'Tensor("dropout/mul_1:0", shape=(128, 9), dtype=float32)' cannot be accessed here: it is defined in another function or code block. Use return values, explicit Python locals or TensorFlow collections to access it. Defined in: FuncGraph(name=lstm_cell_layer_call_and_return_conditional_losses, id=35187592283920); accessed from: FuncGraph(name=lstm_layer_call_and_return_conditional_losses, id=35187592523664).
```